### PR TITLE
Fix Ginkgo command flag placement in run-cyclonus-tests.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,5 +331,6 @@ clean: # Clean temporary files and build artifacts from the project
 
 build-test-binaries: # Builds the test suite binaries
 	mkdir -p ${MAKEFILE_PATH}test/build
+	cd ${MAKEFILE_PATH} && \
 	find ${MAKEFILE_PATH}test -name '*suite_test.go' -type f  | xargs dirname  | xargs ginkgo build
 	find ${MAKEFILE_PATH}test -name "*.test" -print0 | xargs -0 -I {} mv {} ${MAKEFILE_PATH}test/build

--- a/scripts/run-cyclonus-tests.sh
+++ b/scripts/run-cyclonus-tests.sh
@@ -105,7 +105,7 @@ if [[ $ENABLE_STRICT_MODE == "true" ]]; then
     echo "Check aws-node daemonset status"
     kubectl rollout status ds/aws-node -n kube-system --timeout=300s
 
-    CGO_ENABLED=0 ginkgo -v -timeout 15m $GINKGO_TEST_BUILD_DIR/strict.test --no-color --fail-on-pending -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --test-image-registry=$TEST_IMAGE_REGISTRY --ip-family=$IP_FAMILY || TEST_FAILED="true"
+    CGO_ENABLED=0 ginkgo -v -timeout 15m --no-color --fail-on-pending $GINKGO_TEST_BUILD_DIR/strict.test -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --test-image-registry=$TEST_IMAGE_REGISTRY --ip-family=$IP_FAMILY || TEST_FAILED="true"
 
 fi
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The Ginkgo command was failing with "Malformed arguments - detected a flag after the package list" error because the --no-color and --fail-on-pending flags were placed after the test binary path. This commit fixes the issue by moving these flags before the test binary path, following Ginkgo's required command structure where all flags must appear before the package list.


Looks like this error was introduced in 2.23.1 https://github.com/onsi/ginkgo/releases/tag/v2.23.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
