### PR TITLE
Ignore policy restrictions against Node IP

### DIFF
--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -734,8 +734,9 @@ func (l *bpfClient) computeMapEntriesFromEndpointRules(firewallRules []EbpfFirew
 		if !strings.Contains(string(firewallRule.IPCidr), "/") {
 			firewallRule.IPCidr += v1alpha1.NetworkAddress(l.hostMask)
 		}
-		//TODO - Just Purge both the entries and avoid these calls for every CIDR
-		if utils.IsCatchAllIPEntry(string(firewallRule.IPCidr)) {
+
+		if utils.IsCatchAllIPEntry(string(firewallRule.IPCidr)) ||
+			utils.IsNodeIP(l.nodeIP, string(firewallRule.IPCidr)) {
 			continue
 		}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -219,6 +219,14 @@ func IsCatchAllIPEntry(ipAddr string) bool {
 	return false
 }
 
+func IsNodeIP(nodeIP string, ipCidr string) bool {
+	ipAddr, _, _ := net.ParseCIDR(ipCidr)
+	if net.ParseIP(nodeIP).Equal(ipAddr) {
+		return true
+	}
+	return false
+}
+
 func IsNonHostCIDR(ipAddr string) bool {
 	ipSplit := strings.Split(ipAddr, "/")
 	//Ignore Catch All IP entry as well


### PR DESCRIPTION
*Issue #, if available:*
#56 

*Description of changes:*

Network Policy Agent by default allows unrestricted access to/from Node IP. However, if a Network policy selects host networking pods (that are assigned node IP) and narrows down the allowed list of port and protocol combinations, the agent currently honors that but that might break the (http) liveness/readiness probes unless the policy explicitly allows the probe endpoint ports. PR will address this issue and will make sure the enforced policies allow all traffic to/from Node IP.

https://kubernetes.io/docs/concepts/services-networking/network-policies/#what-you-can-t-do-with-network-policies-at-least-not-yet

```
Pods cannot currently block localhost access, nor do they have the ability to block access from their resident node
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
