### PR TITLE
Running cyclonus test with timeout and regular checks

### DIFF
--- a/.github/workflows/e2e-conformance.yaml
+++ b/.github/workflows/e2e-conformance.yaml
@@ -49,7 +49,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.OSS_ROLE_ARN }}
           aws-region: us-west-2
-          role-duration-seconds: 18000 # 5 hours
+          role-duration-seconds: 21600 # 6 hours
       - name: Run e2e conformance test
         env:
           RUN_CONFORMANCE_TESTS: true


### PR DESCRIPTION
*Issue #, if available:*
CI stability

*Description of changes:*
This fixes CI tests to run regular cyclonus job status and times out in 5hrs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
