### PR TITLE
Update the session duration to 5 hrs for github actions

### DIFF
--- a/.github/workflows/e2e-conformance.yaml
+++ b/.github/workflows/e2e-conformance.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.OSS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-          role-duration-seconds: 14400
+          role-duration-seconds: 18000 # 5 hours
       - name: Run e2e conformance test
         env:
           RUN_CONFORMANCE_TESTS: true

--- a/.github/workflows/performance-tests.yaml
+++ b/.github/workflows/performance-tests.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.OSS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-          role-duration-seconds: 14400
+          role-duration-seconds: 18000 # 5 hours
       - name: Run performance tests
         env:
           RUN_PERFORMANCE_TESTS: true


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Github action times out in 4 hrs, but cyclonus v4 suite + cluster creation takes more than that. This increases the timeout to 5 hrs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
