### PR TITLE
Fix getting the latest k8s version

### DIFF
--- a/scripts/lib/cluster.sh
+++ b/scripts/lib/cluster.sh
@@ -17,7 +17,7 @@ function load_default_values(){
 
     # If Kubernetes version is not passed then use the latest available version
     if [[ -z $K8S_VERSION ]]; then
-        K8S_VERSION=$(eksctl version -o json | jq -r '.EKSServerSupportedVersions | sort | reverse | .[0]')
+        K8S_VERSION=$(eksctl utils describe-cluster-versions | jq -r '.clusterVersions[0].ClusterVersion')
     fi
 
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This fixes the way we get the latest k8s version from eksctl API


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
