### PR TITLE
only register PE controller when networkpolicy is enabled

### DIFF
--- a/controllers/policyendpoints_controller.go
+++ b/controllers/policyendpoints_controller.go
@@ -97,6 +97,7 @@ func NewPolicyEndpointsReconciler(k8sClient client.Client, log logr.Logger,
 	var err error
 	r.enableNetworkPolicy = enableNetworkPolicy
 
+	// keep the check here for UT TestIsProgFdShared
 	if enableNetworkPolicy {
 		r.ebpfClient, err = ebpf.NewBpfClient(&r.policyEndpointeBPFContext, r.nodeIP,
 			enablePolicyEventLogs, enableCloudWatchLogs, enableIPv6, conntrackTTL, conntrackTableSize)
@@ -142,12 +143,6 @@ func (r *PolicyEndpointsReconciler) SetNetworkPolicyMode(mode string) {
 }
 
 func (r *PolicyEndpointsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-
-	if !r.enableNetworkPolicy {
-		r.log.Info("Skipping policy endpoint reconciliation as network policy agent is disabled")
-		return ctrl.Result{}, nil
-	}
-
 	r.log.Info("Received a new reconcile request", "req", req)
 	if err := r.reconcile(ctx, req); err != nil {
 		r.log.Error(err, "Reconcile error")

--- a/main.go
+++ b/main.go
@@ -17,8 +17,9 @@ limitations under the License.
 package main
 
 import (
-	"github.com/aws/aws-network-policy-agent/pkg/rpc"
 	"os"
+
+	"github.com/aws/aws-network-policy-agent/pkg/rpc"
 
 	"github.com/aws/aws-network-policy-agent/pkg/logger"
 

--- a/main.go
+++ b/main.go
@@ -90,18 +90,31 @@ func main() {
 	}
 
 	ctx := ctrl.SetupSignalHandler()
-	policyEndpointController, err := controllers.NewPolicyEndpointsReconciler(mgr.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("policyEndpoints"), ctrlConfig.EnablePolicyEventLogs, ctrlConfig.EnableCloudWatchLogs,
-		ctrlConfig.EnableIPv6, ctrlConfig.EnableNetworkPolicy, ctrlConfig.ConntrackCacheCleanupPeriod, ctrlConfig.ConntrackCacheTableSize)
-	if err != nil {
-		setupLog.Error(err, "unable to setup controller", "controller", "PolicyEndpoints init failed")
-		os.Exit(1)
+
+	if ctrlConfig.EnableNetworkPolicy {
+		setupLog.Info("Network Policy is enabled, registering the policyEndpointController...")
+		policyEndpointController, err := controllers.NewPolicyEndpointsReconciler(mgr.GetClient(),
+			ctrl.Log.WithName("controllers").WithName("policyEndpoints"), ctrlConfig.EnablePolicyEventLogs, ctrlConfig.EnableCloudWatchLogs,
+			ctrlConfig.EnableIPv6, ctrlConfig.EnableNetworkPolicy, ctrlConfig.ConntrackCacheCleanupPeriod, ctrlConfig.ConntrackCacheTableSize)
+		if err != nil {
+			setupLog.Error(err, "unable to setup controller", "controller", "PolicyEndpoints init failed")
+			os.Exit(1)
+		}
+
+		if err = policyEndpointController.SetupWithManager(ctx, mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "PolicyEndpoints")
+			os.Exit(1)
+		}
+		go func() {
+			if err := rpc.RunRPCHandler(policyEndpointController); err != nil {
+				setupLog.Error(err, "Failed to set up gRPC Handler")
+				os.Exit(1)
+			}
+		}()
+	} else {
+		setupLog.Info("Network Policy is disabled, skip the policyEndpointController registration")
 	}
 
-	if err = policyEndpointController.SetupWithManager(ctx, mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "PolicyEndpoints")
-		os.Exit(1)
-	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
@@ -114,13 +127,6 @@ func main() {
 	}
 
 	go metrics.ServeMetrics()
-
-	go func() {
-		if err := rpc.RunRPCHandler(policyEndpointController); err != nil {
-			setupLog.Error(err, "Failed to set up gRPC Handler")
-			os.Exit(1)
-		}
-	}()
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctx); err != nil {

--- a/pkg/rpc/rpc_handler.go
+++ b/pkg/rpc/rpc_handler.go
@@ -51,7 +51,7 @@ type server struct {
 
 // EnforceNpToPod processes CNI Enforce NP network request
 func (s *server) EnforceNpToPod(ctx context.Context, in *rpc.EnforceNpRequest) (*rpc.EnforceNpReply, error) {
-	if s.policyReconciler.GeteBPFClient() == nil {
+	if s.policyReconciler == nil || s.policyReconciler.GeteBPFClient() == nil {
 		s.log.Info("Network policy is disabled, returning success")
 		success := rpc.EnforceNpReply{
 			Success: true,
@@ -127,7 +127,7 @@ func (s *server) EnforceNpToPod(ctx context.Context, in *rpc.EnforceNpRequest) (
 
 // DeletePodNp processes CNI Delete Pod NP network request
 func (s *server) DeletePodNp(ctx context.Context, in *rpc.DeleteNpRequest) (*rpc.DeleteNpReply, error) {
-	if s.policyReconciler.GeteBPFClient() == nil {
+	if s.policyReconciler == nil || s.policyReconciler.GeteBPFClient() == nil {
 		s.log.Info("Network policy is disabled, returning success")
 		success := rpc.DeleteNpReply{
 			Success: true,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-network-policy-agent/issues/260
Currently, the NPA registers the PE controller and start to watch for PE CRD even the feature is not enabled. This is unnecessary and may cause some issue like container restart or `aws-node` in CrashBackOff for users not using this feature.
For example, if API server is not available, the NPA will crash, and lead `aws-node` in CrashBackoff eventually if the connectivity to API server is not established before liveness probe succeeds.
```
"level":"error","ts":"2025-03-25T18:26:13.146Z","logger":"controller-runtime.source.EventHandler","caller":"source/kind.go:76","msg":"failed to get informer from cache","error":"failed to get API group resources: unable to retrieve the complete list of server APIs: networking.k8s.aws/v1alpha1: Get \"[https://10.100.0.1:443/apis/networking.k8s.aws/v1alpha1](https://10.100.0.1/apis/networking.k8s.aws/v1alpha1)\": dial tcp 10.100.0.1:443: i/o timeout"}
{"level":"error","ts":"2025-03-25T18:26:43.148Z","logger":"controller-runtime.source.EventHandler","caller":"source/kind.go:76","msg":"failed to get informer from cache","error":"failed to get API group resources: unable to retrieve the complete list of server APIs: networking.k8s.aws/v1alpha1: Get \"[https://10.100.0.1:443/apis/networking.k8s.aws/v1alpha1](https://10.100.0.1/apis/networking.k8s.aws/v1alpha1)\": dial tcp 10.100.0.1:443: i/o timeout"}
```
*Description of changes:*
Improve the behavior to only register the PE controller and start watch and cache when this feature is enabled. This can improve the performance by avoiding unnecessary watch/cache. And avoid surprising customer with any issue of this controller, when they are not using this feature

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

#### manual test
1. test with `--enable-network-policy=false`. created pods with basic ingress/egress NP, verify the pods were up and running, and rpc handler is just returning success since NP disabled.
```
{"level":"info","ts":"2025-03-26T23:31:20.369Z","logger":"setup","caller":"workspace/main.go:108","msg":"Network Policy is disabled, skip the policyEndpointController registration"}
{"level":"info","ts":"2025-03-26T23:31:20.369Z","logger":"setup","caller":"workspace/main.go:133","msg":"starting manager"}
{"level":"info","ts":"2025-03-26T23:31:20.369Z","logger":"controller-runtime.metrics","caller":"server/server.go:208","msg":"Starting metrics server"}
{"level":"info","ts":"2025-03-26T23:31:20.369Z","logger":"controller-runtime.metrics","caller":"server/server.go:247","msg":"Serving metrics server","bindAddress":":8162","secure":false}
{"level":"info","ts":"2025-03-26T23:31:20.369Z","logger":"rpc-handler","caller":"rpc/rpc_handler.go:170","msg":"Serving RPC Handler","Address":"127.0.0.1:50052"}
{"level":"info","ts":"2025-03-26T23:31:20.369Z","caller":"manager/server.go:83","msg":"starting server","name":"health probe","addr":"[::]:8163"}
{"level":"info","ts":"2025-03-26T23:37:03.476Z","logger":"rpc-handler","caller":"rpc/rpc_handler.go:55","msg":"Network policy is disabled, returning success"}
```
2. test with `--enable-network-policy=true`
```
{"level":"info","ts":"2025-03-26T23:45:46.439Z","logger":"setup","caller":"workspace/main.go:94","msg":"Network Policy is enabled, registering the policyEndpointController..."}
{"level":"info","ts":"2025-03-26T23:45:46.441Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:95","msg":"ConntrackTTL","cleanupPeriod":300}
{"level":"info","ts":"2025-03-26T23:45:46.442Z","logger":"ebpf-client-init","caller":"ebpf/bpf_client.go:342","msg":"Validating ","Probe: ":"v4events.bpf.o"}
{"level":"info","ts":"2025-03-26T23:45:46.442Z","logger":"ebpf-client-init","caller":"ebpf/bpf_client.go:354","msg":"comparing new and existing probes ..."}
{"level":"info","ts":"2025-03-26T23:45:46.448Z","logger":"ebpf-client-init","caller":"ebpf/bpf_client.go:342","msg":"Validating ","Probe: ":"tc.v4ingress.bpf.o"}
{"level":"info","ts":"2025-03-26T23:45:46.449Z","logger":"ebpf-client-init","caller":"ebpf/bpf_client.go:354","msg":"comparing new and existing probes ..."}
{"level":"info","ts":"2025-03-26T23:45:46.515Z","logger":"ebpf-client-init","caller":"ebpf/bpf_client.go:342","msg":"Validating ","Probe: ":"tc.v4egress.bpf.o"}
{"level":"info","ts":"2025-03-26T23:45:46.515Z","logger":"ebpf-client-init","caller":"ebpf/bpf_client.go:354","msg":"comparing new and existing probes ..."}
{"level":"info","ts":"2025-03-26T23:45:46.568Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:185","msg":"Probe validation Done"}
{"level":"info","ts":"2025-03-26T23:45:46.568Z","logger":"cp-util","caller":"cp/cp.go:67","msg":"Let's install BPF Binaries on to the host path....."}
{"level":"info","ts":"2025-03-26T23:45:46.568Z","logger":"cp-util","caller":"cp/cp.go:78","msg":"Installing BPF Binary..","target":"/host/opt/cni/bin/v4events.bpf.o","source":"v4events.bpf.o"}
{"level":"info","ts":"2025-03-26T23:45:46.568Z","logger":"cp-util","caller":"cp/cp.go:83","msg":"Successfully installed - ","binary":"/host/opt/cni/bin/v4events.bpf.o"}
{"level":"info","ts":"2025-03-26T23:45:46.569Z","logger":"cp-util","caller":"cp/cp.go:78","msg":"Installing BPF Binary..","target":"/host/opt/cni/bin/tc.v4ingress.bpf.o","source":"tc.v4ingress.bpf.o"}
{"level":"info","ts":"2025-03-26T23:45:46.569Z","logger":"cp-util","caller":"cp/cp.go:83","msg":"Successfully installed - ","binary":"/host/opt/cni/bin/tc.v4ingress.bpf.o"}
{"level":"info","ts":"2025-03-26T23:45:46.569Z","logger":"cp-util","caller":"cp/cp.go:78","msg":"Installing BPF Binary..","target":"/host/opt/cni/bin/tc.v4egress.bpf.o","source":"tc.v4egress.bpf.o"}
{"level":"info","ts":"2025-03-26T23:45:46.569Z","logger":"cp-util","caller":"cp/cp.go:83","msg":"Successfully installed - ","binary":"/host/opt/cni/bin/tc.v4egress.bpf.o"}
{"level":"info","ts":"2025-03-26T23:45:46.569Z","logger":"cp-util","caller":"cp/cp.go:78","msg":"Installing BPF Binary..","target":"/host/opt/cni/bin/aws-eks-na-cli","source":"aws-eks-na-cli"}
{"level":"info","ts":"2025-03-26T23:45:46.580Z","logger":"cp-util","caller":"cp/cp.go:83","msg":"Successfully installed - ","binary":"/host/opt/cni/bin/aws-eks-na-cli"}
{"level":"info","ts":"2025-03-26T23:45:46.580Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:193","msg":"Copied eBPF binaries to the host directory"}
{"level":"info","ts":"2025-03-26T23:45:46.580Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:395","msg":"Total no.of  global maps recovered...","count: ":2}
{"level":"info","ts":"2025-03-26T23:45:46.580Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:397","msg":"Global Map..","Name: ":"/sys/fs/bpf/globals/aws/maps/global_policy_events","updateEventsProbe: ":false}
{"level":"info","ts":"2025-03-26T23:45:46.580Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:406","msg":"Policy event Map is already present on the node ","Recovered FD":10}
{"level":"info","ts":"2025-03-26T23:45:46.580Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:397","msg":"Global Map..","Name: ":"/sys/fs/bpf/globals/aws/maps/global_aws_conntrack_map","updateEventsProbe: ":false}
{"level":"info","ts":"2025-03-26T23:45:46.580Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:399","msg":"Conntrack Map is already present on the node"}
{"level":"info","ts":"2025-03-26T23:45:46.582Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:422","msg":"Number of probes/maps recovered - ","count: ":4}
{"level":"info","ts":"2025-03-26T23:45:46.582Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:424","msg":"Recovered program Identifier: ","Pin Path: ":"/sys/fs/bpf/globals/aws/programs/nginx-statefulset-default_handle_egress"}
{"level":"info","ts":"2025-03-26T23:45:46.582Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:426","msg":"PinPath: ","podIdentifier: ":"nginx-statefulset-default","direction: ":"egress"}
{"level":"info","ts":"2025-03-26T23:45:46.582Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:424","msg":"Recovered program Identifier: ","Pin Path: ":"/sys/fs/bpf/globals/aws/programs/nginx-statefulset-default_handle_ingress"}
{"level":"info","ts":"2025-03-26T23:45:46.582Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:426","msg":"PinPath: ","podIdentifier: ":"nginx-statefulset-default","direction: ":"ingress"}
{"level":"info","ts":"2025-03-26T23:45:46.582Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:424","msg":"Recovered program Identifier: ","Pin Path: ":"/sys/fs/bpf/globals/aws/programs/tester1-7bc45864b4-default_handle_egress"}
{"level":"info","ts":"2025-03-26T23:45:46.582Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:426","msg":"PinPath: ","podIdentifier: ":"tester1-7bc45864b4-default","direction: ":"egress"}
{"level":"info","ts":"2025-03-26T23:45:46.582Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:424","msg":"Recovered program Identifier: ","Pin Path: ":"/sys/fs/bpf/globals/aws/programs/tester1-7bc45864b4-default_handle_ingress"}
{"level":"info","ts":"2025-03-26T23:45:46.582Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:426","msg":"PinPath: ","podIdentifier: ":"tester1-7bc45864b4-default","direction: ":"ingress"}
{"level":"info","ts":"2025-03-26T23:45:46.582Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:205","msg":"Successfully recovered BPF state"}
{"level":"info","ts":"2025-03-26T23:45:46.582Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:250","msg":"Derived existing ConntrackMap identifier"}
{"level":"info","ts":"2025-03-26T23:45:46.582Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:259","msg":"Initialized Conntrack client"}
{"level":"info","ts":"2025-03-26T23:45:46.582Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:270","msg":"Disabled event logging"}
{"level":"info","ts":"2025-03-26T23:45:46.582Z","logger":"ebpf-client","caller":"ebpf/bpf_client.go:285","msg":"BPF Client initialization done"}
{"level":"info","ts":"2025-03-26T23:45:46.582Z","logger":"ebpf-client","caller":"conntrack/conntrack_client.go:54","msg":"Check for any stale entries in the conntrack map"}
{"level":"info","ts":"2025-03-26T23:45:46.583Z","logger":"rpc-handler","caller":"rpc/rpc_handler.go:170","msg":"Serving RPC Handler","Address":"127.0.0.1:50052"}
{"level":"info","ts":"2025-03-26T23:45:46.582Z","logger":"setup","caller":"workspace/main.go:133","msg":"starting manager"}
{"level":"info","ts":"2025-03-26T23:45:46.584Z","logger":"controller-runtime.metrics","caller":"server/server.go:208","msg":"Starting metrics server"}
{"level":"info","ts":"2025-03-26T23:45:46.584Z","logger":"controller-runtime.metrics","caller":"server/server.go:247","msg":"Serving metrics server","bindAddress":":8162","secure":false}
{"level":"info","ts":"2025-03-26T23:45:46.584Z","caller":"manager/server.go:83","msg":"starting server","name":"health probe","addr":"[::]:8163"}
{"level":"info","ts":"2025-03-26T23:45:46.584Z","caller":"controller/controller.go:175","msg":"Starting EventSource","controller":"policyendpoint","controllerGroup":"networking.k8s.aws","controllerKind":"PolicyEndpoint","source":"kind source: *v1alpha1.PolicyEndpoint"}
{"level":"info","ts":"2025-03-26T23:45:46.584Z","caller":"controller/controller.go:183","msg":"Starting Controller","controller":"policyendpoint","controllerGroup":"networking.k8s.aws","controllerKind":"PolicyEndpoint"}
{"level":"info","ts":"2025-03-26T23:45:46.694Z","caller":"controller/controller.go:217","msg":"Starting workers","controller":"policyendpoint","controllerGroup":"networking.k8s.aws","controllerKind":"PolicyEndpoint","worker count":1}
```
Created and deleted basic network policy with pods, logs in npa: https://paste.amazon.com/show/sonyingy/1743033069
```
dev-dsk-sonyingy-2c-61cf589a % k apply -f allow_ingress.yaml
networkpolicy.networking.k8s.io/allow-all-ingress created

dev-dsk-sonyingy-2c-61cf589a % k apply -f allow_egress.yaml
networkpolicy.networking.k8s.io/allow-all-egress created

dev-dsk-sonyingy-2c-61cf589a % k scale statefulset nginx-statefulset --replicas 0
statefulset.apps/nginx-statefulset scaled

dev-dsk-sonyingy-2c-61cf589a % k scale statefulset nginx-statefulset --replicas 2
statefulset.apps/nginx-statefulset scaled

dev-dsk-sonyingy-2c-61cf589a % k get pods -A
NAMESPACE     NAME                      READY   STATUS    RESTARTS   AGE
default       nginx-statefulset-0       1/1     Running   0          95s
default       nginx-statefulset-1       1/1     Running   0          94s
kube-system   aws-node-bmv8r            2/2     Running   0          5m48s
kube-system   coredns-56fb86bd4-8jmmb   1/1     Running   0          7d
kube-system   coredns-56fb86bd4-mr9c7   1/1     Running   0          7d
kube-system   kube-proxy-qt5jt          1/1     Running   0          5h5m
```