### PR TITLE
With catchALL honor "except"

### DIFF
--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -743,7 +743,7 @@ func (l *bpfClient) computeMapEntriesFromEndpointRules(firewallRules []EbpfFirew
 			continue
 		}
 
-		if !isCatchAllIPEntryPresent {
+		if !utils.IsCatchAllIPEntry(string(firewallRule.IPCidr)) {
 			if len(firewallRule.L4Info) == 0 {
 				l.logger.Info("No L4 specified. Add Catch all entry: ", "CIDR: ", firewallRule.IPCidr)
 				l.addCatchAllL4Entry(&firewallRule)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

A network policy can allow catchALL i.e, 0.0.0.0/0 and block certain cidr which was getting ignored for catch all entries.

Sample policy

```
kind: NetworkPolicy
apiVersion: networking.k8s.io/v1
metadata:
  name: test-np
  namespace: default
spec:
  podSelector:
    matchLabels:
      app: nginx
  egress:
  - to:
    - ipBlock:
        cidr: 0.0.0.0/0
        except:
          - 172.31.54.64/32
  policyTypes:
    - Egress
```

Verdict is `Accept` ->

```
{"level":"info","timestamp":"2023-09-12T17:36:37.991Z","logger":"ebpf-client","msg":"Flow Info:  ","Src IP":"192.168.21.79","Src Port":0,"Dest IP":"172.31.54.64","Dest Port":0,"Proto":"ICMP","Verdict":"ACCEPT"}
```

After fix...

Except is honored ->

```
{"level":"info","timestamp":"2023-09-12T17:41:30.922Z","logger":"ebpf-client","msg":"Total L4 entry count for catch all entry: ","count: ":0}
{"level":"info","timestamp":"2023-09-12T17:41:30.922Z","logger":"ebpf-client","msg":"L4 values: ","protocol: ":254,"startPort: ":0,"endPort: ":0}
{"level":"info","timestamp":"2023-09-12T17:41:30.922Z","logger":"ebpf-client","msg":"Parsed Except CIDR","IP Key: ":"172.31.54.64/32"}
{"level":"info","timestamp":"2023-09-12T17:41:30.922Z","logger":"ebpf-client","msg":"L4 values: ","protocol: ":255,"startPort: ":0,"endPort: ":0}
```

Verdict is `Deny` ->
```
{"level":"info","timestamp":"2023-09-12T17:44:04.821Z","logger":"ebpf-client","msg":"Flow Info:  ","Src IP":"192.168.21.79","Src Port":0,"Dest IP":"172.31.54.64","Dest Port":0,"Proto":"ICMP","Verdict":"DENY"}
{"level":"info","timestamp":"2023-09-12T17:44:04.821Z","logger":"ebpf-client","msg":"Sending logs to CW"}
{"level":"info","timestamp":"2023-09-12T17:44:05.822Z","logger":"ebpf-client","msg":"Flow Info:  ","Src IP":"192.168.21.79","Src Port":0,"Dest IP":"172.31.54.64","Dest Port":0,"Proto":"ICMP","Verdict":"DENY"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
