### PR TITLE
Fix problem with policy not being applied to pods on IPv6 nodes

### DIFF
--- a/controllers/policyendpoints_controller.go
+++ b/controllers/policyendpoints_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"errors"
+	"net"
 	"os"
 	"strconv"
 	"sync"
@@ -431,8 +432,9 @@ func (r *PolicyEndpointsReconciler) deriveTargetPods(ctx context.Context,
 	currentPods, podsPresent := r.policyEndpointSelectorMap.Load(policyEndpointIdentifier)
 	// Pods are grouped by Host IP. Individual node agents will filter (local) pods
 	// by the Host IP value.
+	nodeIP := net.ParseIP(r.nodeIP)
 	for _, pod := range policyEndpoint.Spec.PodSelectorEndpoints {
-		if r.nodeIP == string(pod.HostIP) {
+		if nodeIP.Equal(net.ParseIP(string(pod.HostIP))) {
 			r.log.Info("Found a matching Pod: ", "name: ", pod.Name, "namespace: ", pod.Namespace)
 			targetPods = append(targetPods, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})
 			podIdentifier := utils.GetPodIdentifier(pod.Name, pod.Namespace)

--- a/controllers/policyendpoints_controller_test.go
+++ b/controllers/policyendpoints_controller_test.go
@@ -436,10 +436,33 @@ func TestDeriveTargetPods(t *testing.T) {
 		},
 	}
 
+	ipv6NodePolicyEndpoint := policyendpoint.PolicyEndpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+		},
+		Spec: policyendpoint.PolicyEndpointSpec{
+			PodSelector: &metav1.LabelSelector{},
+			PolicyRef: policyendpoint.PolicyReference{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			PodSelectorEndpoints: []policyendpoint.PodEndpoint{
+				{
+					HostIP:    "2001:db8::1",
+					PodIP:     "2001:db8::2",
+					Name:      "foo1",
+					Namespace: "bar",
+				},
+			},
+		},
+	}
+
 	tests := []struct {
 		name           string
 		policyendpoint policyendpoint.PolicyEndpoint
 		currentPods    []types.NamespacedName //Current set of active pods against this policy
+		nodeIP         string                 //Default: 1.1.1.1
 		want           want
 	}{
 		{
@@ -478,6 +501,19 @@ func TestDeriveTargetPods(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:           "Matching Local pods on IPv6 node",
+			policyendpoint: ipv6NodePolicyEndpoint,
+			nodeIP:         "2001:db8:0:0:0:0:0:1",
+			want: want{
+				activePods: []types.NamespacedName{
+					{
+						Name:      "foo1",
+						Namespace: "bar",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -488,7 +524,10 @@ func TestDeriveTargetPods(t *testing.T) {
 		policyEndpointReconciler := PolicyEndpointsReconciler{
 			k8sClient: mockClient,
 			log:       logr.New(&log.NullLogSink{}),
-			nodeIP:    "1.1.1.1",
+			nodeIP:    tt.nodeIP,
+		}
+		if tt.nodeIP == "" {
+			policyEndpointReconciler.nodeIP = "1.1.1.1"
 		}
 
 		if tt.currentPods != nil {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Fixes an issue where policies may not be applied to pods on IPv6 nodes.
The IPv6 address format of PolicyEndpoint's HostIP and metadata returned by IMDS seem to be different.
Use net.IP instead of string for comparison to absorb format differences.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
