### PR TITLE
pin envtest version due to an upstream bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230216140739-c98506dc3b8e
 
 # Check formatting of source code files without modification.
 check-format: FORMAT_FLAGS = -l


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Due to [an upstream issue](https://github.com/kubernetes-sigs/controller-runtime/issues/2720#issuecomment-2016461180), the envtest fails on golang version < 1.22. We make this workaround as [another EKS controller](https://github.com/aws/amazon-vpc-resource-controller-k8s/pull/390).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
