### PR TITLE
Log and return an error when policy is applied to a period-containing pod name

### DIFF
--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -1,6 +1,7 @@
 package ebpf
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -621,6 +622,12 @@ func (l *bpfClient) loadBPFProgram(fileName string, direction string,
 
 	start := time.Now()
 	l.logger.Info("Load the eBPF program")
+
+	if strings.Contains(podIdentifier, ".") {
+		l.logger.Info("Pod name cannot contain '.'")
+		return nil, -1, errors.New("Pod name cannot contain '.'")
+	}
+
 	// Load a new instance of the ingres program
 	progInfo, _, err := l.bpfSDKClient.LoadBpfFile(fileName, podIdentifier)
 	duration := msSince(start)

--- a/pkg/ebpf/bpf_client_test.go
+++ b/pkg/ebpf/bpf_client_test.go
@@ -1,6 +1,7 @@
 package ebpf
 
 import (
+	"errors"
 	"net"
 	"sort"
 	"sync"
@@ -401,6 +402,23 @@ func TestLoadBPFProgram(t *testing.T) {
 
 	mockBpfClient.EXPECT().LoadBpfFile(gomock.Any(), gomock.Any()).AnyTimes()
 	_, _, gotErr := testBpfClient.loadBPFProgram("handle_ingress", "ingress", "test-abcd")
+	assert.Equal(t, gotErr, wantErr)
+}
+func TestLoadBPFProgramPodIdentifierContainsPeriod(t *testing.T) {
+	wantErr := errors.New("Pod name cannot contain '.'")
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockBpfClient := mock_bpfclient.NewMockBpfSDKClient(ctrl)
+	testBpfClient := &bpfClient{
+		nodeIP:       "10.1.1.1",
+		logger:       logr.New(&log.NullLogSink{}),
+		enableIPv6:   false,
+		bpfSDKClient: mockBpfClient,
+	}
+
+	mockBpfClient.EXPECT().LoadBpfFile(gomock.Any(), gomock.Any()).AnyTimes()
+	_, _, gotErr := testBpfClient.loadBPFProgram("handle_ingress", "ingress", "test-ab.cd")
 	assert.Equal(t, gotErr, wantErr)
 }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-network-policy-agent/issues/118

*Description of changes:*
This change prevents the `aws-node` pod from entering a crash loop in the case that a networking policy is applied to a pod containing a period. I also added a unit test to ensure this behavior.

*Testing:*
1. I built and installed an image of `aws-network-policy-agent` into `aws-node` and [followed the documentation to enable network policy](https://docs.aws.amazon.com/eks/latest/userguide/cni-network-policy.html). 
2. I applied the `Sample Policy` and `Sample Deployment` from https://github.com/aws/aws-network-policy-agent/issues/118#issue-1967965139 on the cluster
3. Rather than crashing, I observed the following logs in `/var/logs/aws-routed-eni/network-policy-agent.log`
```
{"level":"info","ts":"2024-02-01T22:04:29.495Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:146","msg":"Processing Pod: ","name:":"sample-app.app-7c547489fb-dws7q","namespace:":"default","podIdentifier: ":"sample-app.app-7c547489fb-default"}
{"level":"info","ts":"2024-02-01T22:04:29.495Z","logger":"ebpf-client","caller":"controllers/policyendpoints_controller.go:243","msg":"AttacheBPFProbes for","pod":"sample-app.app-7c547489fb-dws7q"," in namespace":"default"," with hostVethName":"enid066e956460"}
{"level":"info","ts":"2024-02-01T22:04:29.495Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:412","msg":"Load the eBPF program"}
{"level":"info","ts":"2024-02-01T22:04:29.495Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:412","msg":"Pod identifier cannot contain '.'"}
```
I also observed the following in `/var/logs/aws-routed-eni/ebpf-sdk.log`
```
{"level":"error","ts":"2024-02-01T04:12:45.931Z","caller":"ebpf/bpf_client.go:517","msg":"while loading egress program \"handle egress\" on fd -1: invalid argument"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
