### PR TITLE
Add --ignore-loopback flag to exclude self-referential pod connections, updating cyclonus.

### DIFF
--- a/scripts/lib/tests.sh
+++ b/scripts/lib/tests.sh
@@ -23,11 +23,13 @@ spec:
       containers:
         - name: cyclonus
           imagePullPolicy: Always
-          image: ${CYCLONUS_IMAGE_REPOSITORY}/cyclonus:v0.5.4
+          image: ${CYCLONUS_IMAGE_REPOSITORY}/cyclonus:v0.5.6
           command:
             - ./cyclonus
             - generate
             - --retries=2
+            - --noisy=true
+            - --ignore-loopback=true
             ${IMAGE_REPOSITORY_PARAMETER}
 EOF
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR introduces the --ignore-loopback=true parameter to exclude test cases where a network policy blocks a pod's connection to itself. Our network policy agent attaches tc cls hooks on the host veth side, not on the container's loopback interface. Consequently, self-referential connection tests may fail, as they don't accurately reflect our agent's behavior.

This flag allows for more accurate testing by focusing on inter-pod and external communications, aligning test results with our network policy agent's actual capabilities. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
