### PR TITLE
adding drop bytes and drop packets count metric

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/pkg/ebpf/c/tc.v4egress.bpf.c
+++ b/pkg/ebpf/c/tc.v4egress.bpf.c
@@ -66,6 +66,8 @@ struct data_t {
 	__u32  dest_port;
 	__u32  protocol;
 	__u32  verdict;
+	__u32 packet_sz;
+	__u8 is_egress;
 };
 
 struct bpf_map_def_pvt SEC("maps") egress_map = {

--- a/pkg/ebpf/c/tc.v4egress.bpf.c
+++ b/pkg/ebpf/c/tc.v4egress.bpf.c
@@ -218,7 +218,8 @@ int handle_egress(struct __sk_buff *skb)
 		evt.dest_ip = flow_key.dest_ip;
 		evt.dest_port = flow_key.dest_port;
 		evt.protocol = flow_key.protocol;
-
+		evt.is_egress = 1;
+		evt.packet_sz = skb->len; 
 		__u32 key = 0; 
 		struct pod_state *pst = bpf_map_lookup_elem(&egress_pod_state_map, &key);
 		// There should always be an entry in pod_state_map. pst returned in above line should never be null.

--- a/pkg/ebpf/c/tc.v4ingress.bpf.c
+++ b/pkg/ebpf/c/tc.v4ingress.bpf.c
@@ -217,6 +217,8 @@ int handle_ingress(struct __sk_buff *skb)
 		evt.dest_ip = flow_key.dest_ip;
 		evt.dest_port = flow_key.dest_port;
 		evt.protocol = flow_key.protocol;
+		evt.packet_sz = skb->len
+		evt.is_egress = 0
 
 		__u32 key = 0; 
 		struct pod_state *pst = bpf_map_lookup_elem(&ingress_pod_state_map, &key);

--- a/pkg/ebpf/c/tc.v4ingress.bpf.c
+++ b/pkg/ebpf/c/tc.v4ingress.bpf.c
@@ -66,6 +66,8 @@ struct data_t {
 	__u32  dest_port;
 	__u32  protocol;
 	__u32  verdict;
+	__u32 packet_sz;
+	__u8 is_egress;
 };
 
 struct bpf_map_def_pvt SEC("maps") ingress_map = {
@@ -217,8 +219,8 @@ int handle_ingress(struct __sk_buff *skb)
 		evt.dest_ip = flow_key.dest_ip;
 		evt.dest_port = flow_key.dest_port;
 		evt.protocol = flow_key.protocol;
-		evt.packet_sz = skb->len
-		evt.is_egress = 0
+		evt.packet_sz = skb->len;
+		evt.is_egress = 0;
 
 		__u32 key = 0; 
 		struct pod_state *pst = bpf_map_lookup_elem(&ingress_pod_state_map, &key);

--- a/pkg/ebpf/c/tc.v6egress.bpf.c
+++ b/pkg/ebpf/c/tc.v6egress.bpf.c
@@ -217,19 +217,13 @@ int handle_egress(struct __sk_buff *skb)
 		flow_key.protocol = ip->nexthdr;
 		flow_key.owner_addr = ip->saddr;
 
-	//Check if it's an existing flow
-	flow_val = (struct conntrack_value *)bpf_map_lookup_elem(&aws_conntrack_map, &flow_key);
-	if (flow_val != NULL) { 
-		return BPF_OK;	
-	}
-
-	evt.src_ip = ip->saddr;
-	evt.dest_ip = ip->daddr;	
-	evt.src_port = flow_key.src_port;
-	evt.dest_port = flow_key.dest_port;
-	evt.protocol = flow_key.protocol;
-	evt.is_egress = 1;
-	evt.packet_sz = skb->len;
+		evt.src_ip = ip->saddr;
+		evt.dest_ip = ip->daddr;	
+		evt.src_port = flow_key.src_port;
+		evt.dest_port = flow_key.dest_port;
+		evt.protocol = flow_key.protocol;
+		evt.is_egress = 1;
+		evt.packet_sz = skb->len;
 
 		__u32 key = 0; 
 		struct pod_state *pst = bpf_map_lookup_elem(&egress_pod_state_map, &key);

--- a/pkg/ebpf/c/tc.v6egress.bpf.c
+++ b/pkg/ebpf/c/tc.v6egress.bpf.c
@@ -223,13 +223,13 @@ int handle_egress(struct __sk_buff *skb)
 		return BPF_OK;	
 	}
 
-		evt.src_ip = ip->saddr;
-		evt.dest_ip = ip->daddr;	
-		evt.src_port = flow_key.src_port;
-		evt.dest_port = flow_key.dest_port;
-		evt.protocol = flow_key.protocol;
-			evt.is_egress = 1;
-	evt.packet_sz = skb->len
+	evt.src_ip = ip->saddr;
+	evt.dest_ip = ip->daddr;	
+	evt.src_port = flow_key.src_port;
+	evt.dest_port = flow_key.dest_port;
+	evt.protocol = flow_key.protocol;
+	evt.is_egress = 1;
+	evt.packet_sz = skb->len;
 
 		__u32 key = 0; 
 		struct pod_state *pst = bpf_map_lookup_elem(&egress_pod_state_map, &key);

--- a/pkg/ebpf/c/tc.v6ingress.bpf.c
+++ b/pkg/ebpf/c/tc.v6ingress.bpf.c
@@ -69,6 +69,8 @@ struct data_t {
 	__u32  dest_port;
 	__u32  protocol;
 	__u32  verdict;
+	__u32 packet_sz;
+	__u8 is_egress;
 };
 
 struct bpf_map_def_pvt SEC("maps") ingress_map = {
@@ -220,6 +222,8 @@ int handle_ingress(struct __sk_buff *skb)
 		evt.src_port = flow_key.src_port;
 		evt.dest_port = flow_key.dest_port;
 		evt.protocol = flow_key.protocol;
+		evt.packet_sz = skb->len;
+		evt.is_egress = 0;
 
 		__u32 key = 0; 
 		struct pod_state *pst = bpf_map_lookup_elem(&ingress_pod_state_map, &key);

--- a/pkg/ebpf/c/v4events.bpf.c
+++ b/pkg/ebpf/c/v4events.bpf.c
@@ -23,6 +23,8 @@ struct data_t {
     __u32  dest_port;
     __u32  protocol;
     __u32  verdict;
+    __64 packet_sz;
+    __u8 is_egress;
 };
 
 struct conntrack_key {

--- a/pkg/ebpf/c/v4events.bpf.c
+++ b/pkg/ebpf/c/v4events.bpf.c
@@ -23,7 +23,7 @@ struct data_t {
     __u32  dest_port;
     __u32  protocol;
     __u32  verdict;
-    __64 packet_sz;
+    __u32 packet_sz;
     __u8 is_egress;
 };
 

--- a/pkg/ebpf/c/v6events.bpf.c
+++ b/pkg/ebpf/c/v6events.bpf.c
@@ -25,7 +25,7 @@ struct data_t {
 	__u32  protocol;
 	__u32  verdict;
 	__u32 packet_sz;
-    __u8 is_egress;
+	__u8 is_egress;
 };
 
 struct conntrack_key {

--- a/pkg/ebpf/c/v6events.bpf.c
+++ b/pkg/ebpf/c/v6events.bpf.c
@@ -24,6 +24,8 @@ struct data_t {
 	__u32  dest_port;
 	__u32  protocol;
 	__u32  verdict;
+	__u32 packet_sz;
+    __u8 is_egress;
 };
 
 struct conntrack_key {

--- a/pkg/ebpf/events/events.go
+++ b/pkg/ebpf/events/events.go
@@ -32,6 +32,8 @@ var (
 	NON_EKS_CW_PATH     = "/aws/"
 )
 
+const VerdictDeny uint32 = 0
+
 var (
 	dropCountTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -200,7 +202,7 @@ func capturePolicyEvents(ringbufferdata <-chan []byte, log logr.Logger, enableCl
 
 				protocol := utils.GetProtocol(int(rb.Protocol))
 				verdict := getVerdict(int(rb.Verdict))
-				if rb.Verdict == uint32(0) {
+				if rb.Verdict == VerdictDeny {
 					if rb.IsEgress == 0 {
 						direction = "ingress"
 					}
@@ -221,7 +223,7 @@ func capturePolicyEvents(ringbufferdata <-chan []byte, log logr.Logger, enableCl
 				}
 				protocol := utils.GetProtocol(int(rb.Protocol))
 				verdict := getVerdict(int(rb.Verdict))
-				if rb.Verdict == uint32(0) {
+				if rb.Verdict == VerdictDeny {
 					if rb.IsEgress == 0 {
 						direction = "ingress"
 					}

--- a/pkg/ebpf/events/events.go
+++ b/pkg/ebpf/events/events.go
@@ -189,6 +189,7 @@ func capturePolicyEvents(ringbufferdata <-chan []byte, log logr.Logger, enableCl
 		for record := range ringbufferdata {
 			var logQueue []*cloudwatchlogs.InputLogEvent
 			var message string
+			direction := "egress"
 			if enableIPv6 {
 				var rb ringBufferDataV6_t
 				buf := bytes.NewBuffer(record)
@@ -200,7 +201,6 @@ func capturePolicyEvents(ringbufferdata <-chan []byte, log logr.Logger, enableCl
 				protocol := utils.GetProtocol(int(rb.Protocol))
 				verdict := getVerdict(int(rb.Verdict))
 				if rb.Verdict == uint32(0) {
-					direction := "egress"
 					if rb.IsEgress == 0 {
 						direction = "ingress"
 					}
@@ -209,7 +209,7 @@ func capturePolicyEvents(ringbufferdata <-chan []byte, log logr.Logger, enableCl
 				}
 				log.Info("Flow Info:  ", "Src IP", utils.ConvByteToIPv6(rb.SourceIP).String(), "Src Port", rb.SourcePort,
 					"Dest IP", utils.ConvByteToIPv6(rb.DestIP).String(), "Dest Port", rb.DestPort,
-					"Proto", protocol, "Verdict", verdict, "Packetlen", rb.PacketSz)
+					"Proto", protocol, "Verdict", verdict, "Direction", direction)
 
 				message = "Node: " + nodeName + ";" + "SIP: " + utils.ConvByteToIPv6(rb.SourceIP).String() + ";" + "SPORT: " + strconv.Itoa(int(rb.SourcePort)) + ";" + "DIP: " + utils.ConvByteToIPv6(rb.DestIP).String() + ";" + "DPORT: " + strconv.Itoa(int(rb.DestPort)) + ";" + "PROTOCOL: " + protocol + ";" + "PolicyVerdict: " + verdict
 			} else {
@@ -222,7 +222,6 @@ func capturePolicyEvents(ringbufferdata <-chan []byte, log logr.Logger, enableCl
 				protocol := utils.GetProtocol(int(rb.Protocol))
 				verdict := getVerdict(int(rb.Verdict))
 				if rb.Verdict == uint32(0) {
-					direction := "egress"
 					if rb.IsEgress == 0 {
 						direction = "ingress"
 					}
@@ -231,7 +230,7 @@ func capturePolicyEvents(ringbufferdata <-chan []byte, log logr.Logger, enableCl
 				}
 				log.Info("Flow Info:  ", "Src IP", utils.ConvByteArrayToIP(rb.SourceIP), "Src Port", rb.SourcePort,
 					"Dest IP", utils.ConvByteArrayToIP(rb.DestIP), "Dest Port", rb.DestPort,
-					"Proto", protocol, "Verdict", verdict, "Packetlen", rb.PacketSz)
+					"Proto", protocol, "Verdict", verdict, "Direction", direction)
 
 				message = "Node: " + nodeName + ";" + "SIP: " + utils.ConvByteArrayToIP(rb.SourceIP) + ";" + "SPORT: " + strconv.Itoa(int(rb.SourcePort)) + ";" + "DIP: " + utils.ConvByteArrayToIP(rb.DestIP) + ";" + "DPORT: " + strconv.Itoa(int(rb.DestPort)) + ";" + "PROTOCOL: " + protocol + ";" + "PolicyVerdict: " + verdict
 			}

--- a/pkg/ebpf/events/events.go
+++ b/pkg/ebpf/events/events.go
@@ -61,7 +61,7 @@ type ringBufferDataV4_t struct {
 	DestPort   uint32
 	Protocol   uint32
 	Verdict    uint32
-	PacketSz   uint64
+	PacketSz   uint32
 	IsEgress   uint8
 }
 
@@ -207,7 +207,7 @@ func capturePolicyEvents(ringbufferdata <-chan []byte, log logr.Logger, enableCl
 				var rb ringBufferDataV4_t
 				buf := bytes.NewBuffer(record)
 				if err := binary.Read(buf, binary.LittleEndian, &rb); err != nil {
-					log.Info("Failed to read from Ring buf", err)
+					log.Info("Failed to read from Ring buf", "error", err)
 					continue
 				}
 				protocol := utils.GetProtocol(int(rb.Protocol))
@@ -222,7 +222,7 @@ func capturePolicyEvents(ringbufferdata <-chan []byte, log logr.Logger, enableCl
 				}
 				log.Info("Flow Info:  ", "Src IP", utils.ConvByteArrayToIP(rb.SourceIP), "Src Port", rb.SourcePort,
 					"Dest IP", utils.ConvByteArrayToIP(rb.DestIP), "Dest Port", rb.DestPort,
-					"Proto", protocol, "Verdict", verdict)
+					"Proto", protocol, "Verdict", verdict, "Packetlen", rb.PacketSz)
 
 				message = "Node: " + nodeName + ";" + "SIP: " + utils.ConvByteArrayToIP(rb.SourceIP) + ";" + "SPORT: " + strconv.Itoa(int(rb.SourcePort)) + ";" + "DIP: " + utils.ConvByteArrayToIP(rb.DestIP) + ";" + "DPORT: " + strconv.Itoa(int(rb.DestPort)) + ";" + "PROTOCOL: " + protocol + ";" + "PolicyVerdict: " + verdict
 			}


### PR DESCRIPTION
*Issue #, if available:*

solves #229 
*Description of changes:*
This PR enhances the network policy agent by adding packet length and direction information to policy events. These additions enable the export of more detailed metrics, specifically:

1. Packet drop counts with direction
2. Packet drop bytes with direction


Sample Output of metrics:

We have prometheus port setup here [Code](https://github.com/aws/aws-network-policy-agent/blob/bae33b8d464d178a99e8102742de304d3abda3cd/pkg/metrics/metrics.go#L18.) Customer can use Prometheus or other tool to scrape metrics.
```
 curl localhost:61680/metrics

# HELP network_policy_drop_bytes_total Total number of bytes dropped by network policy agent
# TYPE network_policy_drop_bytes_total counter
network_policy_drop_bytes_total{direction="ingress"} 1.0665324e+07
# HELP network_policy_drop_count_total Total number of packets dropped by network policy agent
# TYPE network_policy_drop_count_total counter
network_policy_drop_count_total{direction="ingress"} 144126
```

### **Important Notes**

These metrics will only be measured if the --enable-policy-event-logs flag is set to true.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
