### PR TITLE
trie value for except should not inherite if  [overlaps between except and allow CIDR] or [except is larger than allow CIDR] ; trie value for except should inherite if except is smaller than allow cidr

### DIFF
--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -859,6 +859,8 @@ func (l *bpfClient) computeMapEntriesFromEndpointRules(firewallRules []EbpfFirew
 	ipCIDRs := make(map[string][]v1alpha1.Port)
 	nonHostCIDRs := make(map[string][]v1alpha1.Port)
 	isCatchAllIPEntryPresent, allowAll := false, false
+	excepts := make(map[v1alpha1.NetworkAddress]struct{})
+	preFireWallMap := make(map[v1alpha1.NetworkAddress][]v1alpha1.Port)
 	var catchAllIPPorts []v1alpha1.Port
 
 	//Traffic from the local node should always be allowed. Add NodeIP by default to map entries.
@@ -866,6 +868,12 @@ func (l *bpfClient) computeMapEntriesFromEndpointRules(firewallRules []EbpfFirew
 	key := utils.ComputeTrieKey(*mapKey, l.enableIPv6)
 	value := utils.ComputeTrieValue([]v1alpha1.Port{}, l.logger, true, false)
 	firewallMap[string(key)] = value
+
+	for index, firewallRule := range firewallRules {
+		if !strings.Contains(string(firewallRule.IPCidr), "/") {
+			firewallRules[index].IPCidr += v1alpha1.NetworkAddress(l.hostMask)
+		}
+	}
 
 	//Sort the rules
 	sortFirewallRulesByPrefixLength(firewallRules, l.hostMask)
@@ -878,6 +886,7 @@ func (l *bpfClient) computeMapEntriesFromEndpointRules(firewallRules []EbpfFirew
 		key := utils.ComputeTrieKey(*mapKey, l.enableIPv6)
 		value := utils.ComputeTrieValue(catchAllIPPorts, l.logger, allowAll, false)
 		firewallMap[string(key)] = value
+		nonHostCIDRs["0.0.0.0/0"] = catchAllIPPorts
 	}
 
 	for _, firewallRule := range firewallRules {
@@ -934,35 +943,52 @@ func (l *bpfClient) computeMapEntriesFromEndpointRules(firewallRules []EbpfFirew
 				}
 				ipCIDRs[string(firewallRule.IPCidr)] = firewallRule.L4Info
 			}
-			//Include port and protocol combination paired with catch all entries
-			firewallRule.L4Info = append(firewallRule.L4Info, catchAllIPPorts...)
-
-			l.logger.Info("Updating Map with ", "IP Key:", firewallRule.IPCidr)
-			_, firewallMapKey, _ := net.ParseCIDR(string(firewallRule.IPCidr))
-			// Key format: Prefix length (4 bytes) followed by 4/16byte IP address
-			firewallKey := utils.ComputeTrieKey(*firewallMapKey, l.enableIPv6)
-
 			if len(firewallRule.L4Info) != 0 {
 				mergedL4Info := mergeDuplicateL4Info(firewallRule.L4Info)
 				firewallRule.L4Info = mergedL4Info
 
 			}
-			firewallValue := utils.ComputeTrieValue(firewallRule.L4Info, l.logger, allowAll, false)
-			firewallMap[string(firewallKey)] = firewallValue
+			preFireWallMap[firewallRule.IPCidr] = mergeDuplicateL4Info(append(preFireWallMap[firewallRule.IPCidr], firewallRule.L4Info...))
 		}
 		if firewallRule.Except != nil {
 			for _, exceptCIDR := range firewallRule.Except {
-				_, mapKey, _ := net.ParseCIDR(string(exceptCIDR))
-				key := utils.ComputeTrieKey(*mapKey, l.enableIPv6)
-				l.logger.Info("Parsed Except CIDR", "IP Key: ", mapKey)
-				if len(firewallRule.L4Info) != 0 {
-					mergedL4Info := mergeDuplicateL4Info(firewallRule.L4Info)
-					firewallRule.L4Info = mergedL4Info
-				}
-				value := utils.ComputeTrieValue(firewallRule.L4Info, l.logger, false, true)
-				firewallMap[string(key)] = value
+				excepts[exceptCIDR] = struct{}{}
 			}
 		}
+	}
+
+	for except := range excepts {
+		var allowPorts []v1alpha1.Port
+		var denyAll bool
+
+		_, exceptCIDR, _ := net.ParseCIDR(string(except))
+		for _, fireWallRule := range firewallRules {
+			_, cidr, _ := net.ParseCIDR(string(fireWallRule.IPCidr))
+			if utils.CheckCIDRContains(cidr, exceptCIDR) && utils.CheckSubExceptNotContains(fireWallRule.Except, exceptCIDR) {
+				allowPorts = append(allowPorts, fireWallRule.L4Info...)
+			}
+		}
+
+		if len(allowPorts) == 0 {
+			denyAll = true
+		}
+
+		key := utils.ComputeTrieKey(*exceptCIDR, l.enableIPv6)
+		value := utils.ComputeTrieValue(mergeDuplicateL4Info(allowPorts), l.logger, false, denyAll)
+		firewallMap[string(key)] = value
+	}
+
+	for fireWallCIDR, ports := range preFireWallMap {
+
+		if _, ok := excepts[fireWallCIDR]; ok {
+			continue
+		}
+
+		_, fireWallMapKey, _ := net.ParseCIDR(string(fireWallCIDR))
+		key := utils.ComputeTrieKey(*fireWallMapKey, l.enableIPv6)
+		value := utils.ComputeTrieValue(mergeDuplicateL4Info(ports), l.logger, allowAll, false)
+
+		firewallMap[string(key)] = value
 	}
 
 	return firewallMap, nil

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -386,3 +386,33 @@ func ConvByteToTrieV6(keyByte []byte) BPFTrieKeyV6 {
 	copy(byteArray[:], keyByte)
 	return v6key
 }
+
+func CheckCIDRContains(ipnet1, ipnet2 *net.IPNet) bool {
+	mask1, _ := ipnet1.Mask.Size()
+	mask2, _ := ipnet2.Mask.Size()
+
+	if !ipnet1.IP.Mask(ipnet1.Mask).Equal(ipnet2.IP.Mask(ipnet1.Mask)) {
+		return false
+	}
+
+	return mask1 <= mask2
+}
+
+func CheckSubExceptNotContains(subExcepts []v1alpha1.NetworkAddress, exceptCIDR *net.IPNet) bool {
+	for _, subExcept := range subExcepts {
+		_, subExceptCIDR, _ := net.ParseCIDR(string(subExcept))
+		if CheckCIDRContains(subExceptCIDR, exceptCIDR) {
+			return false
+		}
+	}
+	return true
+}
+
+func IsExceptInCIDR(item string, s []v1alpha1.NetworkAddress) bool {
+	for _, v := range s {
+		if item == string(v) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
*Issue #, if available:*
Now there is an overlap between allow ip cidrs and except, here is the case:

```
  policyTypes:
  - Egress
  egress:
  - to:
    - ipBlock:
        cidr: 10.0.0.0/24
    ports:
    - port: 8080
  - to:
    - ipBlock:
        cidr: 10.0.0.0/16
        except:
        - 10.0.0.0/24
    ports:
    - port: 8081
```

Here, the ebpf egress map is : 

```
Key : IP/Prefixlen - 10.0.0.0/24
-------------------
Value Entry :  0
Protocol -  TCP
StartPort -  8080
Endport -  0
-------------------
-------------------
Value Entry :  1
Protocol -  TCP
StartPort -  8081
Endport -  0
-------------------
*******************************
Key : IP/Prefixlen - 10.0.0.0/16
-------------------
Value Entry :  0
Protocol -  ANY PROTOCOL
StartPort -  0
Endport -  0
-------------------
*******************************
```

*Description of changes:*

trie key `10.0.0.0/24` should not have `TCP 8081`, which belongs to 10.0.0.0/16 but except 10.0.0.0/24.

We should first collect all the L4Info for nonHostCIDR, and then handle the exceptions. This is because when the eBPF program receives a packet, it matches against the smallest CIDR. If an exception is contained within a certain CIDR, then this exception should inherit the L4Info of that CIDR.

Therefore, after processing all the L4Info associated with the CIDRs, we will handle the exceptions:

For a specific exception (let's call it exceptA), we need to iterate through all the CIDRs and their L4Info. If:

- A certain CIDR contains exceptA and the exceptions of this CIDR do not contain exceptA, then the Trie Value for exceptA should inherit the L4Info of this CIDR.
- A certain CIDR contains exceptA, and this CIDR has an exception that includes exceptA, then the Trie Value for exceptA should not inherit the L4Info of this CIDR.
- A certain CIDR does not contain exceptA, then exceptA should not inherit the L4Info of this CIDR.

Finally, we will process all the CIDRs and exceptions, using these as keys to write into the eBPF map's trie, and determine the corresponding L4Info. If the length of the L4Info is 0, we will write a RESERVE. If it is not 0, we will write the values according to the StartPort, EndPort, and Protocol of the L4Info.


after change，the ebpf egress map is:

```
Key : IP/Prefixlen - 10.0.0.0/24
-------------------
Value Entry :  0
Protocol -  TCP
StartPort -  8080
Endport -  0
-------------------
*******************************
Key : IP/Prefixlen - 10.0.0.0/16
-------------------
Value Entry :  0
Protocol -  TCP
StartPort -  8081
Endport -  0
-------------------
*******************************
```

`port 8081` for `10.0.0.0/16` but except `10.0.0.24` has been removed


For another case , which e :
```
  policyTypes:
  - Egress
  egress:
  - to:
    - ipBlock:
        cidr: 10.0.0.0/24
    ports:
    - port: 8080
  - to:
    - ipBlock:
        cidr: 10.0.0.0/16
        except:
        - 10.0.0.0/25
    ports:
    - port: 8081
```


after change , we can get :

```
Key : IP/Prefixlen - 10.0.0.0/24
-------------------
Value Entry :  0
Protocol -  TCP
StartPort -  8080
Endport -  0
-------------------
-------------------
Value Entry :  0
Protocol -  TCP
StartPort -  8081
Endport -  0
-------------------
*******************************
Key : IP/Prefixlen - 10.0.0.0/24
-------------------
Value Entry :  0
Protocol -  TCP
StartPort -  8080
Endport -  0
-------------------
*******************************
Key : IP/Prefixlen - 10.0.0.0/16
-------------------
Value Entry :  0
Protocol -  TCP
StartPort -  8081
Endport -  0
-------------------
*******************************
```

except `10.0.0.0/25` is in allow cidr `10.0.0.0/24`, so L4Info should gather `10.0.0.0/24`'s`port 8080` and `10.0.0.0/16`'s `port 8081`.


and the last case:

```
  policyTypes:
  - Egress
  egress:
  - to:
    - ipBlock:
        cidr: 10.0.0.0/24
    ports:
    - port: 8080
  - to:
    - ipBlock:
        cidr: 10.0.0.0/16
        except:
        - 10.0.0.0/23
    ports:
    - port: 8081
```
after change , we can get :

```
Key : IP/Prefixlen - 10.0.0.0/24
-------------------
Value Entry :  0
Protocol -  TCP
StartPort -  8080
Endport -  0
-------------------
*******************************
Key : IP/Prefixlen - 10.0.0.0/16
-------------------
Value Entry :  0
Protocol -  TCP
StartPort -  8081
Endport -  0
-------------------
*******************************
Key : IP/Prefixlen - 10.0.0.0/23
-------------------
Value Entry :  0
Protocol -  RESERVERD
StartPort -  0
Endport -  0
-------------------
*******************************
```

we should block any packet that in `10.0.0.0/23` but not in `10.0.0.0/25`, and if packet that in `10.0.0.0/24`, it matches `10.0.0.0/24`, allowing port 8080.


therefore, for an except cidr, if no other allow cidr (for except's parent allow cidr, L4Info should not inherit) contains it , we should deny all ports.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
