### PR TITLE
Use minimal base image for Network Policy agent; update Golang version to 1.21.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM public.ecr.aws/eks-distro-build-tooling/golang:1.21.5-6-gcc-al2 as builder
+FROM public.ecr.aws/eks-distro-build-tooling/golang:1.21.7-8-gcc-al2 as builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -41,12 +41,8 @@ COPY . ./
 COPY --from=vmlinuxbuilder /vmlinuxbuilder/pkg/ebpf/c/vmlinux.h ./pkg/ebpf/c/
 RUN make build-bpf
 
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-base:latest.2
-RUN yum update -y && \
-    yum install -y iptables iproute jq && \
-    yum install -y llvm clang make gcc && \
-    yum install -y coreutils kernel-devel elfutils-libelf-devel zlib-devel libbpf-devel && \
-    yum clean all
+# Container base image
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest.2
 
 WORKDIR /
 COPY --from=builder /workspace/controller .

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/eks-distro-build-tooling/golang:1.21.3-4-gcc-al2
+FROM public.ecr.aws/eks-distro-build-tooling/golang:1.21.7-8-gcc-al2
 WORKDIR /go/src/github.com/aws/aws-network-policy-agent
 
 # Force the go compiler to use modules.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-network-policy-agent/issues/109

*Description of changes:*
This PR modifies the Network Policy agent Dockerfile to use `eks-distro-minimal-base-glibc` as the base image. This minimal image, along with removing the libraries that were installed using `yum`, significantly decreases the size of the container image. My personal build showed a decrease from ~290MB to ~38MB.

A smaller container image means faster image pulls and a smaller surface area for CVEs.

For the libraries that were installed in the container filesystem using `yum`, such as `libbpf-devel`, it turns out that none of these are needed at runtime. The object files created in the `bpfbuilder` stage already have everything they need statically linked.

Also, I updated the Golang builder image to Golang 1.21.7.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
