### PR TITLE
Conntrack cleanup issue with v1.0.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.21
 
 require (
 	github.com/aws/amazon-vpc-cni-k8s v1.15.1
-	github.com/aws/aws-ebpf-sdk-go v1.0.3
 	github.com/aws/aws-sdk-go v1.47.5
 	github.com/go-logr/logr v1.3.0
+	github.com/aws/aws-ebpf-sdk-go v1.0.4-rc1
 	github.com/go-logr/zapr v1.2.4
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.9

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.21
 
 require (
 	github.com/aws/amazon-vpc-cni-k8s v1.15.1
+	github.com/aws/aws-ebpf-sdk-go v1.0.4
 	github.com/aws/aws-sdk-go v1.47.5
 	github.com/go-logr/logr v1.3.0
-	github.com/aws/aws-ebpf-sdk-go v1.0.4-rc1
 	github.com/go-logr/zapr v1.2.4
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.9
@@ -18,7 +18,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	go.uber.org/zap v1.26.0
-	golang.org/x/sys v0.13.0
+	golang.org/x/sys v0.14.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	k8s.io/api v0.28.3
 	k8s.io/apimachinery v0.28.3

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,13 @@
 github.com/aws/amazon-vpc-cni-k8s v1.15.1 h1:zKhJ58AoFj+QaZfo768mSVFpLr3qeSVV0Qn0aeV2fhE=
 github.com/aws/amazon-vpc-cni-k8s v1.15.1/go.mod h1:VjgdEc3U5d05RY5Jnovqt6pLbHmnIkzsgX6sDC6I4II=
-github.com/aws/aws-sdk-go v1.47.5 h1:U2JlfPmrUoz5p+2X/XwKxmaJFo2oV+LbJqx8jyEvyAY=
-github.com/aws/aws-sdk-go v1.47.5/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-ebpf-sdk-go v1.0.4-rc1 h1:X1JOboraocdX6aOT2POU4rJSyD2X2mKy4I2DHnpY1Hg=
 github.com/aws/aws-ebpf-sdk-go v1.0.4-rc1/go.mod h1:08LzhuZ2vJNshF6cZaJNzN8vC59Rrq43jFJdbST5Oi0=
+github.com/aws/aws-ebpf-sdk-go v1.0.4-rc2 h1:DZOKWMO/iCQekTkugs9A3h4o9hYwOvTdNSxIMOB8og4=
+github.com/aws/aws-ebpf-sdk-go v1.0.4-rc2/go.mod h1:CCXK40H7FN2eN1FLt/O2vT9eNIDH0uXZxZGxQEdJaIM=
+github.com/aws/aws-ebpf-sdk-go v1.0.4 h1:WJeuAYd8ThiC22kKJHpGZCJ63wotsJ04rY3JsHhdwVM=
+github.com/aws/aws-ebpf-sdk-go v1.0.4/go.mod h1:CCXK40H7FN2eN1FLt/O2vT9eNIDH0uXZxZGxQEdJaIM=
+github.com/aws/aws-sdk-go v1.47.5 h1:U2JlfPmrUoz5p+2X/XwKxmaJFo2oV+LbJqx8jyEvyAY=
+github.com/aws/aws-sdk-go v1.47.5/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -22,6 +26,7 @@ github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJ
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
@@ -70,8 +75,10 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -93,6 +100,7 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU=
 github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
@@ -181,6 +189,8 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.13.0 h1:bb+I9cTfFazGW51MZqBVmZy7+JEJMouUHTUSKVQLBek=
 golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 github.com/aws/amazon-vpc-cni-k8s v1.15.1 h1:zKhJ58AoFj+QaZfo768mSVFpLr3qeSVV0Qn0aeV2fhE=
 github.com/aws/amazon-vpc-cni-k8s v1.15.1/go.mod h1:VjgdEc3U5d05RY5Jnovqt6pLbHmnIkzsgX6sDC6I4II=
-github.com/aws/aws-ebpf-sdk-go v1.0.3 h1:KylXlB82WtP+2SULhT8n8UQAsa25PahZoUszUJ7Pdb0=
-github.com/aws/aws-ebpf-sdk-go v1.0.3/go.mod h1:08LzhuZ2vJNshF6cZaJNzN8vC59Rrq43jFJdbST5Oi0=
 github.com/aws/aws-sdk-go v1.47.5 h1:U2JlfPmrUoz5p+2X/XwKxmaJFo2oV+LbJqx8jyEvyAY=
 github.com/aws/aws-sdk-go v1.47.5/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
+github.com/aws/aws-ebpf-sdk-go v1.0.4-rc1 h1:X1JOboraocdX6aOT2POU4rJSyD2X2mKy4I2DHnpY1Hg=
+github.com/aws/aws-ebpf-sdk-go v1.0.4-rc1/go.mod h1:08LzhuZ2vJNshF6cZaJNzN8vC59Rrq43jFJdbST5Oi0=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/pkg/ebpf/conntrack/conntrack_client.go
+++ b/pkg/ebpf/conntrack/conntrack_client.go
@@ -118,10 +118,23 @@ func (c *conntrackClient) CleanupConntrackMap() {
 				newKey.Dest_ip = utils.ConvIPv4ToInt(utils.ConvIntToIPv4(iterKey.Dest_ip))
 				newKey.Dest_port = iterKey.Dest_port
 				newKey.Protocol = iterKey.Protocol
+
+				//Check with SIP as owner
+				newKey.Owner_ip = newKey.Source_ip
 				_, ok := localConntrackCache[newKey]
 				if !ok {
 					//Delete the entry in local cache
-					retrievedKey := fmt.Sprintf("Expired/Delete Conntrack Key : Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d", utils.ConvIntToIPv4(iterKey.Source_ip).String(), iterKey.Source_port, utils.ConvIntToIPv4(iterKey.Dest_ip).String(), iterKey.Dest_port, iterKey.Protocol)
+					retrievedKey := fmt.Sprintf("Expired/Delete Conntrack Key with SIP as owner: Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d Owner IP - %s", utils.ConvIntToIPv4(iterKey.Source_ip).String(), iterKey.Source_port, utils.ConvIntToIPv4(iterKey.Dest_ip).String(), iterKey.Dest_port, iterKey.Protocol, utils.ConvIntToIPv4(iterKey.Owner_ip).String())
+					c.logger.Info("Conntrack cleanup", "Entry - ", retrievedKey)
+					expiredList[iterKey] = true
+				}
+				
+				//Check with DIP as owner
+				newKey.Owner_ip = newKey.Dest_ip
+				_, ok = localConntrackCache[newKey]
+				if !ok {
+					//Delete the entry in local cache
+					retrievedKey := fmt.Sprintf("Expired/Delete Conntrack Key with DIP as owner: Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d Owner IP - %s", utils.ConvIntToIPv4(iterKey.Source_ip).String(), iterKey.Source_port, utils.ConvIntToIPv4(iterKey.Dest_ip).String(), iterKey.Dest_port, iterKey.Protocol, utils.ConvIntToIPv4(iterKey.Owner_ip).String())
 					c.logger.Info("Conntrack cleanup", "Entry - ", retrievedKey)
 					expiredList[iterKey] = true
 				}
@@ -217,6 +230,7 @@ func (c *conntrackClient) Cleanupv6ConntrackMap() {
 				}
 				return
 			} else {
+				//Check with SIP as owner
 				newKey := utils.ConntrackKeyV6{}
 				connKey := utils.ConvByteToConntrackV6(byteSlice)
 
@@ -226,10 +240,22 @@ func (c *conntrackClient) Cleanupv6ConntrackMap() {
 				newKey.Source_port = connKey.Source_port
 				newKey.Dest_port = connKey.Dest_port
 				newKey.Protocol = connKey.Protocol
+
+				utils.CopyV6Bytes(&newKey.Owner_ip, connKey.Source_ip)
 				_, ok := localConntrackCache[newKey]
 				if !ok {
 					//Delete the entry in local cache
-					retrievedKey := fmt.Sprintf("Expired/Delete Conntrack Key : Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d", utils.ConvByteToIPv6(newKey.Source_ip).String(), newKey.Source_port, utils.ConvByteToIPv6(newKey.Dest_ip).String(), newKey.Dest_port, newKey.Protocol)
+					retrievedKey := fmt.Sprintf("Expired/Delete Conntrack Key with SIP as owner: Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d Owner IP - %s", utils.ConvByteToIPv6(newKey.Source_ip).String(), newKey.Source_port, utils.ConvByteToIPv6(newKey.Dest_ip).String(), newKey.Dest_port, newKey.Protocol, utils.ConvByteToIPv6(newKey.Owner_ip).String())
+					c.logger.Info("Conntrack cleanup", "Entry - ", retrievedKey)
+					expiredList[newKey] = true
+				}
+				
+				//Check with DIP as owner
+				utils.CopyV6Bytes(&newKey.Owner_ip, connKey.Dest_ip)
+				_, ok = localConntrackCache[newKey]
+				if !ok {
+					//Delete the entry in local cache
+					retrievedKey := fmt.Sprintf("Expired/Delete Conntrack Key with SIP as owner: Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d Owner IP - %s", utils.ConvByteToIPv6(newKey.Source_ip).String(), newKey.Source_port, utils.ConvByteToIPv6(newKey.Dest_ip).String(), newKey.Dest_port, newKey.Protocol, utils.ConvByteToIPv6(newKey.Owner_ip).String())
 					c.logger.Info("Conntrack cleanup", "Entry - ", retrievedKey)
 					expiredList[newKey] = true
 				}

--- a/pkg/ebpf/conntrack/conntrack_client.go
+++ b/pkg/ebpf/conntrack/conntrack_client.go
@@ -119,25 +119,15 @@ func (c *conntrackClient) CleanupConntrackMap() {
 				newKey.Dest_port = iterKey.Dest_port
 				newKey.Protocol = iterKey.Protocol
 
-				//Check with SIP as owner
-				newKey.Owner_ip = newKey.Source_ip
+				newKey.Owner_ip = iterKey.Owner_ip
 				_, ok := localConntrackCache[newKey]
 				if !ok {
 					//Delete the entry in local cache
-					retrievedKey := fmt.Sprintf("Expired/Delete Conntrack Key with SIP as owner: Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d Owner IP - %s", utils.ConvIntToIPv4(iterKey.Source_ip).String(), iterKey.Source_port, utils.ConvIntToIPv4(iterKey.Dest_ip).String(), iterKey.Dest_port, iterKey.Protocol, utils.ConvIntToIPv4(iterKey.Owner_ip).String())
+					retrievedKey := fmt.Sprintf("Expired/Delete Conntrack Key : Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d Owner IP - %s", utils.ConvIntToIPv4(iterKey.Source_ip).String(), iterKey.Source_port, utils.ConvIntToIPv4(iterKey.Dest_ip).String(), iterKey.Dest_port, iterKey.Protocol, utils.ConvIntToIPv4(iterKey.Owner_ip).String())
 					c.logger.Info("Conntrack cleanup", "Entry - ", retrievedKey)
 					expiredList[iterKey] = true
 				}
 
-				//Check with DIP as owner
-				newKey.Owner_ip = newKey.Dest_ip
-				_, ok = localConntrackCache[newKey]
-				if !ok {
-					//Delete the entry in local cache
-					retrievedKey := fmt.Sprintf("Expired/Delete Conntrack Key with DIP as owner: Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d Owner IP - %s", utils.ConvIntToIPv4(iterKey.Source_ip).String(), iterKey.Source_port, utils.ConvIntToIPv4(iterKey.Dest_ip).String(), iterKey.Dest_port, iterKey.Protocol, utils.ConvIntToIPv4(iterKey.Owner_ip).String())
-					c.logger.Info("Conntrack cleanup", "Entry - ", retrievedKey)
-					expiredList[iterKey] = true
-				}
 			}
 			err = goebpfmaps.GetNextMapEntryByID(uintptr(unsafe.Pointer(&iterKey)), uintptr(unsafe.Pointer(&iterNextKey)), mapID)
 			if errors.Is(err, unix.ENOENT) {
@@ -205,7 +195,7 @@ func (c *conntrackClient) Cleanupv6ConntrackMap() {
 		fwdFlowWithDIP.Protocol = conntrackFlow.Forward.Protocol
 		copy(fwdFlowWithDIP.Owner_ip[:], dip)
 
-		localConntrackCache[fwdFlowWithSIP] = true
+		localConntrackCache[fwdFlowWithDIP] = true
 	}
 
 	//Check if the entry is expired..
@@ -230,7 +220,6 @@ func (c *conntrackClient) Cleanupv6ConntrackMap() {
 				}
 				return
 			} else {
-				//Check with SIP as owner
 				newKey := utils.ConntrackKeyV6{}
 				connKey := utils.ConvByteToConntrackV6(byteSlice)
 
@@ -241,21 +230,11 @@ func (c *conntrackClient) Cleanupv6ConntrackMap() {
 				newKey.Dest_port = connKey.Dest_port
 				newKey.Protocol = connKey.Protocol
 
-				utils.CopyV6Bytes(&newKey.Owner_ip, connKey.Source_ip)
+				utils.CopyV6Bytes(&newKey.Owner_ip, connKey.Owner_ip)
 				_, ok := localConntrackCache[newKey]
 				if !ok {
 					//Delete the entry in local cache
-					retrievedKey := fmt.Sprintf("Expired/Delete Conntrack Key with SIP as owner: Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d Owner IP - %s", utils.ConvByteToIPv6(newKey.Source_ip).String(), newKey.Source_port, utils.ConvByteToIPv6(newKey.Dest_ip).String(), newKey.Dest_port, newKey.Protocol, utils.ConvByteToIPv6(newKey.Owner_ip).String())
-					c.logger.Info("Conntrack cleanup", "Entry - ", retrievedKey)
-					expiredList[newKey] = true
-				}
-
-				//Check with DIP as owner
-				utils.CopyV6Bytes(&newKey.Owner_ip, connKey.Dest_ip)
-				_, ok = localConntrackCache[newKey]
-				if !ok {
-					//Delete the entry in local cache
-					retrievedKey := fmt.Sprintf("Expired/Delete Conntrack Key with SIP as owner: Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d Owner IP - %s", utils.ConvByteToIPv6(newKey.Source_ip).String(), newKey.Source_port, utils.ConvByteToIPv6(newKey.Dest_ip).String(), newKey.Dest_port, newKey.Protocol, utils.ConvByteToIPv6(newKey.Owner_ip).String())
+					retrievedKey := fmt.Sprintf("Expired/Delete Conntrack Key : Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d Owner IP - %s", utils.ConvByteToIPv6(newKey.Source_ip).String(), newKey.Source_port, utils.ConvByteToIPv6(newKey.Dest_ip).String(), newKey.Dest_port, newKey.Protocol, utils.ConvByteToIPv6(newKey.Owner_ip).String())
 					c.logger.Info("Conntrack cleanup", "Entry - ", retrievedKey)
 					expiredList[newKey] = true
 				}
@@ -277,9 +256,17 @@ func (c *conntrackClient) Cleanupv6ConntrackMap() {
 	for expiredFlow, _ := range expiredList {
 		c.logger.Info("Conntrack cleanup", "Delete - ", expiredFlow)
 		ceByteSlice := utils.ConvConntrackV6ToByte(expiredFlow)
+		c.printByteArray(ceByteSlice)
 		c.conntrackMap.DeleteMapEntry(uintptr(unsafe.Pointer(&ceByteSlice[0])))
 	}
 
 	c.logger.Info("Done cleanup of conntrack map")
 	return
+}
+
+func (c *conntrackClient) printByteArray(byteArray []byte) {
+	for _, b := range byteArray {
+		c.logger.Info("CONNTRACK VAL", "->", b)
+	}
+	c.logger.Info("DONE")
 }

--- a/pkg/ebpf/conntrack/conntrack_client.go
+++ b/pkg/ebpf/conntrack/conntrack_client.go
@@ -17,19 +17,6 @@ var (
 	CONNTRACK_MAP_PIN_PATH = "/sys/fs/bpf/globals/aws/maps/global_aws_conntrack_map"
 )
 
-type ConntrackKey struct {
-	Source_ip   uint32
-	Source_port uint16
-	Dest_ip     uint32
-	Dest_port   uint16
-	Protocol    uint8
-	Owner_ip    uint32
-}
-
-type ConntrackVal struct {
-	Value uint8
-}
-
 type ConntrackClient interface {
 	CleanupConntrackMap()
 	Cleanupv6ConntrackMap()
@@ -67,11 +54,11 @@ func (c *conntrackClient) CleanupConntrackMap() {
 		return
 	}
 
-	localConntrackCache := make(map[ConntrackKey]bool)
+	localConntrackCache := make(map[utils.ConntrackKey]bool)
 	// Build local conntrack cache
 	for _, conntrackFlow := range conntrackFlows {
 		//Check fwd flow with SIP as owner
-		fwdFlowWithSIP := ConntrackKey{}
+		fwdFlowWithSIP := utils.ConntrackKey{}
 		fwdFlowWithSIP.Source_ip = utils.ConvIPv4ToInt(conntrackFlow.Forward.SrcIP)
 		fwdFlowWithSIP.Source_port = conntrackFlow.Forward.SrcPort
 		fwdFlowWithSIP.Dest_ip = utils.ConvIPv4ToInt(conntrackFlow.Forward.DstIP)
@@ -82,7 +69,7 @@ func (c *conntrackClient) CleanupConntrackMap() {
 		localConntrackCache[fwdFlowWithSIP] = true
 
 		//Check fwd flow with DIP as owner
-		fwdFlowWithDIP := ConntrackKey{}
+		fwdFlowWithDIP := utils.ConntrackKey{}
 		fwdFlowWithDIP.Source_ip = utils.ConvIPv4ToInt(conntrackFlow.Forward.SrcIP)
 		fwdFlowWithDIP.Source_port = conntrackFlow.Forward.SrcPort
 		fwdFlowWithDIP.Dest_ip = utils.ConvIPv4ToInt(conntrackFlow.Forward.DstIP)
@@ -95,15 +82,15 @@ func (c *conntrackClient) CleanupConntrackMap() {
 	}
 
 	//Check if the entry is expired..
-	iterKey := ConntrackKey{}
-	iterNextKey := ConntrackKey{}
-	expiredList := make(map[ConntrackKey]bool)
+	iterKey := utils.ConntrackKey{}
+	iterNextKey := utils.ConntrackKey{}
+	expiredList := make(map[utils.ConntrackKey]bool)
 	err = goebpfmaps.GetFirstMapEntryByID(uintptr(unsafe.Pointer(&iterKey)), mapID)
 	if err != nil {
 		return
 	} else {
 		for {
-			iterValue := ConntrackVal{}
+			iterValue := utils.ConntrackVal{}
 			err = goebpfmaps.GetMapEntryByID(uintptr(unsafe.Pointer(&iterKey)), uintptr(unsafe.Pointer(&iterValue)), mapID)
 			if err != nil {
 				if errors.Is(err, unix.ENOENT) {
@@ -112,7 +99,7 @@ func (c *conntrackClient) CleanupConntrackMap() {
 				}
 				return
 			} else {
-				newKey := ConntrackKey{}
+				newKey := utils.ConntrackKey{}
 				newKey.Source_ip = utils.ConvIPv4ToInt(utils.ConvIntToIPv4(iterKey.Source_ip))
 				newKey.Source_port = iterKey.Source_port
 				newKey.Dest_ip = utils.ConvIPv4ToInt(utils.ConvIntToIPv4(iterKey.Dest_ip))
@@ -211,7 +198,7 @@ func (c *conntrackClient) Cleanupv6ConntrackMap() {
 		return
 	} else {
 		for {
-			iterValue := ConntrackVal{}
+			iterValue := utils.ConntrackVal{}
 			err = goebpfmaps.GetMapEntryByID(uintptr(unsafe.Pointer(&byteSlice[0])), uintptr(unsafe.Pointer(&iterValue)), mapID)
 			if err != nil {
 				if errors.Is(err, unix.ENOENT) {

--- a/pkg/ebpf/conntrack/conntrack_client.go
+++ b/pkg/ebpf/conntrack/conntrack_client.go
@@ -128,7 +128,7 @@ func (c *conntrackClient) CleanupConntrackMap() {
 					c.logger.Info("Conntrack cleanup", "Entry - ", retrievedKey)
 					expiredList[iterKey] = true
 				}
-				
+
 				//Check with DIP as owner
 				newKey.Owner_ip = newKey.Dest_ip
 				_, ok = localConntrackCache[newKey]
@@ -249,7 +249,7 @@ func (c *conntrackClient) Cleanupv6ConntrackMap() {
 					c.logger.Info("Conntrack cleanup", "Entry - ", retrievedKey)
 					expiredList[newKey] = true
 				}
-				
+
 				//Check with DIP as owner
 				utils.CopyV6Bytes(&newKey.Owner_ip, connKey.Dest_ip)
 				_, ok = localConntrackCache[newKey]

--- a/pkg/utils/cp/cp.go
+++ b/pkg/utils/cp/cp.go
@@ -66,9 +66,6 @@ func CopyFile(src, dst string) (err error) {
 func InstallBPFBinaries(pluginBins []string, hostCNIBinPath string) error {
 	utilLogger.Info("Let's install BPF Binaries on to the host path.....")
 	for _, plugin := range pluginBins {
-		if plugin == EKS_V6_CLI_BINARY {
-			plugin = EKS_CLI_BINARY //CLI binary should always refer to aws-eks-na-cli
-		}
 		target := fmt.Sprintf("%s%s", hostCNIBinPath, plugin)
 		source := fmt.Sprintf("%s", plugin)
 		utilLogger.Info("Installing BPF Binary..", "target", target, "source", source)
@@ -77,6 +74,15 @@ func InstallBPFBinaries(pluginBins []string, hostCNIBinPath string) error {
 			utilLogger.Info("Failed to install", "target", target, "error", err)
 		}
 		utilLogger.Info("Successfully installed - ", "binary", target)
+
+		// CLI binary should always refer to aws-eks-na-cli
+		if plugin == EKS_V6_CLI_BINARY {
+			newTarget := fmt.Sprintf("%s%s", hostCNIBinPath, EKS_CLI_BINARY)
+			err := os.Rename(target, newTarget)
+			if err != nil {
+				return fmt.Errorf("failed to rename file: %s", err)
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/utils/cp/cp.go
+++ b/pkg/utils/cp/cp.go
@@ -66,7 +66,14 @@ func CopyFile(src, dst string) (err error) {
 func InstallBPFBinaries(pluginBins []string, hostCNIBinPath string) error {
 	utilLogger.Info("Let's install BPF Binaries on to the host path.....")
 	for _, plugin := range pluginBins {
-		target := fmt.Sprintf("%s%s", hostCNIBinPath, plugin)
+		targetPlugin := plugin
+
+		// CLI binary should always refer to aws-eks-na-cli
+		if plugin == EKS_V6_CLI_BINARY {
+			targetPlugin = EKS_CLI_BINARY
+		}
+
+		target := fmt.Sprintf("%s%s", hostCNIBinPath, targetPlugin)
 		source := fmt.Sprintf("%s", plugin)
 		utilLogger.Info("Installing BPF Binary..", "target", target, "source", source)
 
@@ -74,15 +81,6 @@ func InstallBPFBinaries(pluginBins []string, hostCNIBinPath string) error {
 			utilLogger.Info("Failed to install", "target", target, "error", err)
 		}
 		utilLogger.Info("Successfully installed - ", "binary", target)
-
-		// CLI binary should always refer to aws-eks-na-cli
-		if plugin == EKS_V6_CLI_BINARY {
-			newTarget := fmt.Sprintf("%s%s", hostCNIBinPath, EKS_CLI_BINARY)
-			err := os.Rename(target, newTarget)
-			if err != nil {
-				return fmt.Errorf("failed to rename file: %s", err)
-			}
-		}
 	}
 	return nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -285,9 +285,11 @@ func ConvIPv6ToByte(ipaddr net.IP) []byte {
 type ConntrackKeyV6 struct {
 	Source_ip   [16]byte
 	Source_port uint16
+	_           uint16 //Padding
 	Dest_ip     [16]byte
 	Dest_port   uint16
 	Protocol    uint8
+	_           uint8    //Padding
 	Owner_ip    [16]byte //16
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -285,10 +285,10 @@ func ConvIPv6ToByte(ipaddr net.IP) []byte {
 type ConntrackKeyV6 struct {
 	Source_ip   [16]byte
 	Source_port uint16
-	_           uint16 //Padding
 	Dest_ip     [16]byte
 	Dest_port   uint16
 	Protocol    uint8
+	Owner_ip    [16]byte //16
 }
 
 type ConntrackVal struct {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -293,6 +293,15 @@ type ConntrackKeyV6 struct {
 	Owner_ip    [16]byte //16
 }
 
+type ConntrackKey struct {
+	Source_ip   uint32
+	Source_port uint16
+	Dest_ip     uint32
+	Dest_port   uint16
+	Protocol    uint8
+	Owner_ip    uint32
+}
+
 type ConntrackVal struct {
 	Value uint8
 }
@@ -315,4 +324,34 @@ func CopyV6Bytes(dest *[16]byte, src [16]byte) {
 	for i := 0; i < len(src); i++ {
 		dest[i] = src[i]
 	}
+}
+
+type BPFTrieKey struct {
+	PrefixLen uint32
+	IP        uint32
+}
+
+type BPFTrieKeyV6 struct {
+	PrefixLen uint32
+	IP        [16]byte
+}
+
+type BPFTrieVal struct {
+	Protocol  uint32
+	StartPort uint32
+	EndPort   uint32
+}
+
+func ConvTrieV6ToByte(key BPFTrieKeyV6) []byte {
+	ipSize := unsafe.Sizeof(key)
+	byteArray := (*[20]byte)(unsafe.Pointer(&key))
+	byteSlice := byteArray[:ipSize]
+	return byteSlice
+}
+
+func ConvByteToTrieV6(keyByte []byte) BPFTrieKeyV6 {
+	var v6key BPFTrieKeyV6
+	byteArray := (*[unsafe.Sizeof(v6key)]byte)(unsafe.Pointer(&v6key))
+	copy(byteArray[:], keyByte)
+	return v6key
 }


### PR DESCRIPTION
*Issue #, if available:* fixes #131

*Description of changes:* Conntrack key should have owner IP during cleanup.

*Testing:*

```
[root@ip-192-168-82-239 ~]# ls /proc/32584/fd/ | wc -l
18 <- Start of FDs

[root@ip-192-168-82-239 ~]# ls /proc/32584/fd/ | wc -l
22 <- Total FDs

[root@ip-192-168-82-239 ~]# bpftool map dump id 29 | grep key | wc -l
900 <- Number of conntrack entries

[root@ip-192-168-82-239 ~]# bpftool map dump id 29 | grep key | wc -l
2 <- After cleanup of conntrack entry

[root@ip-192-168-82-239 ~]# ls /proc/32584/fd/ | wc -l
18 <- end of tests run
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
