### PR TITLE
vmlinuxh: use packaged kernel instead of random host kernel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,11 @@ WORKDIR /vmlinuxbuilder
 RUN yum update -y && \
     yum install -y iproute procps-ng && \
     yum install -y llvm clang make gcc && \
-    yum install -y kernel-devel elfutils-libelf-devel zlib-devel libbpf-devel bpftool && \
-    yum clean all
+    yum install -y kernel kernel-devel elfutils-libelf-devel zlib-devel libbpf-devel bpftool && \
+    yum clean all && \
+    /usr/src/kernels/*/scripts/extract-vmlinux /usr/lib/modules/*/vmlinuz > vmlinux
 COPY . ./
-RUN make vmlinuxh
+RUN make vmlinuxh VMLINUX=vmlinux
 
 # Build BPF
 FROM public.ecr.aws/amazonlinux/amazonlinux:2 as bpfbuilder

--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,10 @@ EBPF_OBJ_CORE_HEADERS = $(shell find pkg/ebpf/c -name *.h)
 EBPF_OBJ_SRC = ./pkg/ebpf/c/xdpdrop.bpf.c
 EBPF_OBJ_SRC_TC = ./pkg/ebpf/c/tc.bpf.c
 
+VMLINUX ?= /sys/kernel/btf/vmlinux
+
 vmlinuxh:
-	bpftool btf dump file /sys/kernel/btf/vmlinux format c > $(abspath ./$(EBPF_DIR))/vmlinux.h
+	bpftool btf dump file $(VMLINUX) format c > $(abspath ./$(EBPF_DIR))/vmlinux.h
 
 ARCH := $(shell uname -m | sed 's/x86_64/amd64/g; s/aarch64/arm64/g')
 


### PR DESCRIPTION
Currently Dockerfile build takes btf information from the running host kernel. For me that would be Ubuntu kernel. However, because packaged AL2023 rpm is available, one can instead extract up to date BTF information from it. This should ensure up-to-date vmlinuxh being used for all builds, and reproducible locally without relying on having a matching host kernel.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.