### PR TITLE
Conntrack cleanup with v4

### DIFF
--- a/pkg/ebpf/conntrack/conntrack_client.go
+++ b/pkg/ebpf/conntrack/conntrack_client.go
@@ -99,20 +99,30 @@ func (c *conntrackClient) CleanupConntrackMap() {
 				}
 				return
 			} else {
+
 				newKey := utils.ConntrackKey{}
 				newKey.Source_ip = utils.ConvIPv4ToInt(utils.ConvIntToIPv4(iterKey.Source_ip))
 				newKey.Source_port = iterKey.Source_port
 				newKey.Dest_ip = utils.ConvIPv4ToInt(utils.ConvIntToIPv4(iterKey.Dest_ip))
 				newKey.Dest_port = iterKey.Dest_port
 				newKey.Protocol = iterKey.Protocol
+				newKey.Owner_ip = utils.ConvIPv4ToInt(utils.ConvIntToIPv4(iterKey.Owner_ip))
 
-				newKey.Owner_ip = iterKey.Owner_ip
 				_, ok := localConntrackCache[newKey]
 				if !ok {
 					//Delete the entry in local cache
 					retrievedKey := fmt.Sprintf("Expired/Delete Conntrack Key : Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d Owner IP - %s", utils.ConvIntToIPv4(iterKey.Source_ip).String(), iterKey.Source_port, utils.ConvIntToIPv4(iterKey.Dest_ip).String(), iterKey.Dest_port, iterKey.Protocol, utils.ConvIntToIPv4(iterKey.Owner_ip).String())
 					c.logger.Info("Conntrack cleanup", "Entry - ", retrievedKey)
-					expiredList[iterKey] = true
+
+					// Copy from iterKey since we will replace the value
+					nKey := utils.ConntrackKey{}
+					nKey.Source_ip = iterKey.Source_ip
+					nKey.Source_port = iterKey.Source_port
+					nKey.Dest_ip = iterKey.Dest_ip
+					nKey.Dest_port = iterKey.Dest_port
+					nKey.Protocol = iterKey.Protocol
+					nKey.Owner_ip = iterKey.Owner_ip
+					expiredList[nKey] = true
 				}
 
 			}
@@ -124,6 +134,7 @@ func (c *conntrackClient) CleanupConntrackMap() {
 			if err != nil {
 				break
 			}
+
 			iterKey = iterNextKey
 		}
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -296,9 +296,11 @@ type ConntrackKeyV6 struct {
 type ConntrackKey struct {
 	Source_ip   uint32
 	Source_port uint16
+	_           uint16 //Padding
 	Dest_ip     uint32
 	Dest_port   uint16
 	Protocol    uint8
+	_           uint8 //Padding
 	Owner_ip    uint32
 }
 


### PR DESCRIPTION
*Issue #, if available:* #144

*Description of changes:* Conntrack cleanup logic had the wrong key indexed into kernel lookup cache leading to cleaning of local conntrack table.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
