### PR TITLE
Create a github action to build multi-arch docker image

### DIFF
--- a/.github/actions/build-and-push-image/action.yaml
+++ b/.github/actions/build-and-push-image/action.yaml
@@ -1,0 +1,47 @@
+name: Build Image and Push
+description: 'Builds Multi-arch Network Policy Agent image and pushes to ECR'
+inputs:
+  aws-region:
+    description: AWS region
+    required: true
+outputs:
+  image_uri:
+    description: "Network Policy Agent Image"
+    value: ${{ steps.build.outputs.image_uri }}
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Docker QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Build and Push Image
+      id: build
+      shell: bash
+      env:
+        REGION: ${{ inputs.aws-region }}
+        AWS_ECR_REPO_NAME: amazon/aws-network-policy-agent
+      run: |
+          IMAGE_VERSION=$(git rev-parse HEAD)
+          AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          AWS_ECR_REGISTRY="$AWS_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com"
+
+          aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin ${AWS_ECR_REGISTRY}
+          if ! `aws ecr describe-repositories --registry-id $AWS_ACCOUNT_ID --repository-names $AWS_ECR_REPO_NAME >/dev/null 2>&1`; then
+              echo "creating ECR repo with name $AWS_ECR_REPO_NAME"
+              aws ecr create-repository --repository-name $AWS_ECR_REPO_NAME
+          fi
+
+          if [[ $(aws ecr batch-get-image --repository-name=$AWS_ECR_REPO_NAME --image-ids imageTag=$IMAGE_VERSION \
+              --query 'images[].imageId.imageTag' --region $REGION) != "[]" ]]; then
+            echo "Image $AWS_ECR_REPO_NAME:$IMAGE_VERSION already exists. Skipping image build."
+          else
+            echo "Building AWS Network Policy Agent latest image"
+
+            docker buildx create --name="network-policy-agent-builder" --buildkitd-flags '--allow-insecure-entitlement network.host' --use >/dev/null
+            make multi-arch-build-and-push VERSION=$IMAGE_VERSION IMAGE=$AWS_ECR_REGISTRY/$AWS_ECR_REPO_NAME
+
+            docker buildx rm network-policy-agent-builder
+          fi
+          image_uri=$AWS_ECR_REGISTRY/$AWS_ECR_REPO_NAME:$IMAGE_VERSION
+          echo "image_uri=$(echo $image_uri)" >> $GITHUB_OUTPUT

--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -17,7 +17,4 @@ runs:
       run: |
         curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
         sudo mv /tmp/eksctl /usr/local/bin/
-    - name: Set up Docker QEMU
-      uses: docker/setup-qemu-action@v2
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+

--- a/.github/workflows/e2e-conformance.yaml
+++ b/.github/workflows/e2e-conformance.yaml
@@ -1,4 +1,4 @@
-name: e2e-conformance-tests
+name: E2E Conformance Tests
 
 on:
   workflow_dispatch: {}
@@ -10,7 +10,29 @@ permissions:
   contents: read
 
 jobs:
+  build-image:
+    if: github.repository == 'aws/aws-network-policy-agent'
+    runs-on: ubuntu-latest
+    outputs:
+      AWS_EKS_NODEAGENT_IMAGE: ${{steps.build-and-push-image.outputs.image_uri}}
+    steps:
+      - name: Checkout latest commit
+        uses: actions/checkout@v3
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.OSS_ROLE_ARN }}
+          aws-region: us-west-2
+          role-duration-seconds: 3600 # 1 hour
+          mask-aws-account-id: 'no'
+      - name: Build and Push Network Policy Image
+        id: build-and-push-image
+        uses: ./.github/actions/build-and-push-image
+        with:
+          aws-region: us-west-2
   e2e-conformance-tests:
+    needs: build-image
     strategy:
       fail-fast: false
       matrix:
@@ -19,19 +41,20 @@ jobs:
     if: github.repository == 'aws/aws-network-policy-agent'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout latest commit in the PR
+      - name: Checkout latest commit
         uses: actions/checkout@v3
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.OSS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws-region: us-west-2
           role-duration-seconds: 18000 # 5 hours
       - name: Run e2e conformance test
         env:
           RUN_CONFORMANCE_TESTS: true
           K8S_VERSION: 1.27
           IP_FAMILY: ${{ matrix.ip-family }}
+          AWS_EKS_NODEAGENT_IMAGE: ${{ needs.build-image.outputs.AWS_EKS_NODEAGENT_IMAGE }}
         run: |
           ./scripts/run-tests.sh

--- a/.github/workflows/e2e-conformance.yaml
+++ b/.github/workflows/e2e-conformance.yaml
@@ -20,12 +20,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.OSS_ROLE_ARN }}
           aws-region: us-west-2
           role-duration-seconds: 3600 # 1 hour
-          mask-aws-account-id: 'no'
       - name: Build and Push Network Policy Image
         id: build-and-push-image
         uses: ./.github/actions/build-and-push-image
@@ -45,7 +44,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.OSS_ROLE_ARN }}
           aws-region: us-west-2

--- a/.github/workflows/performance-tests.yaml
+++ b/.github/workflows/performance-tests.yaml
@@ -10,23 +10,45 @@ permissions:
   contents: read
 
 jobs:
-  performance-tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        ip-family: [ "IPv4", "IPv6"]
-        # kubernetes-versions: ["1.25", "1.26", "1.27"]
+  build-image:
     if: github.repository == 'aws/aws-network-policy-agent'
     runs-on: ubuntu-latest
+    outputs:
+      AWS_EKS_NODEAGENT_IMAGE: ${{steps.build-and-push-image.outputs.image_uri}}
     steps:
-      - name: Checkout latest commit in the PR
+      - name: Checkout latest commit
         uses: actions/checkout@v3
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.OSS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws-region: us-west-2
+          role-duration-seconds: 3600 # 1 hour
+          mask-aws-account-id: 'no'
+      - name: Build and Push Network Policy Image
+        id: build-and-push-image
+        uses: ./.github/actions/build-and-push-image
+        with:
+          aws-region: us-west-2
+  performance-tests:
+    needs: build-image
+    strategy:
+      fail-fast: false
+      matrix:
+        ip-family: [ IPv4, IPv6 ]
+        # kubernetes-versions: ["1.25", "1.26", "1.27"]
+    if: github.repository == 'aws/aws-network-policy-agent'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout latest commit
+        uses: actions/checkout@v3
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.OSS_ROLE_ARN }}
+          aws-region: us-west-2
           role-duration-seconds: 18000 # 5 hours
       - name: Run performance tests
         env:
@@ -35,5 +57,6 @@ jobs:
           NODES_CAPACITY: 3
           INSTANCE_TYPE: c5.xlarge
           IP_FAMILY: ${{ matrix.ip-family }}
+          AWS_EKS_NODEAGENT_IMAGE: ${{ needs.build-image.outputs.AWS_EKS_NODEAGENT_IMAGE }}
         run: |
           ./scripts/run-tests.sh

--- a/.github/workflows/performance-tests.yaml
+++ b/.github/workflows/performance-tests.yaml
@@ -20,12 +20,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.OSS_ROLE_ARN }}
           aws-region: us-west-2
           role-duration-seconds: 3600 # 1 hour
-          mask-aws-account-id: 'no'
       - name: Build and Push Network Policy Image
         id: build-and-push-image
         uses: ./.github/actions/build-and-push-image
@@ -45,7 +44,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.OSS_ROLE_ARN }}
           aws-region: us-west-2

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -14,11 +14,6 @@ function load_default_values(){
     : "${CW_POLICY_ARN:=arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy}"
     : "${ENDPOINT_FLAG:=""}"
     : "${HELM_EXTRA_ARGS:=""}"
-
-    IMAGE_VERSION=$(git rev-parse HEAD)
-    AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-    AWS_ECR_REGISTRY="$AWS_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com"
-    AWS_ECR_REPO_NAME="amazon/aws-network-policy-agent"
 }
 
 function create_cluster(){

--- a/scripts/lib/network-policy.sh
+++ b/scripts/lib/network-policy.sh
@@ -111,35 +111,9 @@ function install_network_policy_helm(){
         --set enableNetworkPolicy=true \
         --set originalMatchLabels=true \
         --set init.env.ENABLE_IPv6=$ENABLE_IPv6 \
-        --set image.env.ENABLE_IPv6=$ENABLE_IPv6 \
+        --set env.ENABLE_IPv6=$ENABLE_IPv6 \
         --set nodeAgent.enableIpv6=$ENABLE_IPv6 \
-        --set image.env.ENABLE_PREFIX_DELEGATION=$ENABLE_PREFIX_DELEGATION \
-        --set image.env.ENABLE_IPv4=$ENABLE_IPv4 $HELM_EXTRA_ARGS
+        --set env.ENABLE_PREFIX_DELEGATION=$ENABLE_PREFIX_DELEGATION \
+        --set env.ENABLE_IPv4=$ENABLE_IPv4 $HELM_EXTRA_ARGS
 
-}
-
-function build_and_push_image(){
-
-  # Get ECR credentials
-  aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin ${AWS_ECR_REGISTRY}
-
-  # Create repository if doesn't exist
-  if ! `aws ecr describe-repositories --registry-id $AWS_ACCOUNT_ID --repository-names $AWS_ECR_REPO_NAME >/dev/null 2>&1`; then
-      echo "creating ECR repo with name $AWS_ECR_REPO_NAME"
-      aws ecr create-repository --repository-name $AWS_ECR_REPO_NAME
-  fi
-
-  if [[ $(aws ecr batch-get-image --repository-name=$AWS_ECR_REPO_NAME --image-ids imageTag=$IMAGE_VERSION \
-      --query 'images[].imageId.imageTag' --region $REGION) != "[]" ]]; then
-    echo "Image $AWS_ECR_REPO_NAME:$IMAGE_VERSION already exists. Skipping image build."
-  else
-    START=$SECONDS
-    echo "Building AWS Network Policy Agent latest image"
-
-    docker buildx create --name="network-policy-agent-builder" --buildkitd-flags '--allow-insecure-entitlement network.host' --use >/dev/null
-    make multi-arch-build-and-push VERSION=$IMAGE_VERSION IMAGE=$AWS_ECR_REGISTRY/$AWS_ECR_REPO_NAME
-
-    echo "TIMELINE: Docker build took $(($SECONDS - $START)) seconds."
-    docker buildx rm network-policy-agent-builder
-  fi
 }

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -11,6 +11,7 @@ source ${DIR}/lib/tests.sh
 
 : "${RUN_PERFORMANCE_TESTS:=false}"
 : "${RUN_CONFORMANCE_TESTS:=false}"
+: "${AWS_EKS_NODEAGENT_IMAGE:=""}"
 TEST_FAILED="false"
 
 cleanup() {
@@ -27,8 +28,7 @@ trap cleanup EXIT
 load_default_values
 create_cluster
 
-build_and_push_image
-make update-node-agent-image AWS_EKS_NODEAGENT=$AWS_ECR_REGISTRY/$AWS_ECR_REPO_NAME:$IMAGE_VERSION IP_FAMILY=$IP_FAMILY
+make update-node-agent-image AWS_EKS_NODEAGENT=$AWS_EKS_NODEAGENT_IMAGE IP_FAMILY=$IP_FAMILY
 
 if [[ $RUN_PERFORMANCE_TESTS == "true" ]]; then
   echo "Runnning Performance tests"

--- a/scripts/update-node-agent-image.sh
+++ b/scripts/update-node-agent-image.sh
@@ -22,3 +22,6 @@ else
 fi
 
 install_network_policy_helm
+
+echo "Check aws-node daemonset status"
+kubectl rollout status ds/aws-node -n kube-system --timeout=300s


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This separates out the docker build action into a new job. The succeeding jobs have a dependency on this build job to complete before it starts it's execution. By this way we avoid docker build and push in each sub jobs (v4 and v6)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
