### PR TITLE
Handle overlaps in except and allow CIDRs

### DIFF
--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -915,16 +915,15 @@ func (l *bpfClient) computeMapEntriesFromEndpointRules(firewallRules []EbpfFirew
 	for _, firewallRule := range firewallRules {
 		if firewallRule.Except != nil {
 			for _, exceptCidr := range firewallRule.Except {
-				exceptFirewall := EbpfFirewallRules{
-					IPCidr: exceptCidr,
-					Except: []v1alpha1.NetworkAddress{},
-					L4Info: []v1alpha1.Port{},
+				if _, ok := cidrsMap[string(exceptCidr)]; !ok {
+					exceptFirewall := EbpfFirewallRules{
+						IPCidr: exceptCidr,
+						Except: []v1alpha1.NetworkAddress{},
+						L4Info: []v1alpha1.Port{},
+					}
+					l.addDenyAllL4Entry(&exceptFirewall)
+					cidrsMap[string(exceptCidr)] = exceptFirewall
 				}
-				if existingFirewallRuleInfo, ok := cidrsMap[string(exceptCidr)]; ok {
-					exceptFirewall.L4Info = existingFirewallRuleInfo.L4Info
-				}
-				l.addDenyAllL4Entry(&exceptFirewall)
-				cidrsMap[string(exceptCidr)] = exceptFirewall
 				l.logger.Info("Parsed Except CIDR", "IP Key: ", string(exceptCidr))
 			}
 		}

--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -897,7 +897,6 @@ func (l *bpfClient) computeMapEntriesFromEndpointRules(firewallRules []EbpfFirew
 		}
 
 		if existingFirewallRuleInfo, ok := cidrsMap[string(firewallRule.IPCidr)]; ok {
-			l.logger.Info("[DEBUG] found existing entry appending")
 			firewallRule.L4Info = append(firewallRule.L4Info, existingFirewallRuleInfo.L4Info...)
 			firewallRule.Except = append(firewallRule.Except, existingFirewallRuleInfo.Except...)
 		} else {
@@ -906,7 +905,6 @@ func (l *bpfClient) computeMapEntriesFromEndpointRules(firewallRules []EbpfFirew
 			// we use LPM TRIE map and the /m will always win out.
 			cidrL4Info = l.checkAndDeriveL4InfoFromAnyMatchingCIDRs(string(firewallRule.IPCidr), cidrsMap)
 			if len(cidrL4Info) > 0 {
-				l.logger.Info("[DEBUG] found cidrl4info from cidr matching. appending")
 				firewallRule.L4Info = append(firewallRule.L4Info, cidrL4Info...)
 			}
 		}
@@ -923,12 +921,11 @@ func (l *bpfClient) computeMapEntriesFromEndpointRules(firewallRules []EbpfFirew
 					L4Info: []v1alpha1.Port{},
 				}
 				if existingFirewallRuleInfo, ok := cidrsMap[string(exceptCidr)]; ok {
-					l.logger.Info("[DEBUG] found existing entry appending")
 					exceptFirewall.L4Info = existingFirewallRuleInfo.L4Info
 				}
 				l.addDenyAllL4Entry(&exceptFirewall)
 				cidrsMap[string(exceptCidr)] = exceptFirewall
-				l.logger.Info("Updating map with Except CIDR", "IP Key: ", string(exceptCidr))
+				l.logger.Info("Parsed Except CIDR", "IP Key: ", string(exceptCidr))
 			}
 		}
 	}
@@ -961,9 +958,8 @@ func (l *bpfClient) checkAndDeriveL4InfoFromAnyMatchingCIDRs(firewallRule string
 			continue
 		}
 		_, cidrEntry, _ := net.ParseCIDR(cidr)
-		l.logger.Info("Checking CIDR match: ", "for IP: ", firewallRule, "in CIDR: ", cidr)
 		if cidrEntry.Contains(ipToCheck.IP) {
-			l.logger.Info("Found a CIDR match: ", "for IP: ", firewallRule, "in CIDR: ", cidr)
+			l.logger.Info("Found CIDR match: ", "for IP: ", firewallRule, "in CIDR: ", cidr)
 			// If CIDR contains IP, check if it is part of any except block under CIDR. If yes, do not include cidrL4Info
 			foundInExcept := false
 			for _, except := range cidrFirewallInfo.Except {

--- a/pkg/ebpf/c/tc.v4egress.bpf.c
+++ b/pkg/ebpf/c/tc.v4egress.bpf.c
@@ -201,7 +201,8 @@ int handle_egress(struct __sk_buff *skb)
 				return BPF_DROP;
 			}
 
-			if ((trie_val->protocol == ANY_IP_PROTOCOL) || (trie_val->protocol == ip->protocol &&
+			if ((trie_val->protocol == ANY_IP_PROTOCOL && ((trie_val->start_port == ANY_PORT) || (l4_dst_port == trie_val->start_port) ||
+						 (l4_dst_port > trie_val->start_port && l4_dst_port <= trie_val->end_port))) || (trie_val->protocol == ip->protocol &&
 						((trie_val->start_port == ANY_PORT) || (l4_dst_port == trie_val->start_port) ||
 						 (l4_dst_port > trie_val->start_port && l4_dst_port <= trie_val->end_port)))) {
 				//Inject in to conntrack map

--- a/pkg/ebpf/c/tc.v4ingress.bpf.c
+++ b/pkg/ebpf/c/tc.v4ingress.bpf.c
@@ -201,7 +201,9 @@ int handle_ingress(struct __sk_buff *skb)
 				return BPF_DROP;
 			}
 
-			if ((trie_val->protocol == ANY_IP_PROTOCOL) || (trie_val->protocol == ip->protocol &&
+			if ((trie_val->protocol == ANY_IP_PROTOCOL &&
+						((trie_val->start_port == ANY_PORT) || (l4_dst_port == trie_val->start_port) ||
+						 (l4_dst_port > trie_val->start_port && l4_dst_port <= trie_val->end_port))) || (trie_val->protocol == ip->protocol &&
 						((trie_val->start_port == ANY_PORT) || (l4_dst_port == trie_val->start_port) ||
 						 (l4_dst_port > trie_val->start_port && l4_dst_port <= trie_val->end_port)))) {
 				//Inject in to conntrack map

--- a/pkg/ebpf/c/tc.v6egress.bpf.c
+++ b/pkg/ebpf/c/tc.v6egress.bpf.c
@@ -193,7 +193,9 @@ int handle_egress(struct __sk_buff *skb)
 			return BPF_DROP;
 		}
 
-		if ((trie_val->protocol == ANY_IP_PROTOCOL) || (trie_val->protocol == ip->nexthdr &&
+		if ((trie_val->protocol == ANY_IP_PROTOCOL &&
+					((trie_val->start_port == ANY_PORT) || (l4_dst_port == trie_val->start_port) ||
+					(l4_dst_port > trie_val->start_port && l4_dst_port <= trie_val->end_port))) || (trie_val->protocol == ip->nexthdr &&
 					((trie_val->start_port == ANY_PORT) || (l4_dst_port == trie_val->start_port) ||
 					(l4_dst_port > trie_val->start_port && l4_dst_port <= trie_val->end_port)))) {
 			//Inject in to conntrack map

--- a/pkg/ebpf/c/tc.v6ingress.bpf.c
+++ b/pkg/ebpf/c/tc.v6ingress.bpf.c
@@ -195,7 +195,9 @@ int handle_ingress(struct __sk_buff *skb)
 			return BPF_DROP;
 		}
 
-		if ((trie_val->protocol == ANY_IP_PROTOCOL) || (trie_val->protocol == ip->nexthdr &&
+		if ((trie_val->protocol == ANY_IP_PROTOCOL &&
+					((trie_val->start_port == ANY_PORT) || (l4_dst_port == trie_val->start_port) ||
+					(l4_dst_port > trie_val->start_port && l4_dst_port <= trie_val->end_port))) || (trie_val->protocol == ip->nexthdr &&
 					((trie_val->start_port == ANY_PORT) || (l4_dst_port == trie_val->start_port) ||
 					(l4_dst_port > trie_val->start_port && l4_dst_port <= trie_val->end_port)))) {
 				//Inject in to conntrack map

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -208,7 +208,9 @@ func deriveProtocolValue(l4Info v1alpha1.Port, allowAll, denyAll bool) int {
 		return protocol //Protocol defaults to ANY_IP_PROTOCOL if not specified
 	}
 
-	if *l4Info.Protocol == corev1.ProtocolUDP {
+	if *l4Info.Protocol == corev1.ProtocolTCP {
+		protocol = TCP_PROTOCOL_NUMBER
+	} else if *l4Info.Protocol == corev1.ProtocolUDP {
 		protocol = UDP_PROTOCOL_NUMBER
 	} else if *l4Info.Protocol == corev1.ProtocolSCTP {
 		protocol = SCTP_PROTOCOL_NUMBER


### PR DESCRIPTION
*Issue #, if available:*
If there is an overlap of IPs in an allow rule and in an except block of other rule, we do not handle the merging 

*Description of changes:*

*Example:*

```
egress:
  - to:
      - ipBlock:
          cidr: 192.168.0.0/16
    ports:
      - port: 3306
  - to:
      - ipBlock:
          cidr: 0.0.0.0/0
          except:
            - 192.168.0.0/16
```

*We evaluate this as*

* 0.0.0.0/0 - startPort:0 endPort: 0
* except block - 192.168.0.0/16 - startPort: 0 endPort:0
* 192.168.0.0/16 - allow on port 3306, as this is part of 0.0.0.0/0 allow on all ports. Append previous ports to this new L4 info. Final L4 ports info looks as below
    * startPort: 3306, endPort: 0 - allow 
    * startPort:0, endPort: 0 - allow 
    * startPort:0, endPort:0 - deny 

The correct behavior for 192.168.0.0/16 should be allow on 3306 as explicit allow takes precedence and deny on rest all ports due to except
*New evaluation logic - all except blocks are handled at end*

* 0.0.0.0/0 - startPort:0 endPort: 0
* 192.168.0.0/16 - allow on port 3306. This is part of 0.0.0.0/0, so check if it is part of any except under this cidr. If yes do not add ports of 0.0.0.0/0 to 192.168.0.0/16. If no, add ports. In this case it is part of except so do not add it
* Handle all except at end. For every except key, check if entry is already present in cidrsMap. If yes, there is some explicit allow and everything else will be default deny so no change required. If no, we need to add deny all entry to make sure we deny all traffic and do not allow it if it is part of some other superset CIDR

*Other Changes in the PR:*

* Code refactoring to make it simpler and easy to follow
    * catch all need not be handled separately. We evaluate rules in the order of prefix length, so catch all will be handled first followed by others
* If no protocol specified, it should be allow any protocol. Changed default to any_ip_protocol from tcp
* For any_ip_protocol, check start and end ports for traffic evaluation. Before fix if it is any_protocol we allow on all ports
    * example:
        * Port:53 → This should be evaluated as allow any_protocol on port 53
        
Testing done with multiple cases of except overlaps





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
