### PR TITLE
Fix ebpf maps/progs cleanup test 

### DIFF
--- a/test/agent/Dockerfile
+++ b/test/agent/Dockerfile
@@ -16,7 +16,7 @@ COPY cmd cmd
 # Package all testing binaries into one docker file
 # which can be used for different test scenarios
 RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build \
-    -a -o check-bpf-cleanup-client cmd/check-bpf-cleanup-client/main.go
+    -a -o check-bpf-cleanup-agent cmd/check-bpf-cleanup-agent/main.go
 
 FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2
 

--- a/test/agent/cmd/check-bpf-cleanup-agent/main.go
+++ b/test/agent/cmd/check-bpf-cleanup-agent/main.go
@@ -53,7 +53,7 @@ func leakedMapsFound() error {
 
 	for _, v := range files {
 		if v.Name() != "global_aws_conntrack_map" && v.Name() != "global_policy_events" && !strings.HasPrefix(v.Name(), getPodPrefix()) && !strings.HasPrefix(v.Name(), coreDnsPrefix) {
-            return fmt.Errorf("BPF Maps folder is not cleaned up (except conntrack, policy_events, coreDNS): %v", v.Name())
+			return fmt.Errorf("BPF Maps folder is not cleaned up (except conntrack, policy_events, coreDNS): %v", v.Name())
 		}
 	}
 

--- a/test/agent/cmd/check-bpf-cleanup-agent/main.go
+++ b/test/agent/cmd/check-bpf-cleanup-agent/main.go
@@ -4,11 +4,34 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 )
 
 const baseDir = "/tmp"
 const mapsPath = "/sys/fs/bpf/globals/aws/maps"
 const programsPath = "/sys/fs/bpf/globals/aws/programs"
+const coreDnsPrefix = "coredns"
+
+func getPodPrefix() string {
+	podName := os.Getenv("NODE_NAME")
+	if podName == "" {
+		log.Println("NODE_NAME environment variable is not set. Cleanup pod filtering may not work correctly.")
+		return ""
+	}
+
+	// Split by "." to isolate the first part
+	parts := strings.SplitN(podName, ".", 2) // Get "ip-192-168-59-7" and ignore the rest
+	if len(parts) < 2 {
+		log.Printf("Unexpected node name format: %s", podName)
+		return ""
+	}
+
+	// Replace the first "." with "_" to match the BPF map format
+	prefix := strings.Replace(parts[0], ".", "_", 1) + "_"
+
+	log.Printf("Using prefix to ignore cleanup pod maps/programs: %s", prefix)
+	return prefix
+}
 
 func leakedMapsFound() error {
 
@@ -29,8 +52,8 @@ func leakedMapsFound() error {
 	}
 
 	for _, v := range files {
-		if v.Name() != "global_aws_conntrack_map" && v.Name() != "global_policy_events" {
-			return fmt.Errorf("BPF Maps folder is not cleaned up (except conntrack, policy_events): %v", v.Name())
+		if v.Name() != "global_aws_conntrack_map" && v.Name() != "global_policy_events" && !strings.HasPrefix(v.Name(), getPodPrefix()) && !strings.HasPrefix(v.Name(), coreDnsPrefix) {
+            return fmt.Errorf("BPF Maps folder is not cleaned up (except conntrack, policy_events, coreDNS): %v", v.Name())
 		}
 	}
 
@@ -56,8 +79,12 @@ func leakedProgsFound() error {
 		return err
 	}
 
-	if len(files) > 0 {
-		return fmt.Errorf("BPF Programs folder is not cleaned up")
+	for _, v := range files {
+		progName := v.Name()
+		// Ignore programs that belong to the cleanup pod
+		if !strings.HasPrefix(progName, getPodPrefix()) && !strings.HasPrefix(progName, coreDnsPrefix) {
+			return fmt.Errorf("BPF Programs folder is not cleaned up: %v", progName)
+		}
 	}
 
 	log.Printf("BPF Programs are cleaned up")


### PR DESCRIPTION
*Issue #, if available:*
With recent changes in NP, every pod will have maps/progs created even if policies are not applied to it. Once we run cyclonus tests and clean up the pods and policies, we run a pod which runs cleanup script to check if there are any leaked maps or progs on the node. As we are creating a new pod for this, there will be maps/progs created for this pod.

*Description of changes:*
 Exclude maps/progs with cleanup pod name while checking for leaked maps/progs. core dns pods will also have default probes attached as it is a deployment. Excluding those too 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
