### PR TITLE
Refactor conntrack cleanup - v4 and v6

### DIFF
--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -227,10 +227,12 @@ func NewBpfClient(policyEndpointeBPFContext *sync.Map, nodeIP string, enablePoli
 	}
 
 	// Start Conntrack routines
+	duration := time.Duration(conntrackTTL) * time.Second
+	halfDuration := duration / 2
 	if enableIPv6 {
-		go wait.Forever(ebpfClient.conntrackClient.Cleanupv6ConntrackMap, time.Duration(conntrackTTL)*time.Second)
+		go wait.Forever(ebpfClient.conntrackClient.Cleanupv6ConntrackMap, halfDuration)
 	} else {
-		go wait.Forever(ebpfClient.conntrackClient.CleanupConntrackMap, time.Duration(conntrackTTL)*time.Second)
+		go wait.Forever(ebpfClient.conntrackClient.CleanupConntrackMap, halfDuration)
 	}
 
 	// Initializes prometheus metrics

--- a/pkg/ebpf/conntrack/conntrack_client.go
+++ b/pkg/ebpf/conntrack/conntrack_client.go
@@ -39,8 +39,14 @@ func NewConntrackClient(conntrackMap goebpfmaps.BpfMap, enableIPv6 bool, logger 
 		enableIPv6:            enableIPv6,
 		logger:                logger,
 		hydratelocalConntrack: true,
-		localConntrackV4Cache: make(map[utils.ConntrackKey]bool),
-		localConntrackV6Cache: make(map[utils.ConntrackKeyV6]bool),
+	}
+}
+
+func (c *conntrackClient) InitializeLocalCache() {
+	if c.enableIPv6 {
+		c.localConntrackV6Cache = make(map[utils.ConntrackKeyV6]bool)
+	} else {
+		c.localConntrackV4Cache = make((map[utils.ConntrackKey]bool))
 	}
 }
 
@@ -57,9 +63,8 @@ func (c *conntrackClient) CleanupConntrackMap() {
 	// Read from eBPF Table if local conntrack table is not cached
 	if c.hydratelocalConntrack {
 		//Lets cleanup all entries in cache
-		for conntrackKey := range c.localConntrackV4Cache {
-			delete(c.localConntrackV4Cache, conntrackKey)
-		}
+		c.InitializeLocalCache()
+
 		iterKey := utils.ConntrackKey{}
 		iterNextKey := utils.ConntrackKey{}
 		err = goebpfmaps.GetFirstMapEntryByID(uintptr(unsafe.Pointer(&iterKey)), mapID)
@@ -200,9 +205,7 @@ func (c *conntrackClient) Cleanupv6ConntrackMap() {
 	// Read from eBPF Table if local conntrack table is not cached
 	if c.hydratelocalConntrack {
 		//Lets cleanup all entries in cache
-		for conntrackKey := range c.localConntrackV6Cache {
-			delete(c.localConntrackV6Cache, conntrackKey)
-		}
+		c.InitializeLocalCache()
 		iterKey := utils.ConntrackKeyV6{}
 		iterNextKey := utils.ConntrackKeyV6{}
 

--- a/pkg/ebpf/conntrack/conntrack_client.go
+++ b/pkg/ebpf/conntrack/conntrack_client.go
@@ -25,16 +25,22 @@ type ConntrackClient interface {
 var _ ConntrackClient = (*conntrackClient)(nil)
 
 type conntrackClient struct {
-	conntrackMap goebpfmaps.BpfMap
-	enableIPv6   bool
-	logger       logr.Logger
+	conntrackMap          goebpfmaps.BpfMap
+	enableIPv6            bool
+	logger                logr.Logger
+	hydratelocalConntrack bool
+	localConntrackV4Cache map[utils.ConntrackKey]bool
+	localConntrackV6Cache map[utils.ConntrackKeyV6]bool
 }
 
 func NewConntrackClient(conntrackMap goebpfmaps.BpfMap, enableIPv6 bool, logger logr.Logger) *conntrackClient {
 	return &conntrackClient{
-		conntrackMap: conntrackMap,
-		enableIPv6:   enableIPv6,
-		logger:       logger,
+		conntrackMap:          conntrackMap,
+		enableIPv6:            enableIPv6,
+		logger:                logger,
+		hydratelocalConntrack: true,
+		localConntrackV4Cache: make(map[utils.ConntrackKey]bool),
+		localConntrackV6Cache: make(map[utils.ConntrackKeyV6]bool),
 	}
 }
 
@@ -48,135 +54,136 @@ func (c *conntrackClient) CleanupConntrackMap() {
 	}
 	mapID := int(mapInfo.Id)
 
-	//Read from kernel conntrack table
-	conntrackFlows, err := netlink.ConntrackTableList(netlink.ConntrackTable, unix.AF_INET)
-	if err != nil {
-		c.logger.Info("Failed to read from conntrack table")
-		return
-	}
-
-	localConntrackCache := make(map[utils.ConntrackKey]bool)
-	// Build local conntrack cache
-	for _, conntrackFlow := range conntrackFlows {
-		//Check fwd flow with SIP as owner
-		fwdFlowWithSIP := utils.ConntrackKey{}
-		fwdFlowWithSIP.Source_ip = utils.ConvIPv4ToInt(conntrackFlow.Forward.SrcIP)
-		fwdFlowWithSIP.Source_port = conntrackFlow.Forward.SrcPort
-		fwdFlowWithSIP.Dest_ip = utils.ConvIPv4ToInt(conntrackFlow.Forward.DstIP)
-		fwdFlowWithSIP.Dest_port = conntrackFlow.Forward.DstPort
-		fwdFlowWithSIP.Protocol = conntrackFlow.Forward.Protocol
-		fwdFlowWithSIP.Owner_ip = fwdFlowWithSIP.Source_ip
-
-		localConntrackCache[fwdFlowWithSIP] = true
-
-		//Check fwd flow with DIP as owner
-		fwdFlowWithDIP := utils.ConntrackKey{}
-		fwdFlowWithDIP.Source_ip = utils.ConvIPv4ToInt(conntrackFlow.Forward.SrcIP)
-		fwdFlowWithDIP.Source_port = conntrackFlow.Forward.SrcPort
-		fwdFlowWithDIP.Dest_ip = utils.ConvIPv4ToInt(conntrackFlow.Forward.DstIP)
-		fwdFlowWithDIP.Dest_port = conntrackFlow.Forward.DstPort
-		fwdFlowWithDIP.Protocol = conntrackFlow.Forward.Protocol
-		fwdFlowWithDIP.Owner_ip = fwdFlowWithDIP.Dest_ip
-
-		localConntrackCache[fwdFlowWithDIP] = true
-
-		//Dest can be VIP and pods can be on same node
-		destIP := net.ParseIP(conntrackFlow.Forward.DstIP.String())
-		revDestIP := net.ParseIP(conntrackFlow.Reverse.SrcIP.String())
-
-		if !destIP.Equal(revDestIP) {
-			//Check fwd flow with SIP as owner
-			revFlowWithSIP := utils.ConntrackKey{}
-			revFlowWithSIP.Source_ip = utils.ConvIPv4ToInt(conntrackFlow.Forward.SrcIP)
-			revFlowWithSIP.Source_port = conntrackFlow.Forward.SrcPort
-			revFlowWithSIP.Dest_ip = utils.ConvIPv4ToInt(conntrackFlow.Reverse.SrcIP)
-			revFlowWithSIP.Dest_port = conntrackFlow.Reverse.SrcPort
-			revFlowWithSIP.Protocol = conntrackFlow.Forward.Protocol
-			revFlowWithSIP.Owner_ip = revFlowWithSIP.Source_ip
-
-			localConntrackCache[revFlowWithSIP] = true
-
-			//Check fwd flow with DIP as owner
-			revFlowWithDIP := utils.ConntrackKey{}
-			revFlowWithDIP.Source_ip = utils.ConvIPv4ToInt(conntrackFlow.Forward.SrcIP)
-			revFlowWithDIP.Source_port = conntrackFlow.Forward.SrcPort
-			revFlowWithDIP.Dest_ip = utils.ConvIPv4ToInt(conntrackFlow.Reverse.SrcIP)
-			revFlowWithDIP.Dest_port = conntrackFlow.Reverse.SrcPort
-			revFlowWithDIP.Protocol = conntrackFlow.Forward.Protocol
-			revFlowWithDIP.Owner_ip = revFlowWithDIP.Dest_ip
-
-			localConntrackCache[revFlowWithDIP] = true
+	// Read from eBPF Table if local conntrack table is not cached
+	if c.hydratelocalConntrack {
+		//Lets cleanup all entries in cache
+		for conntrackKey := range c.localConntrackV4Cache {
+			delete(c.localConntrackV4Cache, conntrackKey)
 		}
+		iterKey := utils.ConntrackKey{}
+		iterNextKey := utils.ConntrackKey{}
+		err = goebpfmaps.GetFirstMapEntryByID(uintptr(unsafe.Pointer(&iterKey)), mapID)
+		if err != nil {
+			return
+		} else {
+			for {
+				iterValue := utils.ConntrackVal{}
+				err = goebpfmaps.GetMapEntryByID(uintptr(unsafe.Pointer(&iterKey)), uintptr(unsafe.Pointer(&iterValue)), mapID)
+				if err != nil {
+					if errors.Is(err, unix.ENOENT) {
+						err = nil
+						break
+					}
+					return
+				} else {
 
-	}
-
-	//Check if the entry is expired..
-	iterKey := utils.ConntrackKey{}
-	iterNextKey := utils.ConntrackKey{}
-	expiredList := make(map[utils.ConntrackKey]bool)
-	err = goebpfmaps.GetFirstMapEntryByID(uintptr(unsafe.Pointer(&iterKey)), mapID)
-	if err != nil {
-		return
-	} else {
-		for {
-			iterValue := utils.ConntrackVal{}
-			err = goebpfmaps.GetMapEntryByID(uintptr(unsafe.Pointer(&iterKey)), uintptr(unsafe.Pointer(&iterValue)), mapID)
-			if err != nil {
+					newKey := utils.ConntrackKey{}
+					newKey.Source_ip = iterKey.Source_ip
+					newKey.Source_port = iterKey.Source_port
+					newKey.Dest_ip = iterKey.Dest_ip
+					newKey.Dest_port = iterKey.Dest_port
+					newKey.Protocol = iterKey.Protocol
+					newKey.Owner_ip = iterKey.Owner_ip
+					c.localConntrackV4Cache[newKey] = true
+				}
+				err = goebpfmaps.GetNextMapEntryByID(uintptr(unsafe.Pointer(&iterKey)), uintptr(unsafe.Pointer(&iterNextKey)), mapID)
 				if errors.Is(err, unix.ENOENT) {
 					err = nil
 					break
 				}
-				return
-			} else {
-
-				newKey := utils.ConntrackKey{}
-				newKey.Source_ip = utils.ConvIPv4ToInt(utils.ConvIntToIPv4(iterKey.Source_ip))
-				newKey.Source_port = iterKey.Source_port
-				newKey.Dest_ip = utils.ConvIPv4ToInt(utils.ConvIntToIPv4(iterKey.Dest_ip))
-				newKey.Dest_port = iterKey.Dest_port
-				newKey.Protocol = iterKey.Protocol
-				newKey.Owner_ip = utils.ConvIPv4ToInt(utils.ConvIntToIPv4(iterKey.Owner_ip))
-
-				_, ok := localConntrackCache[newKey]
-				if !ok {
-					//Delete the entry in local cache
-					retrievedKey := fmt.Sprintf("Expired/Delete Conntrack Key : Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d Owner IP - %s", utils.ConvIntToIPv4(iterKey.Source_ip).String(), iterKey.Source_port, utils.ConvIntToIPv4(iterKey.Dest_ip).String(), iterKey.Dest_port, iterKey.Protocol, utils.ConvIntToIPv4(iterKey.Owner_ip).String())
-					c.logger.Info("Conntrack cleanup", "Entry - ", retrievedKey)
-
-					// Copy from iterKey since we will replace the value
-					nKey := utils.ConntrackKey{}
-					nKey.Source_ip = iterKey.Source_ip
-					nKey.Source_port = iterKey.Source_port
-					nKey.Dest_ip = iterKey.Dest_ip
-					nKey.Dest_port = iterKey.Dest_port
-					nKey.Protocol = iterKey.Protocol
-					nKey.Owner_ip = iterKey.Owner_ip
-					expiredList[nKey] = true
+				if err != nil {
+					break
 				}
 
+				iterKey = iterNextKey
 			}
-			err = goebpfmaps.GetNextMapEntryByID(uintptr(unsafe.Pointer(&iterKey)), uintptr(unsafe.Pointer(&iterNextKey)), mapID)
-			if errors.Is(err, unix.ENOENT) {
-				err = nil
-				break
-			}
-			if err != nil {
-				break
-			}
-
-			iterKey = iterNextKey
 		}
-	}
+		c.logger.Info("hydrated local conntrack cache")
+		c.hydratelocalConntrack = false
+	} else {
+		// Conntrack table is already hydrated from previous run
+		// So read from kernel conntrack table
+		conntrackFlows, err := netlink.ConntrackTableList(netlink.ConntrackTable, unix.AF_INET)
+		if err != nil {
+			c.logger.Info("Failed to read from conntrack table")
+			return
+		}
+		kernelConntrackV4Cache := make(map[utils.ConntrackKey]bool)
+		// Build kernel conntrack cache
+		for _, conntrackFlow := range conntrackFlows {
+			//Check fwd flow with SIP as owner
+			fwdFlowWithSIP := utils.ConntrackKey{}
+			fwdFlowWithSIP.Source_ip = utils.ConvIPv4ToInt(conntrackFlow.Forward.SrcIP)
+			fwdFlowWithSIP.Source_port = conntrackFlow.Forward.SrcPort
+			fwdFlowWithSIP.Dest_ip = utils.ConvIPv4ToInt(conntrackFlow.Forward.DstIP)
+			fwdFlowWithSIP.Dest_port = conntrackFlow.Forward.DstPort
+			fwdFlowWithSIP.Protocol = conntrackFlow.Forward.Protocol
+			fwdFlowWithSIP.Owner_ip = fwdFlowWithSIP.Source_ip
 
-	//Delete entries in conntrack table
-	//TODO use bulk delete
-	for expiredFlow, _ := range expiredList {
-		key := fmt.Sprintf("Conntrack Key : Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d Owner IP - %s", utils.ConvIntToIPv4(expiredFlow.Source_ip).String(), expiredFlow.Source_port, utils.ConvIntToIPv4(expiredFlow.Dest_ip).String(), expiredFlow.Dest_port, expiredFlow.Protocol, utils.ConvIntToIPv4(expiredFlow.Owner_ip).String())
-		c.logger.Info("Conntrack cleanup", "Delete - ", key)
-		c.conntrackMap.DeleteMapEntry(uintptr(unsafe.Pointer(&expiredFlow)))
-	}
+			kernelConntrackV4Cache[fwdFlowWithSIP] = true
 
-	c.logger.Info("Done cleanup of conntrack map")
+			//Check fwd flow with DIP as owner
+			fwdFlowWithDIP := utils.ConntrackKey{}
+			fwdFlowWithDIP.Source_ip = utils.ConvIPv4ToInt(conntrackFlow.Forward.SrcIP)
+			fwdFlowWithDIP.Source_port = conntrackFlow.Forward.SrcPort
+			fwdFlowWithDIP.Dest_ip = utils.ConvIPv4ToInt(conntrackFlow.Forward.DstIP)
+			fwdFlowWithDIP.Dest_port = conntrackFlow.Forward.DstPort
+			fwdFlowWithDIP.Protocol = conntrackFlow.Forward.Protocol
+			fwdFlowWithDIP.Owner_ip = fwdFlowWithDIP.Dest_ip
+
+			kernelConntrackV4Cache[fwdFlowWithDIP] = true
+
+			//Dest can be VIP and pods can be on same node
+			destIP := net.ParseIP(conntrackFlow.Forward.DstIP.String())
+			revDestIP := net.ParseIP(conntrackFlow.Reverse.SrcIP.String())
+
+			if !destIP.Equal(revDestIP) {
+				//Check fwd flow with SIP as owner
+				revFlowWithSIP := utils.ConntrackKey{}
+				revFlowWithSIP.Source_ip = utils.ConvIPv4ToInt(conntrackFlow.Forward.SrcIP)
+				revFlowWithSIP.Source_port = conntrackFlow.Forward.SrcPort
+				revFlowWithSIP.Dest_ip = utils.ConvIPv4ToInt(conntrackFlow.Reverse.SrcIP)
+				revFlowWithSIP.Dest_port = conntrackFlow.Reverse.SrcPort
+				revFlowWithSIP.Protocol = conntrackFlow.Forward.Protocol
+				revFlowWithSIP.Owner_ip = revFlowWithSIP.Source_ip
+
+				kernelConntrackV4Cache[revFlowWithSIP] = true
+
+				//Check fwd flow with DIP as owner
+				revFlowWithDIP := utils.ConntrackKey{}
+				revFlowWithDIP.Source_ip = utils.ConvIPv4ToInt(conntrackFlow.Forward.SrcIP)
+				revFlowWithDIP.Source_port = conntrackFlow.Forward.SrcPort
+				revFlowWithDIP.Dest_ip = utils.ConvIPv4ToInt(conntrackFlow.Reverse.SrcIP)
+				revFlowWithDIP.Dest_port = conntrackFlow.Reverse.SrcPort
+				revFlowWithDIP.Protocol = conntrackFlow.Forward.Protocol
+				revFlowWithDIP.Owner_ip = revFlowWithDIP.Dest_ip
+
+				kernelConntrackV4Cache[revFlowWithDIP] = true
+			}
+		}
+		// Check if the local cache and kernel cache is in sync
+		for localConntrackEntry, _ := range c.localConntrackV4Cache {
+			newKey := utils.ConntrackKey{}
+			newKey.Source_ip = utils.ConvIPv4ToInt(utils.ConvIntToIPv4(localConntrackEntry.Source_ip))
+			newKey.Source_port = localConntrackEntry.Source_port
+			newKey.Dest_ip = utils.ConvIPv4ToInt(utils.ConvIntToIPv4(localConntrackEntry.Dest_ip))
+			newKey.Dest_port = localConntrackEntry.Dest_port
+			newKey.Protocol = localConntrackEntry.Protocol
+			newKey.Owner_ip = utils.ConvIPv4ToInt(utils.ConvIntToIPv4(localConntrackEntry.Owner_ip))
+			_, ok := kernelConntrackV4Cache[newKey]
+			if !ok {
+				// Delete the entry in local cache since kernel entry is still missing so expired case
+				expiredFlow := localConntrackEntry
+				key := fmt.Sprintf("Conntrack Key : Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d Owner IP - %s", utils.ConvIntToIPv4(expiredFlow.Source_ip).String(), expiredFlow.Source_port, utils.ConvIntToIPv4(expiredFlow.Dest_ip).String(), expiredFlow.Dest_port, expiredFlow.Protocol, utils.ConvIntToIPv4(expiredFlow.Owner_ip).String())
+				c.logger.Info("Conntrack cleanup", "Delete - ", key)
+				c.conntrackMap.DeleteMapEntry(uintptr(unsafe.Pointer(&expiredFlow)))
+
+			}
+		}
+		//c.localConntrackV4Cache = make(map[utils.ConntrackKey]bool)
+		c.logger.Info("Done cleanup of conntrack map")
+		c.hydratelocalConntrack = true
+	}
 	return
 }
 
@@ -190,140 +197,147 @@ func (c *conntrackClient) Cleanupv6ConntrackMap() {
 	}
 	mapID := int(mapInfo.Id)
 
-	//Read from kernel conntrack table
-	conntrackFlows, err := netlink.ConntrackTableList(netlink.ConntrackTable, unix.AF_INET6)
-	if err != nil {
-		c.logger.Info("Failed to read from conntrack table")
-		return
-	}
-
-	localConntrackCache := make(map[utils.ConntrackKeyV6]bool)
-	// Build local conntrack cache
-	for _, conntrackFlow := range conntrackFlows {
-		//Check fwd flow with SIP as owner
-		fwdFlowWithSIP := utils.ConntrackKeyV6{}
-		sip := utils.ConvIPv6ToByte(conntrackFlow.Forward.SrcIP)
-		copy(fwdFlowWithSIP.Source_ip[:], sip)
-		fwdFlowWithSIP.Source_port = conntrackFlow.Forward.SrcPort
-		dip := utils.ConvIPv6ToByte(conntrackFlow.Forward.DstIP)
-		copy(fwdFlowWithSIP.Dest_ip[:], dip)
-		fwdFlowWithSIP.Dest_port = conntrackFlow.Forward.DstPort
-		fwdFlowWithSIP.Protocol = conntrackFlow.Forward.Protocol
-		copy(fwdFlowWithSIP.Owner_ip[:], sip)
-
-		localConntrackCache[fwdFlowWithSIP] = true
-
-		//Check fwd flow with DIP as owner
-		fwdFlowWithDIP := utils.ConntrackKeyV6{}
-		sip = utils.ConvIPv6ToByte(conntrackFlow.Forward.SrcIP)
-		copy(fwdFlowWithDIP.Source_ip[:], sip)
-		fwdFlowWithDIP.Source_port = conntrackFlow.Forward.SrcPort
-		dip = utils.ConvIPv6ToByte(conntrackFlow.Forward.DstIP)
-		copy(fwdFlowWithDIP.Dest_ip[:], dip)
-		fwdFlowWithDIP.Dest_port = conntrackFlow.Forward.DstPort
-		fwdFlowWithDIP.Protocol = conntrackFlow.Forward.Protocol
-		copy(fwdFlowWithDIP.Owner_ip[:], dip)
-
-		localConntrackCache[fwdFlowWithDIP] = true
-
-		//Dest can be VIP and pods can be on same node
-		destIP := net.ParseIP(conntrackFlow.Forward.DstIP.String())
-		revDestIP := net.ParseIP(conntrackFlow.Reverse.SrcIP.String())
-
-		if !destIP.Equal(revDestIP) {
-			//Check fwd flow with SIP as owner
-			revFlowWithSIP := utils.ConntrackKeyV6{}
-			sip = utils.ConvIPv6ToByte(conntrackFlow.Forward.SrcIP)
-			copy(revFlowWithSIP.Source_ip[:], sip)
-			revFlowWithSIP.Source_port = conntrackFlow.Forward.SrcPort
-			dip = utils.ConvIPv6ToByte(conntrackFlow.Reverse.SrcIP)
-			copy(revFlowWithSIP.Dest_ip[:], dip)
-			revFlowWithSIP.Dest_port = conntrackFlow.Reverse.SrcPort
-			revFlowWithSIP.Protocol = conntrackFlow.Forward.Protocol
-			copy(revFlowWithSIP.Owner_ip[:], sip)
-
-			localConntrackCache[revFlowWithSIP] = true
-
-			//Check fwd flow with DIP as owner
-			revFlowWithDIP := utils.ConntrackKeyV6{}
-			sip = utils.ConvIPv6ToByte(conntrackFlow.Forward.SrcIP)
-			copy(revFlowWithDIP.Source_ip[:], sip)
-			revFlowWithDIP.Source_port = conntrackFlow.Forward.SrcPort
-			dip = utils.ConvIPv6ToByte(conntrackFlow.Reverse.SrcIP)
-			copy(revFlowWithDIP.Dest_ip[:], dip)
-			revFlowWithDIP.Dest_port = conntrackFlow.Reverse.SrcPort
-			revFlowWithDIP.Protocol = conntrackFlow.Forward.Protocol
-			copy(revFlowWithDIP.Owner_ip[:], dip)
-
-			localConntrackCache[revFlowWithDIP] = true
+	// Read from eBPF Table if local conntrack table is not cached
+	if c.hydratelocalConntrack {
+		//Lets cleanup all entries in cache
+		for conntrackKey := range c.localConntrackV6Cache {
+			delete(c.localConntrackV6Cache, conntrackKey)
 		}
+		iterKey := utils.ConntrackKeyV6{}
+		iterNextKey := utils.ConntrackKeyV6{}
 
-	}
+		byteSlice := utils.ConvConntrackV6ToByte(iterKey)
+		nextbyteSlice := utils.ConvConntrackV6ToByte(iterNextKey)
 
-	//Check if the entry is expired..
-	iterKey := utils.ConntrackKeyV6{}
-	iterNextKey := utils.ConntrackKeyV6{}
+		err = goebpfmaps.GetFirstMapEntryByID(uintptr(unsafe.Pointer(&byteSlice[0])), mapID)
+		if err != nil {
+			return
+		} else {
+			for {
+				iterValue := utils.ConntrackVal{}
+				err = goebpfmaps.GetMapEntryByID(uintptr(unsafe.Pointer(&byteSlice[0])), uintptr(unsafe.Pointer(&iterValue)), mapID)
+				if err != nil {
+					if errors.Is(err, unix.ENOENT) {
+						err = nil
+						break
+					}
+					return
+				} else {
+					newKey := utils.ConntrackKeyV6{}
+					connKey := utils.ConvByteToConntrackV6(byteSlice)
 
-	expiredList := make(map[utils.ConntrackKeyV6]bool)
-	byteSlice := utils.ConvConntrackV6ToByte(iterKey)
-	nextbyteSlice := utils.ConvConntrackV6ToByte(iterNextKey)
+					utils.CopyV6Bytes(&newKey.Source_ip, connKey.Source_ip)
+					utils.CopyV6Bytes(&newKey.Dest_ip, connKey.Dest_ip)
 
-	err = goebpfmaps.GetFirstMapEntryByID(uintptr(unsafe.Pointer(&byteSlice[0])), mapID)
-	if err != nil {
-		return
-	} else {
-		for {
-			iterValue := utils.ConntrackVal{}
-			err = goebpfmaps.GetMapEntryByID(uintptr(unsafe.Pointer(&byteSlice[0])), uintptr(unsafe.Pointer(&iterValue)), mapID)
-			if err != nil {
+					newKey.Source_port = connKey.Source_port
+					newKey.Dest_port = connKey.Dest_port
+					newKey.Protocol = connKey.Protocol
+
+					utils.CopyV6Bytes(&newKey.Owner_ip, connKey.Owner_ip)
+					c.localConntrackV6Cache[newKey] = true
+				}
+				err = goebpfmaps.GetNextMapEntryByID(uintptr(unsafe.Pointer(&byteSlice[0])), uintptr(unsafe.Pointer(&nextbyteSlice[0])), mapID)
 				if errors.Is(err, unix.ENOENT) {
 					err = nil
 					break
 				}
-				return
-			} else {
-				newKey := utils.ConntrackKeyV6{}
-				connKey := utils.ConvByteToConntrackV6(byteSlice)
-
-				utils.CopyV6Bytes(&newKey.Source_ip, connKey.Source_ip)
-				utils.CopyV6Bytes(&newKey.Dest_ip, connKey.Dest_ip)
-
-				newKey.Source_port = connKey.Source_port
-				newKey.Dest_port = connKey.Dest_port
-				newKey.Protocol = connKey.Protocol
-
-				utils.CopyV6Bytes(&newKey.Owner_ip, connKey.Owner_ip)
-				_, ok := localConntrackCache[newKey]
-				if !ok {
-					//Delete the entry in local cache
-					retrievedKey := fmt.Sprintf("Expired/Delete Conntrack Key : Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d Owner IP - %s", utils.ConvByteToIPv6(newKey.Source_ip).String(), newKey.Source_port, utils.ConvByteToIPv6(newKey.Dest_ip).String(), newKey.Dest_port, newKey.Protocol, utils.ConvByteToIPv6(newKey.Owner_ip).String())
-					c.logger.Info("Conntrack cleanup", "Entry - ", retrievedKey)
-					expiredList[newKey] = true
+				if err != nil {
+					break
 				}
+				copy(byteSlice, nextbyteSlice)
 			}
-			err = goebpfmaps.GetNextMapEntryByID(uintptr(unsafe.Pointer(&byteSlice[0])), uintptr(unsafe.Pointer(&nextbyteSlice[0])), mapID)
-			if errors.Is(err, unix.ENOENT) {
-				err = nil
-				break
-			}
-			if err != nil {
-				break
-			}
-			copy(byteSlice, nextbyteSlice)
 		}
-	}
+		c.logger.Info("hydrated local conntrack cache")
+		c.hydratelocalConntrack = false
+	} else {
+		// Conntrack table is already hydrated from previous run
+		// So read from kernel conntrack table
+		conntrackFlows, err := netlink.ConntrackTableList(netlink.ConntrackTable, unix.AF_INET6)
+		if err != nil {
+			c.logger.Info("Failed to read from conntrack table")
+			return
+		}
 
-	//Delete entries in conntrack table
-	//TODO use bulk delete
-	for expiredFlow, _ := range expiredList {
-		key := fmt.Sprintf("Conntrack Key : Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d Owner IP - %s", utils.ConvByteToIPv6(expiredFlow.Source_ip).String(), expiredFlow.Source_port, utils.ConvByteToIPv6(expiredFlow.Dest_ip).String(), expiredFlow.Dest_port, expiredFlow.Protocol, utils.ConvByteToIPv6(expiredFlow.Owner_ip).String())
-		c.logger.Info("Conntrack cleanup", "Delete - ", key)
-		ceByteSlice := utils.ConvConntrackV6ToByte(expiredFlow)
-		c.printByteArray(ceByteSlice)
-		c.conntrackMap.DeleteMapEntry(uintptr(unsafe.Pointer(&ceByteSlice[0])))
-	}
+		kernelConntrackV6Cache := make(map[utils.ConntrackKeyV6]bool)
+		// Build local conntrack cache
+		for _, conntrackFlow := range conntrackFlows {
+			//Check fwd flow with SIP as owner
+			fwdFlowWithSIP := utils.ConntrackKeyV6{}
+			sip := utils.ConvIPv6ToByte(conntrackFlow.Forward.SrcIP)
+			copy(fwdFlowWithSIP.Source_ip[:], sip)
+			fwdFlowWithSIP.Source_port = conntrackFlow.Forward.SrcPort
+			dip := utils.ConvIPv6ToByte(conntrackFlow.Forward.DstIP)
+			copy(fwdFlowWithSIP.Dest_ip[:], dip)
+			fwdFlowWithSIP.Dest_port = conntrackFlow.Forward.DstPort
+			fwdFlowWithSIP.Protocol = conntrackFlow.Forward.Protocol
+			copy(fwdFlowWithSIP.Owner_ip[:], sip)
 
-	c.logger.Info("Done cleanup of conntrack map")
+			kernelConntrackV6Cache[fwdFlowWithSIP] = true
+
+			//Check fwd flow with DIP as owner
+			fwdFlowWithDIP := utils.ConntrackKeyV6{}
+			sip = utils.ConvIPv6ToByte(conntrackFlow.Forward.SrcIP)
+			copy(fwdFlowWithDIP.Source_ip[:], sip)
+			fwdFlowWithDIP.Source_port = conntrackFlow.Forward.SrcPort
+			dip = utils.ConvIPv6ToByte(conntrackFlow.Forward.DstIP)
+			copy(fwdFlowWithDIP.Dest_ip[:], dip)
+			fwdFlowWithDIP.Dest_port = conntrackFlow.Forward.DstPort
+			fwdFlowWithDIP.Protocol = conntrackFlow.Forward.Protocol
+			copy(fwdFlowWithDIP.Owner_ip[:], dip)
+
+			kernelConntrackV6Cache[fwdFlowWithDIP] = true
+
+			//Dest can be VIP and pods can be on same node
+			destIP := net.ParseIP(conntrackFlow.Forward.DstIP.String())
+			revDestIP := net.ParseIP(conntrackFlow.Reverse.SrcIP.String())
+
+			if !destIP.Equal(revDestIP) {
+				//Check fwd flow with SIP as owner
+				revFlowWithSIP := utils.ConntrackKeyV6{}
+				sip = utils.ConvIPv6ToByte(conntrackFlow.Forward.SrcIP)
+				copy(revFlowWithSIP.Source_ip[:], sip)
+				revFlowWithSIP.Source_port = conntrackFlow.Forward.SrcPort
+				dip = utils.ConvIPv6ToByte(conntrackFlow.Reverse.SrcIP)
+				copy(revFlowWithSIP.Dest_ip[:], dip)
+				revFlowWithSIP.Dest_port = conntrackFlow.Reverse.SrcPort
+				revFlowWithSIP.Protocol = conntrackFlow.Forward.Protocol
+				copy(revFlowWithSIP.Owner_ip[:], sip)
+
+				kernelConntrackV6Cache[revFlowWithSIP] = true
+
+				//Check fwd flow with DIP as owner
+				revFlowWithDIP := utils.ConntrackKeyV6{}
+				sip = utils.ConvIPv6ToByte(conntrackFlow.Forward.SrcIP)
+				copy(revFlowWithDIP.Source_ip[:], sip)
+				revFlowWithDIP.Source_port = conntrackFlow.Forward.SrcPort
+				dip = utils.ConvIPv6ToByte(conntrackFlow.Reverse.SrcIP)
+				copy(revFlowWithDIP.Dest_ip[:], dip)
+				revFlowWithDIP.Dest_port = conntrackFlow.Reverse.SrcPort
+				revFlowWithDIP.Protocol = conntrackFlow.Forward.Protocol
+				copy(revFlowWithDIP.Owner_ip[:], dip)
+
+				kernelConntrackV6Cache[revFlowWithDIP] = true
+			}
+
+		}
+		// Check if the local cache and kernel cache is in sync
+		for localConntrackEntry, _ := range c.localConntrackV6Cache {
+			_, ok := kernelConntrackV6Cache[localConntrackEntry]
+			if !ok {
+				// Delete the entry in local cache since kernel entry is still missing so expired case
+				expiredFlow := localConntrackEntry
+				key := fmt.Sprintf("Conntrack Key : Source IP - %s Source port - %d Dest IP - %s Dest port - %d Protocol - %d Owner IP - %s", utils.ConvByteToIPv6(expiredFlow.Source_ip).String(), expiredFlow.Source_port, utils.ConvByteToIPv6(expiredFlow.Dest_ip).String(), expiredFlow.Dest_port, expiredFlow.Protocol, utils.ConvByteToIPv6(expiredFlow.Owner_ip).String())
+				c.logger.Info("Conntrack cleanup", "Delete - ", key)
+				ceByteSlice := utils.ConvConntrackV6ToByte(expiredFlow)
+				c.printByteArray(ceByteSlice)
+				c.conntrackMap.DeleteMapEntry(uintptr(unsafe.Pointer(&ceByteSlice[0])))
+			}
+		}
+		//Lets cleanup all entries in cache
+		c.localConntrackV6Cache = make(map[utils.ConntrackKeyV6]bool)
+		c.logger.Info("Done cleanup of conntrack map")
+		c.hydratelocalConntrack = true
+	}
 	return
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
During the conntrack cleanup loop, we need to first hydrate the local cache and then in the next loop we check with kernel conntrack to make sure the entry in kernel is available..this is for cases when egress traffic entry is made in local conntrack table but not yet preset in the kernel contrack table when the cleanup routine runs...

```
{"level":"info","ts":"2024-04-24T05:57:52.764Z","logger":"ebpf-client","caller":"wait/backoff.go:227","msg":"Check for any stale entries in the conntrack map"}
{"level":"info","ts":"2024-04-24T05:57:52.765Z","logger":"ebpf-client","caller":"wait/backoff.go:227","msg":"hydrated local conntrack cache"}


{"level":"info","ts":"2024-04-24T05:59:32.766Z","logger":"ebpf-client","caller":"wait/backoff.go:227","msg":"Check for any stale entries in the conntrack map"}
{"level":"info","ts":"2024-04-24T05:59:32.768Z","logger":"ebpf-client","caller":"wait/backoff.go:227","msg":"Done cleanup of conntrack map"}


{"level":"info","ts":"2024-04-24T06:01:12.768Z","logger":"ebpf-client","caller":"wait/backoff.go:227","msg":"Check for any stale entries in the conntrack map"}
{"level":"info","ts":"2024-04-24T06:01:12.769Z","logger":"ebpf-client","caller":"wait/backoff.go:227","msg":"hydrated local conntrack cache"}


{"level":"info","ts":"2024-04-24T06:02:52.769Z","logger":"ebpf-client","caller":"wait/backoff.go:227","msg":"Check for any stale entries in the conntrack map"}
{"level":"info","ts":"2024-04-24T06:02:52.771Z","logger":"ebpf-client","caller":"wait/backoff.go:227","msg":"Conntrack cleanup","Delete - ":"Conntrack Key : Source IP - 192.168.44.201 Source port - 40370 Dest IP - 192.168.52.173 Dest port - 8080 Protocol - 6 Owner IP - 192.168.52.173"}
{"level":"info","ts":"2024-04-24T06:02:52.771Z","logger":"ebpf-client","caller":"wait/backoff.go:227","msg":"Conntrack cleanup","Delete - ":"Conntrack Key : Source IP - 192.168.51.250 Source port - 34880 Dest IP - 192.168.52.173 Dest port - 8080 Protocol - 6 Owner IP - 192.168.52.173"}
{"level":"info","ts":"2024-04-24T06:02:52.771Z","logger":"ebpf-client","caller":"wait/backoff.go:227","msg":"Done cleanup of conntrack map"}
```

```
[root@ip-192-168-50-132 ~]# /opt/cni/bin/aws-eks-na-cli ebpf dump-maps 9
Conntrack Key : Source IP - 192.168.44.201 Source port - 40370 Dest IP - 192.168.52.173 Dest port - 8080 Protocol - 6 Owner IP - 192.168.52.173
Value : 
Conntrack Val -  1
*******************************
Conntrack Key : Source IP - 192.168.51.250 Source port - 34880 Dest IP - 192.168.52.173 Dest port - 8080 Protocol - 6 Owner IP - 192.168.52.173
Value : 
Conntrack Val -  1
*******************************
Done reading all entries

[root@ip-192-168-50-132 ~]# /opt/cni/bin/aws-eks-na-cli ebpf dump-maps 9
No Entries found, Empty map
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
