### PR TITLE
[WIP] fix: cleaning stale map entries when NP is deleted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ amazon-network-policy-controller-k8s
 
 # Test build files
 test/build/
+.vscode

--- a/controllers/policyendpoints_controller.go
+++ b/controllers/policyendpoints_controller.go
@@ -586,8 +586,12 @@ func (r *PolicyEndpointsReconciler) deriveTargetPodsForParentNP(ctx context.Cont
 		}
 	}
 
-	//Update active podIdentifiers selected by the current Network Policy
-	r.networkPolicyToPodIdentifierMap.Store(utils.GetParentNPNameFromPEName(resourceName), targetPodIdentifiers)
+	// Update active podIdentifiers selected by the current Network Policy
+	if len(targetPodIdentifiers) == 0 {
+		r.networkPolicyToPodIdentifierMap.Delete(utils.GetParentNPNameFromPEName(resourceName))
+	} else {
+		r.networkPolicyToPodIdentifierMap.Store(utils.GetParentNPNameFromPEName(resourceName), targetPodIdentifiers)
+	}
 
 	if len(currentPods) > 0 {
 		podsToBeCleanedUp = r.getPodListToBeCleanedUp(currentPods, targetPods, podIdentifiers)
@@ -709,7 +713,11 @@ func (r *PolicyEndpointsReconciler) deletePolicyEndpointFromPodIdentifierMap(ctx
 			}
 			currentPEList = append(currentPEList, policyEndpointName)
 		}
-		r.podIdentifierToPolicyEndpointMap.Store(podIdentifier, currentPEList)
+		if len(currentPEList) == 0 {
+			r.podIdentifierToPolicyEndpointMap.Delete(podIdentifier)
+		} else {
+			r.podIdentifierToPolicyEndpointMap.Store(podIdentifier, currentPEList)
+		}
 	}
 }
 

--- a/controllers/policyendpoints_controller_test.go
+++ b/controllers/policyendpoints_controller_test.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"context"
+	"os"
+	"sync"
 	"testing"
 
 	policyendpoint "github.com/aws/aws-network-policy-agent/api/v1alpha1"
@@ -9,14 +11,322 @@ import (
 	"github.com/aws/aws-network-policy-agent/pkg/ebpf"
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
+
+func TestPolicyEndpointReconcile(t *testing.T) {
+	namespace := "my-namespace"
+	p1N1 := policyendpoint.PodEndpoint{
+		HostIP:    "1.1.1.1",
+		PodIP:     "10.1.1.1",
+		Name:      "deployment1rs-1",
+		Namespace: namespace,
+	}
+	p2N1 := policyendpoint.PodEndpoint{
+		HostIP:    "1.1.1.1",
+		PodIP:     "10.1.1.2",
+		Name:      "deployment1rs-2",
+		Namespace: namespace,
+	}
+	p1N2 := policyendpoint.PodEndpoint{
+		HostIP:    "1.1.1.2",
+		PodIP:     "10.1.1.3",
+		Name:      "deployment2rs-3",
+		Namespace: namespace,
+	}
+
+	nodeIp := "1.1.1.1"
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("Reconcile call for Create PolicyEndpoint with PodEndpoint local to Node", func(t *testing.T) {
+		mockClient := mock_client.NewMockClient(ctrl)
+		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout)), nodeIp, &ebpf.MockBpfClient{})
+
+		policyEndpoint := getPolicyEndpoint("allow-all-egress", "my-namespace", []policyendpoint.PodEndpoint{p1N1, p2N1})
+
+		mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{
+			Name:      policyEndpoint.GetName(),
+			Namespace: policyEndpoint.GetNamespace(),
+		}, gomock.Any()).DoAndReturn(
+			func(ctx context.Context, key types.NamespacedName, currentPE *policyendpoint.PolicyEndpoint, opts ...client.GetOption) error {
+				*currentPE = policyEndpoint
+				return nil
+			},
+		).AnyTimes()
+
+		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&policyendpoint.PolicyEndpointList{}), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, list *policyendpoint.PolicyEndpointList, opts ...*client.ListOptions) error {
+				*list = policyendpoint.PolicyEndpointList{
+					Items: []policyendpoint.PolicyEndpoint{policyEndpoint},
+				}
+				return nil
+			},
+		).AnyTimes()
+
+		_, err := policyEndpointReconciler.Reconcile(context.TODO(), controllerruntime.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      policyEndpoint.GetName(),
+				Namespace: policyEndpoint.GetNamespace(),
+			},
+		})
+
+		assert.Nil(t, err)
+		val, ok := policyEndpointReconciler.networkPolicyToPodIdentifierMap.Load("allow-all-egress")
+		assert.True(t, ok)
+		assert.True(t, lo.Contains(val.([]string), "deployment1rs-my-namespace"))
+
+		val, ok = policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Load("deployment1rs-my-namespace")
+		assert.True(t, ok)
+		assert.True(t, lo.Contains(val.([]string), "allow-all-egress-abcd"))
+
+		val, ok = policyEndpointReconciler.policyEndpointSelectorMap.Load("allow-all-egress-abcdmy-namespace")
+		assert.True(t, ok)
+		assert.Equal(t, 2, len(val.([]types.NamespacedName)))
+	})
+
+	t.Run("Reconcile for Create and Delete PE", func(t *testing.T) {
+		mockClient := mock_client.NewMockClient(ctrl)
+		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout)), nodeIp, &ebpf.MockBpfClient{})
+
+		policyEndpoint := getPolicyEndpoint("allow-all-egress", "my-namespace", []policyendpoint.PodEndpoint{p1N1, p2N1})
+
+		mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{
+			Name:      policyEndpoint.GetName(),
+			Namespace: policyEndpoint.GetNamespace(),
+		}, gomock.Any()).DoAndReturn(
+			func(ctx context.Context, key types.NamespacedName, currentPE *policyendpoint.PolicyEndpoint, opts ...client.GetOption) error {
+				*currentPE = policyEndpoint
+				return nil
+			},
+		).MaxTimes(3)
+
+		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&policyendpoint.PolicyEndpointList{}), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, list *policyendpoint.PolicyEndpointList, opts ...*client.ListOptions) error {
+				*list = policyendpoint.PolicyEndpointList{
+					Items: []policyendpoint.PolicyEndpoint{policyEndpoint},
+				}
+				return nil
+			},
+		).MaxTimes(1)
+
+		_, err := policyEndpointReconciler.Reconcile(context.TODO(), controllerruntime.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      policyEndpoint.GetName(),
+				Namespace: policyEndpoint.GetNamespace(),
+			},
+		})
+
+		assert.Nil(t, err)
+		val, ok := policyEndpointReconciler.networkPolicyToPodIdentifierMap.Load("allow-all-egress")
+		assert.True(t, ok)
+		assert.True(t, lo.Contains(val.([]string), "deployment1rs-my-namespace"))
+
+		val, ok = policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Load("deployment1rs-my-namespace")
+		assert.True(t, ok)
+		assert.True(t, lo.Contains(val.([]string), "allow-all-egress-abcd"))
+
+		val, ok = policyEndpointReconciler.policyEndpointSelectorMap.Load("allow-all-egress-abcdmy-namespace")
+		assert.True(t, ok)
+		assert.Equal(t, 2, len(val.([]types.NamespacedName)))
+
+		mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{
+			Name:      policyEndpoint.GetName(),
+			Namespace: policyEndpoint.GetNamespace(),
+		}, gomock.Any()).DoAndReturn(
+			func(ctx context.Context, key types.NamespacedName, currentPE *policyendpoint.PolicyEndpoint, opts ...client.GetOption) error {
+				return apierrors.NewNotFound(schema.GroupResource{Group: networking.SchemeGroupVersion.Group, Resource: ""}, "")
+			},
+		).AnyTimes()
+
+		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&policyendpoint.PolicyEndpointList{}), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, list *policyendpoint.PolicyEndpointList, opts ...*client.ListOptions) error {
+				*list = policyendpoint.PolicyEndpointList{}
+				return nil
+			},
+		).AnyTimes()
+
+		_, err = policyEndpointReconciler.Reconcile(context.TODO(), controllerruntime.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      policyEndpoint.GetName(),
+				Namespace: policyEndpoint.GetNamespace(),
+			},
+		})
+		assert.Nil(t, err)
+		assert.Equal(t, 0, sizeOfSyncMap(&policyEndpointReconciler.networkPolicyToPodIdentifierMap))
+		assert.Equal(t, 0, sizeOfSyncMap(&policyEndpointReconciler.podIdentifierToPolicyEndpointMap))
+		assert.Equal(t, 0, sizeOfSyncMap(&policyEndpointReconciler.policyEndpointSelectorMap))
+
+	})
+
+	t.Run("Reconcile with PE having PodEndpoints local and non-local to Node", func(t *testing.T) {
+		mockClient := mock_client.NewMockClient(ctrl)
+		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout)), nodeIp, &ebpf.MockBpfClient{})
+
+		policyEndpoint := getPolicyEndpoint("allow-all-egress", "my-namespace", []policyendpoint.PodEndpoint{p1N1, p2N1, p1N2})
+
+		mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{
+			Name:      policyEndpoint.GetName(),
+			Namespace: policyEndpoint.GetNamespace(),
+		}, gomock.Any()).DoAndReturn(
+			func(ctx context.Context, key types.NamespacedName, currentPE *policyendpoint.PolicyEndpoint, opts ...client.GetOption) error {
+				*currentPE = policyEndpoint
+				return nil
+			},
+		).AnyTimes()
+
+		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&policyendpoint.PolicyEndpointList{}), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, list *policyendpoint.PolicyEndpointList, opts ...*client.ListOptions) error {
+				*list = policyendpoint.PolicyEndpointList{
+					Items: []policyendpoint.PolicyEndpoint{policyEndpoint},
+				}
+				return nil
+			},
+		).AnyTimes()
+
+		_, err := policyEndpointReconciler.Reconcile(context.TODO(), controllerruntime.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      policyEndpoint.GetName(),
+				Namespace: policyEndpoint.GetNamespace(),
+			},
+		})
+
+		assert.Nil(t, err)
+		val, ok := policyEndpointReconciler.networkPolicyToPodIdentifierMap.Load("allow-all-egress")
+		assert.True(t, ok)
+		assert.True(t, lo.Contains(val.([]string), "deployment1rs-my-namespace"))
+
+		val, ok = policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Load("deployment1rs-my-namespace")
+		assert.True(t, ok)
+		assert.True(t, lo.Contains(val.([]string), "allow-all-egress-abcd"))
+
+		val, ok = policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Load("deployment2rs-my-namespace")
+		assert.True(t, ok)
+		assert.True(t, lo.Contains(val.([]string), "allow-all-egress-abcd"))
+
+		val, ok = policyEndpointReconciler.policyEndpointSelectorMap.Load("allow-all-egress-abcdmy-namespace")
+		assert.True(t, ok)
+		assert.Equal(t, 2, len(val.([]types.NamespacedName)))
+	})
+
+	t.Run("Reconcile for Create and Delete PE having PodEndpoints local and non-local to Node", func(t *testing.T) {
+		mockClient := mock_client.NewMockClient(ctrl)
+		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout)), nodeIp, &ebpf.MockBpfClient{})
+
+		policyEndpoint := getPolicyEndpoint("allow-all-egress", namespace, []policyendpoint.PodEndpoint{p1N1, p2N1, p1N2})
+
+		mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{
+			Name:      policyEndpoint.GetName(),
+			Namespace: policyEndpoint.GetNamespace(),
+		}, gomock.Any()).DoAndReturn(
+			func(ctx context.Context, key types.NamespacedName, currentPE *policyendpoint.PolicyEndpoint, opts ...client.GetOption) error {
+				*currentPE = policyEndpoint
+				return nil
+			},
+		).MaxTimes(3)
+
+		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&policyendpoint.PolicyEndpointList{}), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, list *policyendpoint.PolicyEndpointList, opts ...*client.ListOptions) error {
+				*list = policyendpoint.PolicyEndpointList{
+					Items: []policyendpoint.PolicyEndpoint{policyEndpoint},
+				}
+				return nil
+			},
+		).MaxTimes(1)
+
+		_, err := policyEndpointReconciler.Reconcile(context.TODO(), controllerruntime.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      policyEndpoint.GetName(),
+				Namespace: policyEndpoint.GetNamespace(),
+			},
+		})
+
+		assert.Nil(t, err)
+		val, ok := policyEndpointReconciler.networkPolicyToPodIdentifierMap.Load("allow-all-egress")
+		assert.True(t, ok)
+		assert.True(t, lo.Contains(val.([]string), "deployment1rs-my-namespace"))
+
+		val, ok = policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Load("deployment1rs-my-namespace")
+		assert.True(t, ok)
+		assert.True(t, lo.Contains(val.([]string), "allow-all-egress-abcd"))
+
+		// we store non-local PodIds also to immediately apply NP if Pod belonging to PodId lands on this node
+		val, ok = policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Load("deployment2rs-my-namespace")
+		assert.True(t, ok)
+		assert.True(t, lo.Contains(val.([]string), "allow-all-egress-abcd"))
+
+		val, ok = policyEndpointReconciler.policyEndpointSelectorMap.Load("allow-all-egress-abcdmy-namespace")
+		assert.True(t, ok)
+		assert.Equal(t, 2, len(val.([]types.NamespacedName)))
+
+		mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{
+			Name:      policyEndpoint.GetName(),
+			Namespace: policyEndpoint.GetNamespace(),
+		}, gomock.Any()).DoAndReturn(
+			func(ctx context.Context, key types.NamespacedName, currentPE *policyendpoint.PolicyEndpoint, opts ...client.GetOption) error {
+				return apierrors.NewNotFound(schema.GroupResource{Group: networking.SchemeGroupVersion.Group, Resource: ""}, "")
+			},
+		).AnyTimes()
+
+		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&policyendpoint.PolicyEndpointList{}), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, list *policyendpoint.PolicyEndpointList, opts ...*client.ListOptions) error {
+				*list = policyendpoint.PolicyEndpointList{}
+				return nil
+			},
+		).AnyTimes()
+
+		_, err = policyEndpointReconciler.Reconcile(context.TODO(), controllerruntime.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      policyEndpoint.GetName(),
+				Namespace: policyEndpoint.GetNamespace(),
+			},
+		})
+		assert.Nil(t, err)
+		assert.Equal(t, 0, sizeOfSyncMap(&policyEndpointReconciler.networkPolicyToPodIdentifierMap))
+		assert.Equal(t, 0, sizeOfSyncMap(&policyEndpointReconciler.podIdentifierToPolicyEndpointMap))
+		assert.Equal(t, 0, sizeOfSyncMap(&policyEndpointReconciler.policyEndpointSelectorMap))
+	})
+
+}
+
+func getPolicyEndpoint(npName string, namespace string, podEndpoints []policyendpoint.PodEndpoint) policyendpoint.PolicyEndpoint {
+	return policyendpoint.PolicyEndpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      npName + "-abcd",
+			Namespace: namespace,
+		},
+		Spec: policyendpoint.PolicyEndpointSpec{
+			PodSelector:          &metav1.LabelSelector{},
+			PodSelectorEndpoints: podEndpoints,
+			PolicyRef: policyendpoint.PolicyReference{
+				Name:      npName,
+				Namespace: namespace,
+			},
+			Egress: []policyendpoint.EndpointInfo{},
+		},
+	}
+}
+
+func sizeOfSyncMap(m *sync.Map) int {
+	count := 0
+	m.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	return count
+}
 
 func TestIsProgFdShared(t *testing.T) {
 	type want struct {
@@ -59,8 +369,7 @@ func TestIsProgFdShared(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockClient := mock_client.NewMockClient(ctrl)
-		policyEndpointReconciler, _ := NewPolicyEndpointsReconciler(mockClient, logr.New(&log.NullLogSink{}),
-			false, false, false, false, 300, 262144)
+		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, logr.New(&log.NullLogSink{}), "", nil)
 		policyEndpointReconciler.ebpfClient = ebpf.NewMockBpfClient()
 		for pod, progFd := range podToProgFd {
 			policyEndpointReconciler.ebpfClient.GetIngressPodToProgMap().Store(pod, progFd)
@@ -385,8 +694,7 @@ func TestDeriveIngressAndEgressFirewallRules(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockClient := mock_client.NewMockClient(ctrl)
-		policyEndpointReconciler, _ := NewPolicyEndpointsReconciler(mockClient, logr.New(&log.NullLogSink{}),
-			false, false, false, false, 300, 262144)
+		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, logr.New(&log.NullLogSink{}), "", nil)
 		var policyEndpointsList []string
 		policyEndpointsList = append(policyEndpointsList, tt.policyEndpointName)
 		policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Store(tt.podIdentifier, policyEndpointsList)
@@ -591,7 +899,7 @@ func TestDeriveTargetPods(t *testing.T) {
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			gotActivePods, _ := policyEndpointReconciler.deriveTargetPods(context.Background(),
+			gotActivePods, _, _ := policyEndpointReconciler.deriveTargetPods(context.Background(),
 				&tt.policyendpoint, tt.parentPEList)
 			assert.Equal(t, tt.want.activePods, gotActivePods)
 		})
@@ -804,8 +1112,7 @@ func TestArePoliciesAvailableInLocalCache(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockClient := mock_client.NewMockClient(ctrl)
-		policyEndpointReconciler, _ := NewPolicyEndpointsReconciler(mockClient, logr.New(&log.NullLogSink{}),
-			false, false, false, false, 300, 262144)
+		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, logr.New(&log.NullLogSink{}), "", nil)
 		var policyEndpointsList []string
 		policyEndpointsList = append(policyEndpointsList, tt.policyEndpointName...)
 		policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Store(tt.podIdentifier, policyEndpointsList)
@@ -1050,8 +1357,7 @@ func TestDeriveFireWallRulesPerPodIdentifier(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockClient := mock_client.NewMockClient(ctrl)
-		policyEndpointReconciler, _ := NewPolicyEndpointsReconciler(mockClient, logr.New(&log.NullLogSink{}),
-			false, false, false, false, 300, 262144)
+		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, logr.New(&log.NullLogSink{}), "", nil)
 		var policyEndpointsList []string
 		policyEndpointsList = append(policyEndpointsList, tt.policyEndpointName)
 		policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Store(tt.podIdentifier, policyEndpointsList)

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/samber/lo v1.50.0
 	github.com/vishvananda/netns v0.0.4 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoG
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/samber/lo v1.50.0 h1:XrG0xOeHs+4FQ8gJR97zDz5uOFMW7OwFWiFVzqopKgY=
+github.com/samber/lo v1.50.0/go.mod h1:RjZyNk6WSnUFRKK6EyOhsRJMqft3G+pg7dCWHQCWvsc=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -136,12 +136,12 @@ type EbpfFirewallRules struct {
 	L4Info []v1alpha1.Port
 }
 
-func NewBpfClient(policyEndpointeBPFContext *sync.Map, nodeIP string, enablePolicyEventLogs, enableCloudWatchLogs bool,
+func NewBpfClient(nodeIP string, enablePolicyEventLogs, enableCloudWatchLogs bool,
 	enableIPv6 bool, conntrackTTL int, conntrackTableSize int) (*bpfClient, error) {
 	var conntrackMap goebpfmaps.BpfMap
 
 	ebpfClient := &bpfClient{
-		policyEndpointeBPFContext: policyEndpointeBPFContext,
+		policyEndpointeBPFContext: new(sync.Map),
 		IngressPodToProgMap:       new(sync.Map),
 		EgressPodToProgMap:        new(sync.Map),
 		nodeIP:                    nodeIP,
@@ -196,7 +196,7 @@ func NewBpfClient(policyEndpointeBPFContext *sync.Map, nodeIP string, enablePoli
 	var interfaceNametoIngressPinPath map[string]string
 	var interfaceNametoEgressPinPath map[string]string
 	eventBufferFD := 0
-	isConntrackMapPresent, isPolicyEventsMapPresent, eventBufferFD, interfaceNametoIngressPinPath, interfaceNametoEgressPinPath, err = recoverBPFState(ebpfClient.bpfTCClient, ebpfClient.bpfSDKClient, policyEndpointeBPFContext,
+	isConntrackMapPresent, isPolicyEventsMapPresent, eventBufferFD, interfaceNametoIngressPinPath, interfaceNametoEgressPinPath, err = recoverBPFState(ebpfClient.bpfTCClient, ebpfClient.bpfSDKClient, ebpfClient.policyEndpointeBPFContext,
 		ebpfClient.GlobalMaps, ingressUpdateRequired, egressUpdateRequired, eventsUpdateRequired)
 	if err != nil {
 		//Log the error and move on

--- a/pkg/ebpf/bpf_client_mock.go
+++ b/pkg/ebpf/bpf_client_mock.go
@@ -3,6 +3,7 @@ package ebpf
 import (
 	"sync"
 
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -21,4 +22,56 @@ func NewMockBpfClient() BpfClient {
 		hostMask:                  "/32",
 		logger:                    ctrl.Log.WithName("mock-bpfclient"),
 	}
+}
+
+type MockBpfClient struct{}
+
+func (m *MockBpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier string) error {
+	return nil
+}
+
+func (m *MockBpfClient) UpdateEbpfMaps(podIdentifier string, ingressFirewallRules []EbpfFirewallRules, egressFirewallRules []EbpfFirewallRules) error {
+	return nil
+}
+
+func (m *MockBpfClient) UpdatePodStateEbpfMaps(podIdentifier string, state int, updateIngress bool, updateEgress bool) error {
+	return nil
+}
+
+func (m *MockBpfClient) IsEBPFProbeAttached(podName string, podNamespace string) (bool, bool) {
+	return false, false
+}
+
+func (m *MockBpfClient) IsFirstPodInPodIdentifier(podIdentifier string) bool {
+	return false
+}
+func (m *MockBpfClient) GetIngressPodToProgMap() *sync.Map {
+	return nil
+}
+func (m *MockBpfClient) GetEgressPodToProgMap() *sync.Map {
+	return nil
+}
+func (m *MockBpfClient) GetIngressProgToPodsMap() *sync.Map {
+	return nil
+}
+func (m *MockBpfClient) GetEgressProgToPodsMap() *sync.Map {
+	return nil
+}
+
+func (m *MockBpfClient) DeletePodFromIngressProgPodCaches(podName string, podNamespace string) {
+}
+
+func (m *MockBpfClient) DeletePodFromEgressProgPodCaches(podName string, podNamespace string) {
+}
+
+func (m *MockBpfClient) ReAttachEbpfProbes() error {
+	return nil
+}
+
+func (m *MockBpfClient) DeleteBPFProgramAndMaps(podIdentifier string) error {
+	return nil
+}
+
+func (m *MockBpfClient) GetDeletePodIdentifierLockMap() *sync.Map {
+	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*

currently `networkPolicyToPodIdentifierMap` and `podIdentifierToPolicyEndpointMap` are not getting cleaned up when NP is deleted 

*Description of changes:*
this change cleans up stale entries from map when NP is deleted.

manual testing logs
```
test case
- create a deployment
- create 2 NP
- delete both NP and check map states

buggy scenario

Created NP and deployment

{"level":"info","ts":"2025-05-08T16:23:27.887Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:158","msg":"NetworkPolicyToPodIdentifierMap","key: ":"deny-all-egress","
value: ":["nginx-deployment-758c8f7769-default"]}
{"level":"info","ts":"2025-05-08T16:23:27.887Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:158","msg":"NetworkPolicyToPodIdentifierMap","key: ":"allow-all-egress","value: ":["nginx-deployment-758c8f7769-default"]}
{"level":"info","ts":"2025-05-08T16:23:27.887Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:162","msg":"PodIdentifierToPolicyEndpointMap","key: ":"nginx-deployment-758c8f7769-default","value: ":["allow-all-egress-rjnb9","deny-all-egress-9c962"]}
{"level":"info","ts":"2025-05-08T16:23:27.887Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:166","msg":"PolicyEndpointSelectorMap","key: ":"deny-all-egress-9c962default","value: ":[{"Namespace":"default","Name":"nginx-deployment-758c8f7769-hn4n8"},{"Namespace":"default","Name":"nginx-deployment-758c8f7769-4ss5s"}]}
{"level":"info","ts":"2025-05-08T16:23:27.887Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:166","msg":"PolicyEndpointSelectorMap","key: ":"allow-all-egress-rjnb9default","value: ":[{"Namespace":"default","Name":"nginx-deployment-758c8f7769-hn4n8"},{"Namespace":"default","Name":"nginx-deployment-758c8f7769-4ss5s"}]}


after deleting NP and deployment, entries with empty key present in Map

{"level":"info","ts":"2025-05-08T16:25:47.448Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:158","msg":"NetworkPolicyToPodIdentifierMap","key: ":"deny-all-egress","
value: ":[]}
{"level":"info","ts":"2025-05-08T16:25:47.448Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:158","msg":"NetworkPolicyToPodIdentifierMap","key: ":"allow-all-egress","value: ":[]}
{"level":"info","ts":"2025-05-08T16:25:47.448Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:162","msg":"PodIdentifierToPolicyEndpointMap","key: ":"nginx-deployment-758c8f7769-default","value: ":[]}



Fix scenario

Created NP and deployment

{"level":"info","ts":"2025-05-08T16:43:31.986Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:157","msg":"logging map states"}
{"level":"info","ts":"2025-05-08T16:43:31.986Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:159","msg":"NetworkPolicyToPodIdentifierMap","key: ":"deny-all-egress","value: ":["nginx-deployment-758c8f7769-default"]}
{"level":"info","ts":"2025-05-08T16:43:31.986Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:159","msg":"NetworkPolicyToPodIdentifierMap","key: ":"allow-all-egress","value: ":["nginx-deployment-758c8f7769-default"]}
{"level":"info","ts":"2025-05-08T16:43:31.986Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:163","msg":"PodIdentifierToPolicyEndpointMap","key: ":"nginx-deployment-758c8f7769-default","value: ":["allow-all-egress-4w8nh","deny-all-egress-g59sk"]}
{"level":"info","ts":"2025-05-08T16:43:31.986Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:167","msg":"PolicyEndpointSelectorMap","key: ":"deny-all-egress-g59skdefault","value: ":[{"Namespace":"default","Name":"nginx-deployment-758c8f7769-5chhw"},{"Namespace":"default","Name":"nginx-deployment-758c8f7769-npg84"}]}
{"level":"info","ts":"2025-05-08T16:43:31.986Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:167","msg":"PolicyEndpointSelectorMap","key: ":"allow-all-egress-4w8nhdefault","value: ":[{"Namespace":"default","Name":"nginx-deployment-758c8f7769-5chhw"},{"Namespace":"default","Name":"nginx-deployment-758c8f7769-npg84"}]}

no entries in map post cleanup of NP and deployment

allow NP deleted

{"level":"info","ts":"2025-05-08T17:21:53.596Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:157","msg":"logging map states"}
{"level":"info","ts":"2025-05-08T17:21:53.596Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:159","msg":"NetworkPolicyToPodIdentifierMap","key: ":"deny-all-egress","
value: ":["nginx-deployment-758c8f7769-default"]}
{"level":"info","ts":"2025-05-08T17:21:53.596Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:163","msg":"PodIdentifierToPolicyEndpointMap","key: ":"nginx-deployment-758c8f7769-default","value: ":["deny-all-egress-kbkc7"]}
{"level":"info","ts":"2025-05-08T17:21:53.596Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:167","msg":"PolicyEndpointSelectorMap","key: ":"deny-all-egress-kbkc7default","value: ":[{"Namespace":"default","Name":"nginx-deployment-758c8f7769-khch5"},{"Namespace":"default","Name":"nginx-deployment-758c8f7769-2vg7b"}]}

delete NP deleted

{"level":"info","ts":"2025-05-08T17:24:12.529Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:157","msg":"logging map states"}


create both NP again 

{"level":"info","ts":"2025-05-08T17:26:40.491Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:157","msg":"logging map states"}
{"level":"info","ts":"2025-05-08T17:26:40.491Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:159","msg":"NetworkPolicyToPodIdentifierMap","key: ":"deny-all-egress","value: ":["nginx-deployment-758c8f7769-default"]}
{"level":"info","ts":"2025-05-08T17:26:40.491Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:159","msg":"NetworkPolicyToPodIdentifierMap","key: ":"allow-all-egress","value: ":["nginx-deployment-758c8f7769-default"]}
{"level":"info","ts":"2025-05-08T17:26:40.492Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:163","msg":"PodIdentifierToPolicyEndpointMap","key: ":"nginx-deployment-758c8f7769-default","value: ":["allow-all-egress-gm4mf","deny-all-egress-2x87h"]}
{"level":"info","ts":"2025-05-08T17:26:40.492Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:167","msg":"PolicyEndpointSelectorMap","key: ":"deny-all-egress-2x87hdefault","value: ":[{"Namespace":"default","Name":"nginx-deployment-758c8f7769-khch5"},{"Namespace":"default","Name":"nginx-deployment-758c8f7769-2vg7b"}]}
{"level":"info","ts":"2025-05-08T17:26:40.492Z","logger":"controllers.policyEndpoints","caller":"controllers/policyendpoints_controller.go:167","msg":"PolicyEndpointSelectorMap","key: ":"allow-all-egress-gm4mfdefault","value: ":[{"Namespace":"default","Name":"nginx-deployment-758c8f7769-2vg7b"},{"Namespace":"default","Name":"nginx-deployment-758c8f7769-khch5"}]}


```

- [wip] cyclonous test passed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
