### PR TITLE
Remove callSkip to prevent Logger.check error

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,6 +133,6 @@ func loadControllerConfig() (config.ControllerConfig, error) {
 
 // getLoggerWithLogLevel returns logger with specific log level.
 func getLoggerWithLogLevel(logLevel string, logFilePath string) (logr.Logger, error) {
-	ctrlLogger := logger.New(logLevel, logFilePath, 2)
+	ctrlLogger := logger.New(logLevel, logFilePath)
 	return zapr.NewLogger(ctrlLogger), nil
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -55,7 +55,7 @@ func getEncoder() zapcore.Encoder {
 	return zapcore.NewJSONEncoder(encoderConfig)
 }
 
-func (logConfig *Configuration) newZapLogger(callSkip int) *zap.Logger { //Logger {
+func (logConfig *Configuration) newZapLogger() *zap.Logger { //Logger {
 	var cores []zapcore.Core
 
 	logLevel := getZapLevel(logConfig.LogLevel)
@@ -66,11 +66,8 @@ func (logConfig *Configuration) newZapLogger(callSkip int) *zap.Logger { //Logge
 
 	combinedCore := zapcore.NewTee(cores...)
 
-	// Allow callers to set value for call skip. The value should be 2 by default, but goroutines
-	// set it to 0 or 1 to avoid log stack errors.
 	logger := zap.New(combinedCore,
 		zap.AddCaller(),
-		zap.AddCallerSkip(callSkip),
 	)
 	defer logger.Sync()
 
@@ -105,12 +102,12 @@ func getLogWriter(logFilePath string) zapcore.WriteSyncer {
 }
 
 // New logger initializes logger
-func New(logLevel, logLocation string, callSkip int) *zap.Logger {
+func New(logLevel, logLocation string) *zap.Logger {
 	inputLogConfig := &Configuration{
 		LogLevel:    logLevel,
 		LogLocation: logLocation,
 	}
 
-	logger := inputLogConfig.newZapLogger(callSkip)
+	logger := inputLogConfig.newZapLogger()
 	return logger
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -47,6 +47,6 @@ func setupMetricsServer() *http.Server {
 }
 
 func getMetricsLogger() logr.Logger {
-	ctrlLogger := logger.New("info", "", 0)
+	ctrlLogger := logger.New("info", "")
 	return zapr.NewLogger(ctrlLogger)
 }


### PR DESCRIPTION
*Issue #, if available:*

#103

*Description of changes:*

The message `Logger.check error: failed to get caller` is generated by zap when call stack is empty after filtering callerSkip
https://github.com/uber-go/zap/blob/v1.27.0/logger.go#L382-L388

In previous PR https://github.com/aws/aws-network-policy-agent/pull/168, we addressed `failed to get caller` in the metrics server. But the error still exists because rpc handler has same issue.
For our use case, we don't need to use `zap.AddCallerSkip`. If we remove `zap.AddCallerSkip`, the message is disappeared and the log includes `caller`.

```
{"level":"info","ts":"2024-04-17T15:13:30.592Z","logger":"rpc-handler","caller":"rpc/rpc_handler.go:94","msg":"Serving RPC Handler","Address":"127.0.0.1:50052"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
