### PR TITLE
CW logs stored under cluster-name

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -4,10 +4,25 @@ import (
 	"context"
 
 	"github.com/achevuru/aws-network-policy-agent/pkg/aws/services"
+	"github.com/achevuru/aws-network-policy-agent/pkg/utils"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/pkg/errors"
+)
+
+const (
+	resourceID  = "resource-id"
+	resourceKey = "key"
+)
+
+var (
+	clusterNameTags = []string{
+		"aws:eks:cluster-name",
+	}
 )
 
 type Cloud interface {
@@ -19,14 +34,17 @@ type Cloud interface {
 
 	// Region for the kubernetes cluster
 	Region() string
+
+	// Cluster Name
+	ClusterName() string
 }
 
 func NewCloud(cfg CloudConfig) (Cloud, error) {
 	sess := session.Must(session.NewSession(aws.NewConfig()))
 	//injectUserAgent(&sess.Handlers)
 
+	metadata := services.NewEC2Metadata(sess)
 	if len(cfg.Region) == 0 {
-		metadata := services.NewEC2Metadata(sess)
 		region, err := metadata.Region()
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to introspect region from EC2Metadata, specify --aws-region instead if EC2Metadata is unavailable")
@@ -44,6 +62,14 @@ func NewCloud(cfg CloudConfig) (Cloud, error) {
 		}
 		cfg.AccountID = accountID
 	}
+
+	instanceIdentityDocument, err := metadata.GetInstanceIdentityDocument()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get instanceIdentityDocument from EC2Metadata")
+	}
+	ec2ServiceClient := ec2.New(sess)
+	cfg.ClusterName = getClusterName(ec2ServiceClient, instanceIdentityDocument)
+
 	return &defaultCloud{
 		cfg:            cfg,
 		cloudWatchlogs: services.NewCloudWatchLogs(sess),
@@ -68,4 +94,54 @@ func (c *defaultCloud) AccountID() string {
 
 func (c *defaultCloud) Region() string {
 	return c.cfg.Region
+}
+
+func (c *defaultCloud) ClusterName() string {
+	return c.cfg.ClusterName
+}
+
+func getClusterName(ec2ServiceClient ec2iface.EC2API, instanceIdentityDocument ec2metadata.EC2InstanceIdentityDocument) string {
+	var clusterName string
+	var err error
+	for _, tag := range clusterNameTags {
+		clusterName, err = getClusterTag(tag, ec2ServiceClient, instanceIdentityDocument)
+		if err == nil && clusterName != "" {
+			break
+		}
+	}
+	if clusterName == "" {
+		clusterName = utils.DEFAULT_CLUSTER_NAME
+	}
+	return clusterName
+}
+
+// getClusterTag is used to retrieve a tag from the ec2 instance
+func getClusterTag(tagKey string, ec2ServiceClient ec2iface.EC2API, instanceIdentityDocument ec2metadata.EC2InstanceIdentityDocument) (string, error) {
+	input := ec2.DescribeTagsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String(resourceID),
+				Values: []*string{
+					aws.String(instanceIdentityDocument.InstanceID),
+				},
+			}, {
+				Name: aws.String(resourceKey),
+				Values: []*string{
+					aws.String(tagKey),
+				},
+			},
+		},
+	}
+
+	//log.Infof("Calling DescribeTags with key %s", tagKey)
+	results, err := ec2ServiceClient.DescribeTags(&input)
+	if err != nil {
+		return "", errors.Wrap(err, "GetClusterTag: Unable to obtain EC2 instance tags")
+	}
+
+	if len(results.Tags) < 1 {
+		return "", errors.Errorf("GetClusterTag: No tag matching key: %s", tagKey)
+	}
+
+	return aws.StringValue(results.Tags[0].Value), nil
 }

--- a/pkg/aws/cloud_config.go
+++ b/pkg/aws/cloud_config.go
@@ -14,6 +14,8 @@ type CloudConfig struct {
 	Region string
 	// AccountID for the kubernetes cluster
 	AccountID string
+	// Cluster Name for the kubernetes cluster
+	ClusterName string
 }
 
 func (cfg *CloudConfig) BindFlags(fs *pflag.FlagSet) {

--- a/pkg/aws/services/ec2_metadata.go
+++ b/pkg/aws/services/ec2_metadata.go
@@ -7,6 +7,7 @@ import (
 
 type EC2Metadata interface {
 	Region() (string, error)
+	GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error)
 }
 
 // NewEC2Metadata constructs new EC2Metadata implementation.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -25,7 +25,8 @@ var (
 	TRIE_V6_KEY_LENGTH          = 20
 	TRIE_VALUE_LENGTH           = 96
 
-	CATCH_ALL_PROTOCOL corev1.Protocol = "ANY_IP_PROTOCOL"
+	CATCH_ALL_PROTOCOL   corev1.Protocol = "ANY_IP_PROTOCOL"
+	DEFAULT_CLUSTER_NAME                 = "k8s-cluster"
 )
 
 func GetPodNamespacedName(podName, podNamespace string) string {
@@ -168,9 +169,12 @@ func deriveProtocolValue(l4Info v1alpha1.Port, allowAll, denyAll bool) int {
 }
 
 func IsLinkNotFoundError(error string) bool {
-	errCode := strings.Split(error, ":")
-	if errCode[1] == "Link not found" {
-		return true
+	if strings.Contains(error, ":") {
+		errCode := strings.Split(error, ":")
+
+		if errCode[1] == "Link not found" {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Fetch cluster-name from "aws:eks:cluster-name" tag from the nodes.

Non-eks cluster will have a default cluster name.

Right now there is no option to configure the cluster name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
