### PR TITLE
Fix error handling while publishing events to cloudwatch

### DIFF
--- a/pkg/ebpf/events/events.go
+++ b/pkg/ebpf/events/events.go
@@ -144,9 +144,7 @@ func publishDataToCloudwatch(logQueue []*cloudwatchlogs.InputLogEvent, message s
 		resp, err := cwl.PutLogEvents(&input)
 		if err != nil {
 			log.Info("Push log events", "Failed ", err)
-		}
-
-		if resp != nil {
+		} else if resp != nil && resp.NextSequenceToken != nil {
 			sequenceToken = *resp.NextSequenceToken
 		}
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-network-policy-agent/issues/362

*Description of changes:*
When resp is maformed or we get partial response it will crash as we try to reference nil pointer. 
Check resp only if err is nil and also check if resp.nextSequenceToken is not nil 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
