### PR TITLE
Add prefix to identify log stream for network policy events

### DIFF
--- a/pkg/ebpf/events/events.go
+++ b/pkg/ebpf/events/events.go
@@ -234,8 +234,8 @@ func ensureLogGroupExists(name string) error {
 }
 
 func createLogStream() error {
-	name := uuid.New().String()
 
+	name := "aws-network-policy-agent-audit-" + uuid.New().String()
 	_, err := cwl.CreateLogStream(&cloudwatchlogs.CreateLogStreamInput{
 		LogGroupName:  &logGroupName,
 		LogStreamName: &name,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-network-policy-agent/issues/99

*Description of changes:*
Added prefix `aws-network-policy-agent-<uuid>` to the log stream

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
