### PR TITLE
Update CI scripts to the test on latest available k8s cluster

### DIFF
--- a/.github/workflows/e2e-conformance.yaml
+++ b/.github/workflows/e2e-conformance.yaml
@@ -53,7 +53,6 @@ jobs:
       - name: Run e2e conformance test
         env:
           RUN_CONFORMANCE_TESTS: true
-          K8S_VERSION: 1.27
           IP_FAMILY: ${{ matrix.ip-family }}
           INSTANCE_TYPE: ${{ matrix.instance-type }}
           AWS_EKS_NODEAGENT_IMAGE: ${{ needs.build-image.outputs.AWS_EKS_NODEAGENT_IMAGE }}

--- a/.github/workflows/performance-tests.yaml
+++ b/.github/workflows/performance-tests.yaml
@@ -52,7 +52,6 @@ jobs:
       - name: Run performance tests
         env:
           RUN_PERFORMANCE_TESTS: true
-          K8S_VERSION: 1.27
           NODES_CAPACITY: 3
           INSTANCE_TYPE: c5.xlarge
           IP_FAMILY: ${{ matrix.ip-family }}

--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -8,12 +8,18 @@ function load_default_values(){
     NODEGROUP_TYPE="${NODEGROUP_TYPE:=linux}"
     NODES_CAPACITY="${NODES_CAPACITY:=3}"
     INSTANCE_TYPE="${INSTANCE_TYPE:=t3.large}"
-    K8S_VERSION="${K8S_VERSION:=1.27}"
+    K8S_VERSION="${K8S_VERSION:=""}"
     IP_FAMILY="${IP_FAMILY:=IPv4}"
     CW_NAMESPACE="${CW_NAMESPACE:=amazon-cloudwatch}"
     CW_POLICY_ARN="${CW_POLICY_ARN:=arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy}"
     ENDPOINT_FLAG="${ENDPOINT_FLAG:=""}"
     HELM_EXTRA_ARGS="${HELM_EXTRA_ARGS:=""}"
+
+    # If Kubernetes version is not passed then use the latest available version
+    if [[ -z $K8S_VERSION ]]; then
+        K8S_VERSION=$(eksctl version -o json | jq -r '.EKSServerSupportedVersions | sort | reverse | .[0]')
+    fi
+
 }
 
 function create_cluster(){
@@ -60,6 +66,6 @@ EOF
 
 function delete_cluster(){
 
-    eksctl delete cluster -f ./eks-cluster.yaml || echo "Cluster Delete failed"
+    eksctl delete cluster -f ./eks-cluster.yaml --disable-nodegroup-eviction || echo "Cluster Delete failed"
     rm -rf ./eks-cluster.yaml || echo "Cluster config file not found"
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This updates the CI jobs to use the latest available k8s version and runs the conformance test against it. This also adds a flag to delete the cluster ignoring coredns PDB

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
