### PR TITLE
Restart container if grpc handler setup fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,7 +114,13 @@ func main() {
 	}
 
 	go metrics.ServeMetrics()
-	go rpc.RunRPCHandler(policyEndpointController)
+
+	go func() {
+		if err := rpc.RunRPCHandler(policyEndpointController); err != nil {
+			setupLog.Error(err, "Failed to set up gRPC Handler")
+			os.Exit(1)
+		}
+	}()
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctx); err != nil {


### PR DESCRIPTION
*Issue #, if available:*
If grpc handler setup fails for any reason restart the container. This is a blocker for pod creation as np agent listens on this port for any new pods to attach probes

*Description of changes:*
If grpc handler setup fails for any reason stop the process

*Testing*

Forced a failure in rpc_handler - container restarted 

```
{"level":"info","ts":"2025-02-08T01:07:17.673Z","logger":"setup","caller":"workspace/main.go:125","msg":"starting manager"}
{"level":"info","ts":"2025-02-08T01:07:17.673Z","logger":"controller-runtime.metrics","caller":"server/server.go:208","msg":"Starting metrics server"}
{"level":"info","ts":"2025-02-08T01:07:17.673Z","logger":"ebpf-client","caller":"conntrack/conntrack_client.go:54","msg":"Check for any stale entries in the conntrack map"}
{"level":"info","ts":"2025-02-08T01:07:17.673Z","logger":"rpc-handler","caller":"rpc/rpc_handler.go:102","msg":"Serving RPC Handler","Address":"127.0.0.1:50052"}
{"level":"info","ts":"2025-02-08T01:07:17.673Z","logger":"controller-runtime.metrics","caller":"server/server.go:247","msg":"Serving metrics server","bindAddress":":8162","secure":false}
{"level":"info","ts":"2025-02-08T01:07:17.673Z","caller":"manager/server.go:83","msg":"starting server","name":"health probe","addr":"[::]:8163"}
{"level":"error","ts":"2025-02-08T01:07:17.674Z","logger":"rpc-handler","caller":"rpc/rpc_handler.go:110","msg":"Forcing error for testing container restart","error":"forcing a test error:gRPC server intentionally failing","errorVerbose":"forcing a test error: gRPC server intentionally failing\ngithub.com/aws/aws-network-policy-agent/pkg/rpc.RunRPCHandler\n\t/workspace/pkg/rpc/rpc_handler.go:109\nmain.main.func1\n\t/workspace/main.go:119\nruntime.goexit\n\t/root/sdk/go1.22.10/src/runtime/asm_amd64.s:1695"}
{"level":"error","ts":"2025-02-08T01:07:17.674Z","logger":"setup","caller":"workspace/main.go:120","msg":"Failed to set up gRPC Handler","error":"forcing a test error: gRPC server intentionally failing","errorVerbose":"forcing a test error: gRPC server intentionally failing\ngithub.com/aws/aws-network-policy-agent/pkg/rpc.RunRPCHandler\n\t/workspace/pkg/rpc/rpc_handler.go:109\nmain.main.func1\n\t/workspace/main.go:119\nruntime.goexit\n\t/root/sdk/go1.22.10/src/runtime/asm_amd64.s:1695"}
{"level":"info","ts":"2025-02-08T01:07:34.834Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:88","msg":"ConntrackTTL","cleanupPeriod":300}
{"level":"info","ts":"2025-02-08T01:07:34.834Z","logger":"ebpf-client-init","caller":"ebpf/bpf_client.go:318","msg":"Validating ","Probe: ":"v4events.bpf.o"}
```

No failure in grpc handler 

```
{"level":"info","ts":"2025-02-08T00:45:52.830Z","logger":"setup","caller":"workspace/main.go:125","msg":"starting manager"}
{"level":"info","ts":"2025-02-08T00:45:52.830Z","logger":"ebpf-client","caller":"conntrack/conntrack_client.go:54","msg":"Check for any stale entries in the conntrack map"}
{"level":"info","ts":"2025-02-08T00:45:52.830Z","logger":"rpc-handler","caller":"rpc/rpc_handler.go:102","msg":"Serving RPC Handler","Address":"127.0.0.1:50052"}
{"level":"info","ts":"2025-02-08T00:45:52.831Z","logger":"controller-runtime.metrics","caller":"server/server.go:208","msg":"Starting metrics server"}
{"level":"info","ts":"2025-02-08T00:45:52.831Z","caller":"manager/server.go:83","msg":"starting server","name":"health probe","addr":"[::]:8163"}
{"level":"info","ts":"2025-02-08T00:45:52.831Z","caller":"controller/controller.go:175","msg":"Starting EventSource","controller":"policyendpoint","controllerGroup":"networking.k8s.aws","controllerKind":"PolicyEndpoint","source":"kind source: *v1alpha1.PolicyEndpoint"}
{"level":"info","ts":"2025-02-08T00:45:52.831Z","caller":"controller/controller.go:183","msg":"Starting Controller","controller":"policyendpoint","controllerGroup":"networking.k8s.aws","controllerKind":"PolicyEndpoint"}
{"level":"info","ts":"2025-02-08T00:45:52.831Z","logger":"controller-runtime.metrics","caller":"server/server.go:247","msg":"Serving metrics server","bindAddress":":8162","secure":false}
{"level":"info","ts":"2025-02-08T00:45:52.947Z","caller":"controller/controller.go:217","msg":"Starting workers","controller":"policyendpoint","controllerGroup":"networking.k8s.aws","controllerKind":"PolicyEndpoint","worker count":1}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
