### PR TITLE
Remove early probes cleanup when updateprobes required

### DIFF
--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -372,17 +372,6 @@ func checkAndUpdateBPFBinaries(bpfTCClient tc.BpfTc, bpfBinaries []string, hostB
 			}
 		}
 	}
-
-	//Clean up probes
-	if updateIngressProbe || updateEgressProbe {
-		err := bpfTCClient.CleanupQdiscs(updateIngressProbe, updateEgressProbe)
-		if err != nil {
-			log.Error(err, "Probe cleanup failed")
-			sdkAPIErr.WithLabelValues("CleanupQdiscs").Inc()
-			return updateIngressProbe, updateEgressProbe, updateEventsProbe, err
-		}
-	}
-
 	return updateIngressProbe, updateEgressProbe, updateEventsProbe, nil
 }
 


### PR DESCRIPTION
*Issue #, if available:*
If probe binary is updated, we first gather attached probes info and cleanup probes and reattach the probes with new binary https://github.com/aws/aws-network-policy-agent/blob/main/pkg/ebpf/bpf_client.go#L451-L475. This earlier cleanup needs to be removed --> This was removed but got added by mistake during git merge 

```
{"level":"info","ts":"2025-02-20T19:25:16.159Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:449","msg":"GetAllBpfProgramsAndMaps ","returned":4}
{"level":"info","ts":"2025-02-20T19:25:16.164Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:460","msg":"Got attached ","ingressprogIds ":5," egressprogIds ":5}
{"level":"info","ts":"2025-02-20T19:25:16.166Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:482","msg":"Collected all data for reattaching probes"}
{"level":"info","ts":"2025-02-20T19:25:16.167Z","logger":"ebpf-client","caller":"e
```

attachedprogids returned will always be 0 if we first clean up probes and try to collect current probes info.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
