### PR TITLE
Check the new addon versions in the right regions

### DIFF
--- a/scripts/lib/network-policy.sh
+++ b/scripts/lib/network-policy.sh
@@ -3,7 +3,7 @@ function load_addon_details() {
 
   ADDON_NAME="vpc-cni"
   echo "loading $ADDON_NAME addon details"
-  LATEST_ADDON_VERSION=$(aws eks describe-addon-versions $ENDPOINT_FLAG --addon-name $ADDON_NAME --kubernetes-version $K8S_VERSION | jq '.addons[0].addonVersions[0].addonVersion' -r)
+  LATEST_ADDON_VERSION=$(aws eks describe-addon-versions $ENDPOINT_FLAG --addon-name $ADDON_NAME --kubernetes-version $K8S_VERSION --region $REGION | jq '.addons[0].addonVersions[0].addonVersion' -r)
   get_service_account_role_arn
 }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
We should look for addon versions in the right regions instead of looking in the default region where the test is run from

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
