### PR TITLE
Cli fix

### DIFF
--- a/pkg/clihelper/show.go
+++ b/pkg/clihelper/show.go
@@ -167,6 +167,10 @@ func MapWalk(mapID int) error {
 
 		err = goebpfmaps.GetFirstMapEntryByID(uintptr(unsafe.Pointer(&iterKey)), mapID)
 		if err != nil {
+			if errors.Is(err, unix.ENOENT) {
+				fmt.Println("No Entries found, Empty map")
+				return nil
+			}
 			return fmt.Errorf("Unable to get First key: %v", err)
 		} else {
 			for {
@@ -204,6 +208,10 @@ func MapWalk(mapID int) error {
 		iterNextKey := ConntrackKey{}
 		err = goebpfmaps.GetFirstMapEntryByID(uintptr(unsafe.Pointer(&iterKey)), mapID)
 		if err != nil {
+			if errors.Is(err, unix.ENOENT) {
+				fmt.Println("No Entries found, Empty map")
+				return nil
+			}
 			return fmt.Errorf("Unable to get First key: %v", err)
 		} else {
 			for {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
If the map is empty, SDK returns `ENOENT` which should be captured by NA.

Before fix -

```
sudo /opt/cni/bin/aws-eks-na-cli ebpf dump-maps 5
Failed to execute the cmd -  Unable to get First key: no such file or directory
```

After fix -

1. 
```
sudo /opt/cni/bin/aws-eks-na-cli ebpf dump-maps 5
No Entries found, Empty map
```

2. Create some entries 

```
sudo /opt/cni/bin/aws-eks-na-cli ebpf dump-maps 5
Conntrack Key : Source IP - 192.168.21.79 Source port - 33704 Dest IP - 10.100.0.10 Dest port - 53 Protocol - 17
Value : 
Conntrack Val -  192
*******************************
Conntrack Key : Source IP - 192.168.21.79 Source port - 43126 Dest IP - 10.100.0.10 Dest port - 53 Protocol - 17
Value : 
Conntrack Val -  192
*******************************
Conntrack Key : Source IP - 192.168.21.79 Source port - 0 Dest IP - 142.250.217.110 Dest port - 0 Protocol - 1
Value : 
Conntrack Val -  192
*******************************
Conntrack Key : Source IP - 192.168.21.79 Source port - 48811 Dest IP - 10.100.0.10 Dest port - 53 Protocol - 17
Value : 
Conntrack Val -  192
*******************************
Conntrack Key : Source IP - 192.168.21.79 Source port - 34423 Dest IP - 10.100.0.10 Dest port - 53 Protocol - 17
Value : 
Conntrack Val -  192
*******************************
Conntrack Key : Source IP - 192.168.21.79 Source port - 34096 Dest IP - 10.100.0.10 Dest port - 53 Protocol - 17
Value : 
Conntrack Val -  192
*******************************
Conntrack Key : Source IP - 192.168.21.79 Source port - 57915 Dest IP - 10.100.0.10 Dest port - 53 Protocol - 17
Value : 
Conntrack Val -  192
*******************************
Done reading all entries
```

3. Cleanup entries -
```
sudo /opt/cni/bin/aws-eks-na-cli ebpf dump-maps 5
No Entries found, Empty map
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
