### PR TITLE
Fix metrics logging error; Remove version log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ controller
 bin/
 config/
 vendor/
+scripts/results.log

--- a/Makefile
+++ b/Makefile
@@ -308,3 +308,8 @@ update-node-agent-image: ## Updates node agent image on an existing cluster. Opt
 update-image-and-test: ## Updates node agent image on existing cluster and runs cyclonus tests. Call with CLUSTER_NAME=<name of the cluster> and AWS_EKS_NODEAGENT=<Image URI> 
 	$(MAKE) update-node-agent-image AWS_EKS_NODEAGENT=$(AWS_EKS_NODEAGENT)
 	$(MAKE) run-cyclonus-test CLUSTER_NAME=$(CLUSTER_NAME) SKIP_ADDON_INSTALLATION=true
+
+clean: # Clean temporary files and build artifacts from the project
+	@rm -f -- aws-eks-na-cli
+	@rm -f -- aws-eks-na-cli-v6
+	@rm -f -- coverage.txt

--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/aws/aws-network-policy-agent/pkg/logger"
 
-	"github.com/aws/aws-network-policy-agent/pkg/version"
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"github.com/spf13/pflag"
@@ -56,11 +55,6 @@ func init() {
 
 func main() {
 	initLogger, _ := getLoggerWithLogLevel("info", "")
-	initLogger.Info("version",
-		"GitVersion", version.GitVersion,
-		"GitCommit", version.GitCommit,
-		"BuildDate", version.BuildDate,
-	)
 
 	ctrlConfig, err := loadControllerConfig()
 	if err != nil {
@@ -111,7 +105,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	go metrics.ServeMetrics(setupLog)
+	go metrics.ServeMetrics()
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctx); err != nil {
@@ -135,6 +129,6 @@ func loadControllerConfig() (config.ControllerConfig, error) {
 
 // getLoggerWithLogLevel returns logger with specific log level.
 func getLoggerWithLogLevel(logLevel string, logFilePath string) (logr.Logger, error) {
-	ctrlLogger := logger.New(logLevel, logFilePath)
+	ctrlLogger := logger.New(logLevel, logFilePath, 2)
 	return zapr.NewLogger(ctrlLogger), nil
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -55,7 +55,7 @@ func getEncoder() zapcore.Encoder {
 	return zapcore.NewJSONEncoder(encoderConfig)
 }
 
-func (logConfig *Configuration) newZapLogger() *zap.Logger { //Logger {
+func (logConfig *Configuration) newZapLogger(callSkip int) *zap.Logger { //Logger {
 	var cores []zapcore.Core
 
 	logLevel := getZapLevel(logConfig.LogLevel)
@@ -66,9 +66,11 @@ func (logConfig *Configuration) newZapLogger() *zap.Logger { //Logger {
 
 	combinedCore := zapcore.NewTee(cores...)
 
+	// Allow callers to set value for call skip. The value should be 2 by default, but goroutines
+	// set it to 0 or 1 to avoid log stack errors.
 	logger := zap.New(combinedCore,
 		zap.AddCaller(),
-		zap.AddCallerSkip(2),
+		zap.AddCallerSkip(callSkip),
 	)
 	defer logger.Sync()
 
@@ -103,12 +105,12 @@ func getLogWriter(logFilePath string) zapcore.WriteSyncer {
 }
 
 // New logger initializes logger
-func New(logLevel, logLocation string) *zap.Logger {
+func New(logLevel, logLocation string, callSkip int) *zap.Logger {
 	inputLogConfig := &Configuration{
 		LogLevel:    logLevel,
 		LogLocation: logLocation,
 	}
 
-	logger := inputLogConfig.newZapLogger()
+	logger := inputLogConfig.newZapLogger(callSkip)
 	return logger
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-network-policy-agent/issues/103
https://github.com/aws/aws-network-policy-agent/issues/49

*Description of changes:*
This PR fixes two issues:
1. The metrics server runs in a goroutine. Logging was broken in the metrics server because the call stack was starting at -2 when it needed to start at 0. This PR instantiates a new logger in the metrics goroutine and resolves https://github.com/aws/aws-network-policy-agent/issues/103
2. During init, the agent was trying to log version information. This information is not properly set, leading to https://github.com/aws/aws-network-policy-agent/issues/49. This PR removes that log, as the image tag is sufficient to determine version.

New log looks like:
```
% kubectl logs -n kube-system aws-node-57t4f -c aws-eks-nodeagent
{"level":"info","ts":"2023-12-26T20:57:29.306Z","caller":"metrics/metrics.go:23","msg":"Serving metrics on ","port":61680}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
