### PR TITLE
refactor: extracted FW rule processing code into pkg for better encapsulation

### DIFF
--- a/controllers/policyendpoints_controller_test.go
+++ b/controllers/policyendpoints_controller_test.go
@@ -8,6 +8,7 @@ import (
 	policyendpoint "github.com/aws/aws-network-policy-agent/api/v1alpha1"
 	mock_client "github.com/aws/aws-network-policy-agent/mocks/controller-runtime/client"
 	"github.com/aws/aws-network-policy-agent/pkg/ebpf"
+	fwrp "github.com/aws/aws-network-policy-agent/pkg/fwruleprocessor"
 	"github.com/golang/mock/gomock"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -257,8 +258,8 @@ func TestDeriveIngressAndEgressFirewallRules(t *testing.T) {
 	}
 
 	type want struct {
-		ingressRules      []ebpf.EbpfFirewallRules
-		egressRules       []ebpf.EbpfFirewallRules
+		ingressRules      []fwrp.EbpfFirewallRules
+		egressRules       []fwrp.EbpfFirewallRules
 		isIngressIsolated bool
 		isEgressIsolated  bool
 	}
@@ -415,7 +416,7 @@ func TestDeriveIngressAndEgressFirewallRules(t *testing.T) {
 				},
 			},
 			want: want{
-				ingressRules: []ebpf.EbpfFirewallRules{
+				ingressRules: []fwrp.EbpfFirewallRules{
 					{
 						IPCidr: "1.1.1.1/32",
 						L4Info: []policyendpoint.Port{
@@ -426,7 +427,7 @@ func TestDeriveIngressAndEgressFirewallRules(t *testing.T) {
 						},
 					},
 				},
-				egressRules: []ebpf.EbpfFirewallRules{
+				egressRules: []fwrp.EbpfFirewallRules{
 					{
 						IPCidr: "2.2.2.2/32",
 						L4Info: []policyendpoint.Port{
@@ -458,7 +459,7 @@ func TestDeriveIngressAndEgressFirewallRules(t *testing.T) {
 				},
 			},
 			want: want{
-				ingressRules: []ebpf.EbpfFirewallRules{
+				ingressRules: []fwrp.EbpfFirewallRules{
 					{
 						IPCidr: "1.1.1.1/32",
 						L4Info: []policyendpoint.Port{
@@ -490,7 +491,7 @@ func TestDeriveIngressAndEgressFirewallRules(t *testing.T) {
 				},
 			},
 			want: want{
-				egressRules: []ebpf.EbpfFirewallRules{
+				egressRules: []fwrp.EbpfFirewallRules{
 					{
 						IPCidr: "2.2.2.2/32",
 						L4Info: []policyendpoint.Port{
@@ -770,7 +771,7 @@ func TestAddCatchAllEntry(t *testing.T) {
 	protocolTCP := corev1.ProtocolTCP
 	var port80 int32 = 80
 
-	sampleFirewallRules := []ebpf.EbpfFirewallRules{
+	sampleFirewallRules := []fwrp.EbpfFirewallRules{
 		{
 			IPCidr: "1.1.1.1/32",
 			L4Info: []policyendpoint.Port{
@@ -782,18 +783,18 @@ func TestAddCatchAllEntry(t *testing.T) {
 		},
 	}
 
-	catchAllFirewallRule := ebpf.EbpfFirewallRules{
+	catchAllFirewallRule := fwrp.EbpfFirewallRules{
 		IPCidr: "0.0.0.0/0",
 	}
 
-	var sampleFirewallRulesWithCatchAllEntry []ebpf.EbpfFirewallRules
+	var sampleFirewallRulesWithCatchAllEntry []fwrp.EbpfFirewallRules
 	sampleFirewallRulesWithCatchAllEntry = append(sampleFirewallRulesWithCatchAllEntry, sampleFirewallRules...)
 	sampleFirewallRulesWithCatchAllEntry = append(sampleFirewallRulesWithCatchAllEntry, catchAllFirewallRule)
 
 	tests := []struct {
 		name          string
-		firewallRules []ebpf.EbpfFirewallRules
-		want          []ebpf.EbpfFirewallRules
+		firewallRules []fwrp.EbpfFirewallRules
+		want          []fwrp.EbpfFirewallRules
 	}{
 		{
 			name:          "Append Catch All Entry",
@@ -994,8 +995,8 @@ func TestDeriveFireWallRulesPerPodIdentifier(t *testing.T) {
 	}
 
 	type want struct {
-		ingressRules      []ebpf.EbpfFirewallRules
-		egressRules       []ebpf.EbpfFirewallRules
+		ingressRules      []fwrp.EbpfFirewallRules
+		egressRules       []fwrp.EbpfFirewallRules
 		isIngressIsolated bool
 		isEgressIsolated  bool
 	}
@@ -1118,7 +1119,7 @@ func TestDeriveFireWallRulesPerPodIdentifier(t *testing.T) {
 				},
 			},
 			want: want{
-				ingressRules: []ebpf.EbpfFirewallRules{
+				ingressRules: []fwrp.EbpfFirewallRules{
 					{
 						IPCidr: "1.1.1.1/32",
 						L4Info: []policyendpoint.Port{
@@ -1129,7 +1130,7 @@ func TestDeriveFireWallRulesPerPodIdentifier(t *testing.T) {
 						},
 					},
 				},
-				egressRules: []ebpf.EbpfFirewallRules{
+				egressRules: []fwrp.EbpfFirewallRules{
 					{
 						IPCidr: "2.2.2.2/32",
 						L4Info: []policyendpoint.Port{
@@ -1160,7 +1161,7 @@ func TestDeriveFireWallRulesPerPodIdentifier(t *testing.T) {
 				},
 			},
 			want: want{
-				ingressRules: []ebpf.EbpfFirewallRules{
+				ingressRules: []fwrp.EbpfFirewallRules{
 					{
 						IPCidr: "1.1.1.1/32",
 						L4Info: []policyendpoint.Port{
@@ -1192,7 +1193,7 @@ func TestDeriveFireWallRulesPerPodIdentifier(t *testing.T) {
 				},
 			},
 			want: want{
-				egressRules: []ebpf.EbpfFirewallRules{
+				egressRules: []fwrp.EbpfFirewallRules{
 					{
 						IPCidr: "2.2.2.2/32",
 						L4Info: []policyendpoint.Port{

--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -7,10 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"net"
-	"sort"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 	"unsafe"
@@ -21,9 +17,9 @@ import (
 	goelf "github.com/aws/aws-ebpf-sdk-go/pkg/elfparser"
 	goebpfmaps "github.com/aws/aws-ebpf-sdk-go/pkg/maps"
 	"github.com/aws/aws-ebpf-sdk-go/pkg/tc"
-	"github.com/aws/aws-network-policy-agent/api/v1alpha1"
 	"github.com/aws/aws-network-policy-agent/pkg/ebpf/conntrack"
 	"github.com/aws/aws-network-policy-agent/pkg/ebpf/events"
+	fwrp "github.com/aws/aws-network-policy-agent/pkg/fwruleprocessor"
 	"github.com/aws/aws-network-policy-agent/pkg/logger"
 	"github.com/aws/aws-network-policy-agent/pkg/rpcclient"
 	"github.com/aws/aws-network-policy-agent/pkg/utils"
@@ -108,7 +104,7 @@ func prometheusRegister() {
 
 type BpfClient interface {
 	AttacheBPFProbes(pod types.NamespacedName, policyEndpoint string) error
-	UpdateEbpfMaps(podIdentifier string, ingressFirewallRules []EbpfFirewallRules, egressFirewallRules []EbpfFirewallRules) error
+	UpdateEbpfMaps(podIdentifier string, ingressFirewallRules []fwrp.EbpfFirewallRules, egressFirewallRules []fwrp.EbpfFirewallRules) error
 	UpdatePodStateEbpfMaps(podIdentifier string, state int, updateIngress bool, updateEgress bool) error
 	IsEBPFProbeAttached(podName string, podNamespace string) (bool, bool)
 	IsFirstPodInPodIdentifier(podIdentifier string) bool
@@ -133,12 +129,6 @@ type BPFContext struct {
 	conntrackMapInfo goebpfmaps.BpfMap
 }
 
-type EbpfFirewallRules struct {
-	IPCidr v1alpha1.NetworkAddress
-	Except []v1alpha1.NetworkAddress
-	L4Info []v1alpha1.Port
-}
-
 func NewBpfClient(nodeIP string, enablePolicyEventLogs, enableCloudWatchLogs bool,
 	enableIPv6 bool, conntrackTTL int, conntrackTableSize int) (*bpfClient, error) {
 	var conntrackMap goebpfmaps.BpfMap
@@ -148,8 +138,6 @@ func NewBpfClient(nodeIP string, enablePolicyEventLogs, enableCloudWatchLogs boo
 		policyEndpointeBPFContext: new(sync.Map),
 		IngressPodToProgMap:       new(sync.Map),
 		EgressPodToProgMap:        new(sync.Map),
-		nodeIP:                    nodeIP,
-		enableIPv6:                enableIPv6,
 		GlobalMaps:                new(sync.Map),
 		IngressProgToPodsMap:      new(sync.Map),
 		EgressProgToPodsMap:       new(sync.Map),
@@ -171,6 +159,8 @@ func NewBpfClient(nodeIP string, enablePolicyEventLogs, enableCloudWatchLogs boo
 
 	ebpfClient.bpfSDKClient = goelf.New()
 	ebpfClient.bpfTCClient = tc.New([]string{POD_VETH_PREFIX, BRANCH_ENI_VETH_PREFIX})
+
+	ebpfClient.fwRuleProcessor = fwrp.NewFirewallRuleProcessor(nodeIP, hostMask, enableIPv6)
 
 	//Set RLIMIT
 	err = ebpfClient.bpfSDKClient.IncreaseRlimit()
@@ -301,10 +291,6 @@ type bpfClient struct {
 	EgressPodToProgMap *sync.Map
 	// Stores info on the global maps the agent creates
 	GlobalMaps *sync.Map
-	// Primary IP of the node
-	nodeIP string
-	// Flag to track the IPv6 mode
-	enableIPv6 bool
 	// Ingress eBPF probe binary
 	ingressBinary string
 	// Egress eBPF probe binary
@@ -329,6 +315,8 @@ type bpfClient struct {
 	interfaceNametoEgressPinPath map[string]string
 	// Stores podIdentifier to deletepod lock mapping
 	DeletePodIdentifierLock *sync.Map
+	// FirewallRuleProcessor is used to convert firewall rules into ebpf Map content
+	fwRuleProcessor *fwrp.FirewallRuleProcessor
 }
 
 func checkAndUpdateBPFBinaries(bpfTCClient tc.BpfTc, bpfBinaries []string, hostBinaryPath string) (bool, bool, bool, error) {
@@ -801,8 +789,8 @@ func (l *bpfClient) loadBPFProgram(fileName string, direction string,
 	return progInfo, progFD, nil
 }
 
-func (l *bpfClient) UpdateEbpfMaps(podIdentifier string, ingressFirewallRules []EbpfFirewallRules,
-	egressFirewallRules []EbpfFirewallRules) error {
+func (l *bpfClient) UpdateEbpfMaps(podIdentifier string, ingressFirewallRules []fwrp.EbpfFirewallRules,
+	egressFirewallRules []fwrp.EbpfFirewallRules) error {
 
 	var ingressProgFD, egressProgFD int
 	var mapToUpdate goebpfmaps.BpfMap
@@ -922,10 +910,10 @@ func (l *bpfClient) IsFirstPodInPodIdentifier(podIdentifier string) bool {
 	return firstPodInPodIdentifier
 }
 
-func (l *bpfClient) updateEbpfMap(mapToUpdate goebpfmaps.BpfMap, firewallRules []EbpfFirewallRules) error {
+func (l *bpfClient) updateEbpfMap(mapToUpdate goebpfmaps.BpfMap, firewallRules []fwrp.EbpfFirewallRules) error {
 	start := time.Now()
 	duration := msSince(start)
-	mapEntries, err := l.computeMapEntriesFromEndpointRules(firewallRules)
+	mapEntries, err := l.fwRuleProcessor.ComputeMapEntriesFromEndpointRules(firewallRules)
 	if err != nil {
 		log().Errorf("Trie entry creation/validation failed %v", err)
 		return err
@@ -940,227 +928,6 @@ func (l *bpfClient) updateEbpfMap(mapToUpdate goebpfmaps.BpfMap, firewallRules [
 		return err
 	}
 	return nil
-}
-
-func sortFirewallRulesByPrefixLength(rules []EbpfFirewallRules, prefixLenStr string) {
-	sort.Slice(rules, func(i, j int) bool {
-
-		prefixSplit := strings.Split(prefixLenStr, "/")
-		prefixLen, _ := strconv.Atoi(prefixSplit[1])
-		prefixLenIp1 := prefixLen
-		prefixLenIp2 := prefixLen
-
-		if strings.Contains(string(rules[i].IPCidr), "/") {
-			prefixIp1 := strings.Split(string(rules[i].IPCidr), "/")
-			prefixLenIp1, _ = strconv.Atoi(prefixIp1[1])
-
-		}
-
-		if strings.Contains(string(rules[j].IPCidr), "/") {
-
-			prefixIp2 := strings.Split(string(rules[j].IPCidr), "/")
-			prefixLenIp2, _ = strconv.Atoi(prefixIp2[1])
-		}
-
-		return prefixLenIp1 < prefixLenIp2
-	})
-}
-
-func mergeDuplicateL4Info(ports []v1alpha1.Port) []v1alpha1.Port {
-	uniquePorts := make(map[string]v1alpha1.Port)
-	var result []v1alpha1.Port
-	var key string
-
-	for _, p := range ports {
-
-		portKey := 0
-		endPortKey := 0
-
-		if p.Port != nil {
-			portKey = int(*p.Port)
-		}
-
-		if p.EndPort != nil {
-			endPortKey = int(*p.EndPort)
-		}
-		if p.Protocol == nil {
-			key = fmt.Sprintf("%s-%d-%d", "", portKey, endPortKey)
-		} else {
-			key = fmt.Sprintf("%s-%d-%d", *p.Protocol, portKey, endPortKey)
-		}
-
-		if _, ok := uniquePorts[key]; ok {
-			continue
-		} else {
-			uniquePorts[key] = p
-		}
-	}
-
-	for _, port := range uniquePorts {
-		result = append(result, port)
-	}
-
-	return result
-}
-
-func (l *bpfClient) computeMapEntriesFromEndpointRules(firewallRules []EbpfFirewallRules) (map[string][]byte, error) {
-
-	firewallMap := make(map[string][]byte)
-	ipCIDRs := make(map[string][]v1alpha1.Port)
-	nonHostCIDRs := make(map[string][]v1alpha1.Port)
-	isCatchAllIPEntryPresent, allowAll := false, false
-	var catchAllIPPorts []v1alpha1.Port
-
-	//Traffic from the local node should always be allowed. Add NodeIP by default to map entries.
-	_, mapKey, _ := net.ParseCIDR(l.nodeIP + l.hostMask)
-	key := utils.ComputeTrieKey(*mapKey, l.enableIPv6)
-	value := utils.ComputeTrieValue([]v1alpha1.Port{}, true, false)
-	firewallMap[string(key)] = value
-
-	//Sort the rules
-	sortFirewallRulesByPrefixLength(firewallRules, l.hostMask)
-
-	//Check and aggregate L4 Port Info for Catch All Entries.
-	catchAllIPPorts, isCatchAllIPEntryPresent, allowAll = l.checkAndDeriveCatchAllIPPorts(firewallRules)
-	if isCatchAllIPEntryPresent {
-		//Add the Catch All IP entry
-		_, mapKey, _ := net.ParseCIDR("0.0.0.0/0")
-		key := utils.ComputeTrieKey(*mapKey, l.enableIPv6)
-		value := utils.ComputeTrieValue(catchAllIPPorts, allowAll, false)
-		firewallMap[string(key)] = value
-	}
-
-	for _, firewallRule := range firewallRules {
-		var cidrL4Info []v1alpha1.Port
-
-		if !strings.Contains(string(firewallRule.IPCidr), "/") {
-			firewallRule.IPCidr += v1alpha1.NetworkAddress(l.hostMask)
-		}
-
-		if utils.IsNodeIP(l.nodeIP, string(firewallRule.IPCidr)) {
-			continue
-		}
-
-		if l.enableIPv6 && !strings.Contains(string(firewallRule.IPCidr), "::") {
-			log().Debugf("Skipping ipv4 rule in ipv6 cluster CIDR: %s", string(firewallRule.IPCidr))
-			continue
-		}
-
-		if !l.enableIPv6 && strings.Contains(string(firewallRule.IPCidr), "::") {
-			log().Debugf("Skipping ipv6 rule in ipv4 cluster CIDR: %s", string(firewallRule.IPCidr))
-			continue
-		}
-
-		if !utils.IsCatchAllIPEntry(string(firewallRule.IPCidr)) {
-			if len(firewallRule.L4Info) == 0 {
-				l.addCatchAllL4Entry(&firewallRule)
-			}
-			if utils.IsNonHostCIDR(string(firewallRule.IPCidr)) {
-				existingL4Info, ok := nonHostCIDRs[string(firewallRule.IPCidr)]
-				if ok {
-					firewallRule.L4Info = append(firewallRule.L4Info, existingL4Info...)
-				} else {
-					// Check if the /m entry is part of any /n CIDRs that we've encountered so far
-					// If found, we need to include the port and protocol combination against the current entry as well since
-					// we use LPM TRIE map and the /m will always win out.
-					cidrL4Info = l.checkAndDeriveL4InfoFromAnyMatchingCIDRs(string(firewallRule.IPCidr), nonHostCIDRs)
-					if len(cidrL4Info) > 0 {
-						firewallRule.L4Info = append(firewallRule.L4Info, cidrL4Info...)
-					}
-				}
-				nonHostCIDRs[string(firewallRule.IPCidr)] = firewallRule.L4Info
-			} else {
-				if existingL4Info, ok := ipCIDRs[string(firewallRule.IPCidr)]; ok {
-					firewallRule.L4Info = append(firewallRule.L4Info, existingL4Info...)
-				}
-				// Check if the /32 entry is part of any non host CIDRs that we've encountered so far
-				// If found, we need to include the port and protocol combination against the current entry as well since
-				// we use LPM TRIE map and the /32 will always win out.
-				cidrL4Info = l.checkAndDeriveL4InfoFromAnyMatchingCIDRs(string(firewallRule.IPCidr), nonHostCIDRs)
-				if len(cidrL4Info) > 0 {
-					firewallRule.L4Info = append(firewallRule.L4Info, cidrL4Info...)
-				}
-				ipCIDRs[string(firewallRule.IPCidr)] = firewallRule.L4Info
-			}
-			//Include port and protocol combination paired with catch all entries
-			firewallRule.L4Info = append(firewallRule.L4Info, catchAllIPPorts...)
-
-			log().Infof("Updating Map with IP Key: %s", string(firewallRule.IPCidr))
-			_, firewallMapKey, _ := net.ParseCIDR(string(firewallRule.IPCidr))
-			// Key format: Prefix length (4 bytes) followed by 4/16byte IP address
-			firewallKey := utils.ComputeTrieKey(*firewallMapKey, l.enableIPv6)
-
-			if len(firewallRule.L4Info) != 0 {
-				mergedL4Info := mergeDuplicateL4Info(firewallRule.L4Info)
-				firewallRule.L4Info = mergedL4Info
-
-			}
-			firewallValue := utils.ComputeTrieValue(firewallRule.L4Info, allowAll, false)
-			firewallMap[string(firewallKey)] = firewallValue
-		}
-		if firewallRule.Except != nil {
-			for _, exceptCIDR := range firewallRule.Except {
-				_, mapKey, _ := net.ParseCIDR(string(exceptCIDR))
-				key := utils.ComputeTrieKey(*mapKey, l.enableIPv6)
-				log().Infof("Parsed Except CIDR IP Key: %s", mapKey.String())
-				if len(firewallRule.L4Info) != 0 {
-					mergedL4Info := mergeDuplicateL4Info(firewallRule.L4Info)
-					firewallRule.L4Info = mergedL4Info
-				}
-				value := utils.ComputeTrieValue(firewallRule.L4Info, false, true)
-				firewallMap[string(key)] = value
-			}
-		}
-	}
-
-	return firewallMap, nil
-}
-
-func (l *bpfClient) checkAndDeriveCatchAllIPPorts(firewallRules []EbpfFirewallRules) ([]v1alpha1.Port, bool, bool) {
-	var catchAllL4Info []v1alpha1.Port
-	isCatchAllIPEntryPresent := false
-	allowAllPortAndProtocols := false
-	for _, firewallRule := range firewallRules {
-		if !strings.Contains(string(firewallRule.IPCidr), "/") {
-			firewallRule.IPCidr += v1alpha1.NetworkAddress(l.hostMask)
-		}
-		if !l.enableIPv6 && strings.Contains(string(firewallRule.IPCidr), "::") {
-			log().Debug("IPv6 catch all entry in IPv4 mode - skip ")
-			continue
-		}
-		if utils.IsCatchAllIPEntry(string(firewallRule.IPCidr)) {
-			catchAllL4Info = append(catchAllL4Info, firewallRule.L4Info...)
-			isCatchAllIPEntryPresent = true
-			if len(firewallRule.L4Info) == 0 {
-				//All ports and protocols
-				allowAllPortAndProtocols = true
-			}
-		}
-	}
-	log().Debugf("Total L4 entry count for catch all entry: count: %d", len(catchAllL4Info))
-	return catchAllL4Info, isCatchAllIPEntryPresent, allowAllPortAndProtocols
-}
-
-func (l *bpfClient) checkAndDeriveL4InfoFromAnyMatchingCIDRs(firewallRule string,
-	nonHostCIDRs map[string][]v1alpha1.Port) []v1alpha1.Port {
-	var matchingCIDRL4Info []v1alpha1.Port
-
-	_, ipToCheck, _ := net.ParseCIDR(firewallRule)
-	for nonHostCIDR, l4Info := range nonHostCIDRs {
-		_, cidrEntry, _ := net.ParseCIDR(nonHostCIDR)
-		if cidrEntry.Contains(ipToCheck.IP) {
-			log().Debugf("Found a CIDR match for IP: %s in CIDR %s ", firewallRule, nonHostCIDR)
-			matchingCIDRL4Info = append(matchingCIDRL4Info, l4Info...)
-		}
-	}
-	return matchingCIDRL4Info
-}
-
-func (l *bpfClient) addCatchAllL4Entry(firewallRule *EbpfFirewallRules) {
-	catchAllL4Entry := v1alpha1.Port{
-		Protocol: &CATCH_ALL_PROTOCOL,
-	}
-	firewallRule.L4Info = append(firewallRule.L4Info, catchAllL4Entry)
 }
 
 func (l *bpfClient) DeletePodFromIngressProgPodCaches(podName string, podNamespace string) {

--- a/pkg/ebpf/bpf_client_mock.go
+++ b/pkg/ebpf/bpf_client_mock.go
@@ -3,6 +3,7 @@ package ebpf
 import (
 	"sync"
 
+	fwrp "github.com/aws/aws-network-policy-agent/pkg/fwruleprocessor"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -16,8 +17,6 @@ func NewMockBpfClient() BpfClient {
 		IngressProgToPodsMap:      new(sync.Map),
 		EgressProgToPodsMap:       new(sync.Map),
 		GlobalMaps:                new(sync.Map),
-		nodeIP:                    "127.0.0.1",
-		enableIPv6:                false,
 		hostMask:                  "/32",
 	}
 }
@@ -28,7 +27,7 @@ func (m *MockBpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier
 	return nil
 }
 
-func (m *MockBpfClient) UpdateEbpfMaps(podIdentifier string, ingressFirewallRules []EbpfFirewallRules, egressFirewallRules []EbpfFirewallRules) error {
+func (m *MockBpfClient) UpdateEbpfMaps(podIdentifier string, ingressFirewallRules []fwrp.EbpfFirewallRules, egressFirewallRules []fwrp.EbpfFirewallRules) error {
 	return nil
 }
 

--- a/pkg/fwruleprocessor/fw_rule_processor.go
+++ b/pkg/fwruleprocessor/fw_rule_processor.go
@@ -1,0 +1,265 @@
+package fwruleprocessor
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-network-policy-agent/api/v1alpha1"
+	"github.com/aws/aws-network-policy-agent/pkg/logger"
+	"github.com/aws/aws-network-policy-agent/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func log() logger.Logger {
+	return logger.Get()
+}
+
+var CATCH_ALL_PROTOCOL corev1.Protocol = "ANY_IP_PROTOCOL"
+
+type EbpfFirewallRules struct {
+	IPCidr v1alpha1.NetworkAddress
+	Except []v1alpha1.NetworkAddress
+	L4Info []v1alpha1.Port
+}
+
+type FirewallRuleProcessor struct {
+	// Primary IP of the node
+	nodeIP   string
+	hostMask string
+	// Flag to track the IPv6 mode
+	enableIPv6 bool
+}
+
+func NewFirewallRuleProcessor(nodeIP string, hostMask string, enableIPv6 bool) *FirewallRuleProcessor {
+	fwrp := &FirewallRuleProcessor{
+		nodeIP:     nodeIP,
+		hostMask:   hostMask,
+		enableIPv6: enableIPv6,
+	}
+	return fwrp
+}
+
+func (f *FirewallRuleProcessor) ComputeMapEntriesFromEndpointRules(firewallRules []EbpfFirewallRules) (map[string][]byte, error) {
+
+	firewallMap := make(map[string][]byte)
+	ipCIDRs := make(map[string][]v1alpha1.Port)
+	nonHostCIDRs := make(map[string][]v1alpha1.Port)
+	isCatchAllIPEntryPresent, allowAll := false, false
+	var catchAllIPPorts []v1alpha1.Port
+
+	//Traffic from the local node should always be allowed. Add NodeIP by default to map entries.
+	_, mapKey, _ := net.ParseCIDR(f.nodeIP + f.hostMask)
+	key := utils.ComputeTrieKey(*mapKey, f.enableIPv6)
+	value := utils.ComputeTrieValue([]v1alpha1.Port{}, true, false)
+	firewallMap[string(key)] = value
+
+	//Sort the rules
+	sortFirewallRulesByPrefixLength(firewallRules, f.hostMask)
+
+	//Check and aggregate L4 Port Info for Catch All Entries.
+	catchAllIPPorts, isCatchAllIPEntryPresent, allowAll = f.checkAndDeriveCatchAllIPPorts(firewallRules)
+	if isCatchAllIPEntryPresent {
+		//Add the Catch All IP entry
+		_, mapKey, _ := net.ParseCIDR("0.0.0.0/0")
+		key := utils.ComputeTrieKey(*mapKey, f.enableIPv6)
+		value := utils.ComputeTrieValue(catchAllIPPorts, allowAll, false)
+		firewallMap[string(key)] = value
+	}
+
+	for _, firewallRule := range firewallRules {
+		var cidrL4Info []v1alpha1.Port
+
+		if !strings.Contains(string(firewallRule.IPCidr), "/") {
+			firewallRule.IPCidr += v1alpha1.NetworkAddress(f.hostMask)
+		}
+
+		if utils.IsNodeIP(f.nodeIP, string(firewallRule.IPCidr)) {
+			continue
+		}
+
+		if f.enableIPv6 && !strings.Contains(string(firewallRule.IPCidr), "::") {
+			log().Debugf("Skipping ipv4 rule in ipv6 cluster CIDR: %s", string(firewallRule.IPCidr))
+			continue
+		}
+
+		if !f.enableIPv6 && strings.Contains(string(firewallRule.IPCidr), "::") {
+			log().Debugf("Skipping ipv6 rule in ipv4 cluster CIDR: %s", string(firewallRule.IPCidr))
+			continue
+		}
+
+		if !utils.IsCatchAllIPEntry(string(firewallRule.IPCidr)) {
+			if len(firewallRule.L4Info) == 0 {
+				addCatchAllL4Entry(&firewallRule)
+			}
+			if utils.IsNonHostCIDR(string(firewallRule.IPCidr)) {
+				existingL4Info, ok := nonHostCIDRs[string(firewallRule.IPCidr)]
+				if ok {
+					firewallRule.L4Info = append(firewallRule.L4Info, existingL4Info...)
+				} else {
+					// Check if the /m entry is part of any /n CIDRs that we've encountered so far
+					// If found, we need to include the port and protocol combination against the current entry as well since
+					// we use LPM TRIE map and the /m will always win out.
+					cidrL4Info = checkAndDeriveL4InfoFromAnyMatchingCIDRs(string(firewallRule.IPCidr), nonHostCIDRs)
+					if len(cidrL4Info) > 0 {
+						firewallRule.L4Info = append(firewallRule.L4Info, cidrL4Info...)
+					}
+				}
+				nonHostCIDRs[string(firewallRule.IPCidr)] = firewallRule.L4Info
+			} else {
+				if existingL4Info, ok := ipCIDRs[string(firewallRule.IPCidr)]; ok {
+					firewallRule.L4Info = append(firewallRule.L4Info, existingL4Info...)
+				}
+				// Check if the /32 entry is part of any non host CIDRs that we've encountered so far
+				// If found, we need to include the port and protocol combination against the current entry as well since
+				// we use LPM TRIE map and the /32 will always win out.
+				cidrL4Info = checkAndDeriveL4InfoFromAnyMatchingCIDRs(string(firewallRule.IPCidr), nonHostCIDRs)
+				if len(cidrL4Info) > 0 {
+					firewallRule.L4Info = append(firewallRule.L4Info, cidrL4Info...)
+				}
+				ipCIDRs[string(firewallRule.IPCidr)] = firewallRule.L4Info
+			}
+			//Include port and protocol combination paired with catch all entries
+			firewallRule.L4Info = append(firewallRule.L4Info, catchAllIPPorts...)
+
+			log().Infof("Updating Map with IP Key: %s", string(firewallRule.IPCidr))
+			_, firewallMapKey, _ := net.ParseCIDR(string(firewallRule.IPCidr))
+			// Key format: Prefix length (4 bytes) followed by 4/16byte IP address
+			firewallKey := utils.ComputeTrieKey(*firewallMapKey, f.enableIPv6)
+
+			if len(firewallRule.L4Info) != 0 {
+				mergedL4Info := mergeDuplicateL4Info(firewallRule.L4Info)
+				firewallRule.L4Info = mergedL4Info
+
+			}
+			firewallValue := utils.ComputeTrieValue(firewallRule.L4Info, allowAll, false)
+			firewallMap[string(firewallKey)] = firewallValue
+		}
+		if firewallRule.Except != nil {
+			for _, exceptCIDR := range firewallRule.Except {
+				_, mapKey, _ := net.ParseCIDR(string(exceptCIDR))
+				key := utils.ComputeTrieKey(*mapKey, f.enableIPv6)
+				log().Infof("Parsed Except CIDR IP Key: %s", mapKey.String())
+				if len(firewallRule.L4Info) != 0 {
+					mergedL4Info := mergeDuplicateL4Info(firewallRule.L4Info)
+					firewallRule.L4Info = mergedL4Info
+				}
+				value := utils.ComputeTrieValue(firewallRule.L4Info, false, true)
+				firewallMap[string(key)] = value
+			}
+		}
+	}
+
+	return firewallMap, nil
+}
+
+func (f *FirewallRuleProcessor) checkAndDeriveCatchAllIPPorts(firewallRules []EbpfFirewallRules) ([]v1alpha1.Port, bool, bool) {
+	var catchAllL4Info []v1alpha1.Port
+	isCatchAllIPEntryPresent := false
+	allowAllPortAndProtocols := false
+	for _, firewallRule := range firewallRules {
+		if !strings.Contains(string(firewallRule.IPCidr), "/") {
+			firewallRule.IPCidr += v1alpha1.NetworkAddress(f.hostMask)
+		}
+		if !f.enableIPv6 && strings.Contains(string(firewallRule.IPCidr), "::") {
+			log().Debug("IPv6 catch all entry in IPv4 mode - skip ")
+			continue
+		}
+		if utils.IsCatchAllIPEntry(string(firewallRule.IPCidr)) {
+			catchAllL4Info = append(catchAllL4Info, firewallRule.L4Info...)
+			isCatchAllIPEntryPresent = true
+			if len(firewallRule.L4Info) == 0 {
+				//All ports and protocols
+				allowAllPortAndProtocols = true
+			}
+		}
+	}
+	log().Debugf("Total L4 entry count for catch all entry: count: %d", len(catchAllL4Info))
+	return catchAllL4Info, isCatchAllIPEntryPresent, allowAllPortAndProtocols
+}
+
+// sorting Firewall Rules in Ascending Order of Prefix length
+func sortFirewallRulesByPrefixLength(rules []EbpfFirewallRules, prefixLenStr string) {
+	sort.Slice(rules, func(i, j int) bool {
+
+		prefixSplit := strings.Split(prefixLenStr, "/")
+		prefixLen, _ := strconv.Atoi(prefixSplit[1])
+		prefixLenIp1 := prefixLen
+		prefixLenIp2 := prefixLen
+
+		if strings.Contains(string(rules[i].IPCidr), "/") {
+			prefixIp1 := strings.Split(string(rules[i].IPCidr), "/")
+			prefixLenIp1, _ = strconv.Atoi(prefixIp1[1])
+
+		}
+
+		if strings.Contains(string(rules[j].IPCidr), "/") {
+
+			prefixIp2 := strings.Split(string(rules[j].IPCidr), "/")
+			prefixLenIp2, _ = strconv.Atoi(prefixIp2[1])
+		}
+
+		return prefixLenIp1 < prefixLenIp2
+	})
+}
+
+func addCatchAllL4Entry(firewallRule *EbpfFirewallRules) {
+	catchAllL4Entry := v1alpha1.Port{
+		Protocol: &CATCH_ALL_PROTOCOL,
+	}
+	firewallRule.L4Info = append(firewallRule.L4Info, catchAllL4Entry)
+}
+
+func checkAndDeriveL4InfoFromAnyMatchingCIDRs(firewallRule string,
+	nonHostCIDRs map[string][]v1alpha1.Port) []v1alpha1.Port {
+	var matchingCIDRL4Info []v1alpha1.Port
+
+	_, ipToCheck, _ := net.ParseCIDR(firewallRule)
+	for nonHostCIDR, l4Info := range nonHostCIDRs {
+		_, cidrEntry, _ := net.ParseCIDR(nonHostCIDR)
+		if cidrEntry.Contains(ipToCheck.IP) {
+			log().Debugf("Found a CIDR match for IP: %s in CIDR %s ", firewallRule, nonHostCIDR)
+			matchingCIDRL4Info = append(matchingCIDRL4Info, l4Info...)
+		}
+	}
+	return matchingCIDRL4Info
+}
+
+func mergeDuplicateL4Info(ports []v1alpha1.Port) []v1alpha1.Port {
+	uniquePorts := make(map[string]v1alpha1.Port)
+	var result []v1alpha1.Port
+	var key string
+
+	for _, p := range ports {
+
+		portKey := 0
+		endPortKey := 0
+
+		if p.Port != nil {
+			portKey = int(*p.Port)
+		}
+
+		if p.EndPort != nil {
+			endPortKey = int(*p.EndPort)
+		}
+		if p.Protocol == nil {
+			key = fmt.Sprintf("%s-%d-%d", "", portKey, endPortKey)
+		} else {
+			key = fmt.Sprintf("%s-%d-%d", *p.Protocol, portKey, endPortKey)
+		}
+
+		if _, ok := uniquePorts[key]; ok {
+			continue
+		} else {
+			uniquePorts[key] = p
+		}
+	}
+
+	for _, port := range uniquePorts {
+		result = append(result, port)
+	}
+
+	return result
+}

--- a/pkg/fwruleprocessor/fw_rule_processor_test.go
+++ b/pkg/fwruleprocessor/fw_rule_processor_test.go
@@ -1,0 +1,513 @@
+package fwruleprocessor
+
+import (
+	"net"
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-network-policy-agent/api/v1alpha1"
+	"github.com/aws/aws-network-policy-agent/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestFWRuleProcessor_ComputeMapEntriesFromEndpointRules(t *testing.T) {
+	protocolTCP := corev1.ProtocolTCP
+	//protocolUDP := corev1.ProtocolUDP
+	//protocolSCTP := corev1.ProtocolSCTP
+
+	var testIP v1alpha1.NetworkAddress
+	var gotKeys []string
+
+	nodeIP := "10.1.1.1"
+	_, nodeIPCIDR, _ := net.ParseCIDR(nodeIP + "/32")
+	nodeIPKey := utils.ComputeTrieKey(*nodeIPCIDR, false)
+
+	var testPort int32
+	testPort = 80
+	testIP = "10.1.1.2/32"
+	_, testIPCIDR, _ := net.ParseCIDR(string(testIP))
+
+	testIPKey := utils.ComputeTrieKey(*testIPCIDR, false)
+	type args struct {
+		firewallRules []EbpfFirewallRules
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr error
+	}{
+		{
+			name: "CIDR with Port and Protocol",
+			args: args{
+				[]EbpfFirewallRules{
+					{
+						IPCidr: "10.1.1.2/32",
+						L4Info: []v1alpha1.Port{
+							{
+								Protocol: &protocolTCP,
+								Port:     &testPort,
+							},
+						},
+					},
+				},
+			},
+			want: []string{string(nodeIPKey), string(testIPKey)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewFirewallRuleProcessor("10.1.1.1", "/32", false).ComputeMapEntriesFromEndpointRules(tt.args.firewallRules)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				for key, _ := range got {
+					gotKeys = append(gotKeys, key)
+				}
+				sort.Strings(tt.want)
+				sort.Strings(gotKeys)
+				assert.Equal(t, tt.want, gotKeys)
+			}
+		})
+	}
+}
+
+func TestFWRuleProcessor_CheckAndDeriveCatchAllIPPorts(t *testing.T) {
+	protocolTCP := corev1.ProtocolTCP
+	var port80 int32 = 80
+
+	type want struct {
+		catchAllL4Info           []v1alpha1.Port
+		isCatchAllIPEntryPresent bool
+		allowAllPortAndProtocols bool
+	}
+
+	l4InfoWithCatchAllEntry := []EbpfFirewallRules{
+		{
+			IPCidr: "0.0.0.0/0",
+			L4Info: []v1alpha1.Port{
+				{
+					Protocol: &protocolTCP,
+					Port:     &port80,
+				},
+			},
+		},
+	}
+
+	l4InfoWithNoCatchAllEntry := []EbpfFirewallRules{
+		{
+			IPCidr: "1.1.1.1/32",
+			L4Info: []v1alpha1.Port{
+				{
+					Protocol: &protocolTCP,
+					Port:     &port80,
+				},
+			},
+		},
+	}
+
+	l4InfoWithCatchAllEntryAndAllProtocols := []EbpfFirewallRules{
+		{
+			IPCidr: "0.0.0.0/0",
+		},
+	}
+
+	tests := []struct {
+		name          string
+		firewallRules []EbpfFirewallRules
+		want          want
+	}{
+		{
+			name:          "Catch All Entry present",
+			firewallRules: l4InfoWithCatchAllEntry,
+			want: want{
+				catchAllL4Info: []v1alpha1.Port{
+					{
+						Protocol: &protocolTCP,
+						Port:     &port80,
+					},
+				},
+				isCatchAllIPEntryPresent: true,
+				allowAllPortAndProtocols: false,
+			},
+		},
+
+		{
+			name:          "No Catch All Entry present",
+			firewallRules: l4InfoWithNoCatchAllEntry,
+			want: want{
+				isCatchAllIPEntryPresent: false,
+				allowAllPortAndProtocols: false,
+			},
+		},
+
+		{
+			name:          "Catch All Entry With no Port info",
+			firewallRules: l4InfoWithCatchAllEntryAndAllProtocols,
+			want: want{
+				isCatchAllIPEntryPresent: true,
+				allowAllPortAndProtocols: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCatchAllL4Info, gotIsCatchAllIPEntryPresent, gotAllowAllPortAndProtocols := NewFirewallRuleProcessor("10.1.1.1", "/32", false).checkAndDeriveCatchAllIPPorts(tt.firewallRules)
+			assert.Equal(t, tt.want.catchAllL4Info, gotCatchAllL4Info)
+			assert.Equal(t, tt.want.isCatchAllIPEntryPresent, gotIsCatchAllIPEntryPresent)
+			assert.Equal(t, tt.want.allowAllPortAndProtocols, gotAllowAllPortAndProtocols)
+		})
+	}
+}
+
+func TestFWRuleProcessor_CheckAndDeriveL4InfoFromAnyMatchingCIDRs(t *testing.T) {
+	protocolTCP := corev1.ProtocolTCP
+	var port80 int32 = 80
+
+	type want struct {
+		matchingCIDRL4Info []v1alpha1.Port
+	}
+
+	sampleNonHostCIDRs := map[string][]v1alpha1.Port{
+		"1.1.1.0/24": {
+			{
+				Protocol: &protocolTCP,
+				Port:     &port80,
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		firewallRule string
+		nonHostCIDRs map[string][]v1alpha1.Port
+		want         want
+	}{
+		{
+			name:         "Match Present",
+			firewallRule: "1.1.1.2/32",
+			nonHostCIDRs: sampleNonHostCIDRs,
+			want: want{
+				matchingCIDRL4Info: []v1alpha1.Port{
+					{
+						Protocol: &protocolTCP,
+						Port:     &port80,
+					},
+				},
+			},
+		},
+
+		{
+			name:         "No Match",
+			firewallRule: "2.1.1.2/32",
+			nonHostCIDRs: sampleNonHostCIDRs,
+			want:         want{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMatchingCIDRL4Info := checkAndDeriveL4InfoFromAnyMatchingCIDRs(tt.firewallRule, tt.nonHostCIDRs)
+			assert.Equal(t, tt.want.matchingCIDRL4Info, gotMatchingCIDRL4Info)
+		})
+	}
+}
+
+func TestFWRuleProcessor_AddCatchAllL4Entry(t *testing.T) {
+	protocolTCP := corev1.ProtocolTCP
+	var port80 int32 = 80
+
+	l4InfoWithNoCatchAllEntry := EbpfFirewallRules{
+		IPCidr: "1.1.1.1/32",
+		L4Info: []v1alpha1.Port{
+			{
+				Protocol: &protocolTCP,
+				Port:     &port80,
+			},
+		},
+	}
+
+	l4InfoWithCatchAllL4Info := EbpfFirewallRules{
+		IPCidr: "1.1.1.1/32",
+		L4Info: []v1alpha1.Port{
+			{
+				Protocol: &protocolTCP,
+				Port:     &port80,
+			},
+			{
+				Protocol: &CATCH_ALL_PROTOCOL,
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		firewallRules EbpfFirewallRules
+	}{
+		{
+			name:          "Append Catch All Entry",
+			firewallRules: l4InfoWithNoCatchAllEntry,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addCatchAllL4Entry(&tt.firewallRules)
+			assert.Equal(t, tt.firewallRules, l4InfoWithCatchAllL4Info)
+		})
+	}
+}
+
+func TestFWRuleProcessor_MergeDuplicateL4Info(t *testing.T) {
+	type mergeDuplicatePortsTestCase struct {
+		Name     string
+		Ports    []v1alpha1.Port
+		Expected []v1alpha1.Port
+	}
+	protocolTCP := corev1.ProtocolTCP
+	protocolUDP := corev1.ProtocolUDP
+
+	testCases := []mergeDuplicatePortsTestCase{
+		{
+			Name: "Merge Duplicate Ports with nil Protocol",
+			Ports: []v1alpha1.Port{
+				{Protocol: &protocolTCP, Port: Int32Ptr(80), EndPort: Int32Ptr(8080)},
+				{Protocol: nil, Port: Int32Ptr(53), EndPort: Int32Ptr(53)},
+				{Protocol: nil, Port: Int32Ptr(53), EndPort: Int32Ptr(53)},
+				{Protocol: &protocolTCP, Port: Int32Ptr(80), EndPort: Int32Ptr(8080)},
+				{Protocol: &protocolTCP, Port: Int32Ptr(8081), EndPort: Int32Ptr(8081)},
+			},
+			Expected: []v1alpha1.Port{
+				{Protocol: &protocolTCP, Port: Int32Ptr(80), EndPort: Int32Ptr(8080)},
+				{Protocol: nil, Port: Int32Ptr(53), EndPort: Int32Ptr(53)},
+				{Protocol: &protocolTCP, Port: Int32Ptr(8081), EndPort: Int32Ptr(8081)},
+			},
+		},
+		{
+			Name: "Merge Duplicate Ports with nil EndPort",
+			Ports: []v1alpha1.Port{
+				{Protocol: &protocolUDP, Port: Int32Ptr(53), EndPort: nil},
+				{Protocol: &protocolUDP, Port: Int32Ptr(53), EndPort: nil},
+			},
+			Expected: []v1alpha1.Port{
+				{Protocol: &protocolUDP, Port: Int32Ptr(53), EndPort: nil},
+			},
+		},
+		{
+			Name: "Merge Duplicate Ports with nil Port",
+			Ports: []v1alpha1.Port{
+				{Protocol: &protocolTCP, Port: nil, EndPort: Int32Ptr(8080)},
+				{Protocol: &protocolTCP, Port: nil, EndPort: Int32Ptr(8080)},
+			},
+			Expected: []v1alpha1.Port{
+				{Protocol: &protocolTCP, Port: nil, EndPort: Int32Ptr(8080)},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			mergedPorts := mergeDuplicateL4Info(tc.Ports)
+			assert.Equal(t, len(tc.Expected), len(mergedPorts))
+		})
+	}
+}
+
+func Int32Ptr(i int32) *int32 {
+	return &i
+}
+
+func TestFWRuleProcessor_SortFirewallRulesByPrefixLength(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputRules     []EbpfFirewallRules
+		hostMask       string
+		expectedOutput []EbpfFirewallRules
+	}{
+		{
+			name: "Sort IPv4 CIDRs by prefix length",
+			inputRules: []EbpfFirewallRules{
+				{IPCidr: "192.168.1.1/32"},
+				{IPCidr: "10.0.0.0/8"},
+				{IPCidr: "172.16.0.0/16"},
+				{IPCidr: "192.168.0.0/24"},
+			},
+			hostMask: "/32",
+			expectedOutput: []EbpfFirewallRules{
+				{IPCidr: "10.0.0.0/8"},
+				{IPCidr: "172.16.0.0/16"},
+				{IPCidr: "192.168.0.0/24"},
+				{IPCidr: "192.168.1.1/32"},
+			},
+		},
+		{
+			name: "Sort IPv4 CIDRs with some missing prefix",
+			inputRules: []EbpfFirewallRules{
+				{IPCidr: "192.168.1.1"}, // No prefix, should use hostMask
+				{IPCidr: "10.0.0.0/8"},
+				{IPCidr: "172.16.0.0/16"},
+			},
+			hostMask: "/32",
+			expectedOutput: []EbpfFirewallRules{
+				{IPCidr: "10.0.0.0/8"},
+				{IPCidr: "172.16.0.0/16"},
+				{IPCidr: "192.168.1.1"}, // Still no prefix in the output
+			},
+		},
+		{
+			name: "Sort IPv6 CIDRs by prefix length",
+			inputRules: []EbpfFirewallRules{
+				{IPCidr: "2001:db8::/32"},
+				{IPCidr: "2001:db8:1::/48"},
+				{IPCidr: "2001:db8:1:2::/64"},
+				{IPCidr: "2001:db8:1:2:3::/80"},
+			},
+			hostMask: "/128",
+			expectedOutput: []EbpfFirewallRules{
+				{IPCidr: "2001:db8::/32"},
+				{IPCidr: "2001:db8:1::/48"},
+				{IPCidr: "2001:db8:1:2::/64"},
+				{IPCidr: "2001:db8:1:2:3::/80"},
+			},
+		},
+		{
+			name: "Sort mixed IPv4 and IPv6 CIDRs",
+			inputRules: []EbpfFirewallRules{
+				{IPCidr: "192.168.1.0/24"},
+				{IPCidr: "2001:db8::/32"},
+				{IPCidr: "10.0.0.0/8"},
+				{IPCidr: "2001:db8:1::/48"},
+			},
+			hostMask: "/32",
+			expectedOutput: []EbpfFirewallRules{
+				{IPCidr: "10.0.0.0/8"},
+				{IPCidr: "192.168.1.0/24"},
+				{IPCidr: "2001:db8::/32"},
+				{IPCidr: "2001:db8:1::/48"},
+			},
+		},
+		{
+			name: "Sort with catch-all IP entry (0.0.0.0/0)",
+			inputRules: []EbpfFirewallRules{
+				{IPCidr: "192.168.1.0/24"},
+				{IPCidr: "0.0.0.0/0"},
+				{IPCidr: "10.0.0.0/8"},
+			},
+			hostMask: "/32",
+			expectedOutput: []EbpfFirewallRules{
+				{IPCidr: "0.0.0.0/0"},
+				{IPCidr: "10.0.0.0/8"},
+				{IPCidr: "192.168.1.0/24"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a copy of the input rules to avoid modifying the test data
+			inputCopy := make([]EbpfFirewallRules, len(tt.inputRules))
+			copy(inputCopy, tt.inputRules)
+
+			// Call the function being tested
+			sortFirewallRulesByPrefixLength(inputCopy, tt.hostMask)
+
+			// Check if the result matches the expected output
+			assert.Equal(t, tt.expectedOutput, inputCopy, "Sorted rules do not match expected output")
+		})
+	}
+}
+
+func TestFWRuleProcessor_SortFirewallRulesByPrefixLengthWithL4Info(t *testing.T) {
+	// Create protocol variables for test
+	tcp := corev1.ProtocolTCP
+	udp := corev1.ProtocolUDP
+
+	// Create port variables for test
+	port80 := int32(80)
+	port443 := int32(443)
+	port8080 := int32(8080)
+
+	tests := []struct {
+		name           string
+		inputRules     []EbpfFirewallRules
+		hostMask       string
+		expectedOutput []EbpfFirewallRules
+	}{
+		{
+			name: "Sort rules with L4 info preserved",
+			inputRules: []EbpfFirewallRules{
+				{
+					IPCidr: "192.168.1.0/24",
+					L4Info: []v1alpha1.Port{
+						{Protocol: &tcp, Port: &port80},
+						{Protocol: &tcp, Port: &port443},
+					},
+				},
+				{
+					IPCidr: "10.0.0.0/8",
+					L4Info: []v1alpha1.Port{
+						{Protocol: &udp, Port: &port8080},
+					},
+				},
+			},
+			hostMask: "/32",
+			expectedOutput: []EbpfFirewallRules{
+				{
+					IPCidr: "10.0.0.0/8",
+					L4Info: []v1alpha1.Port{
+						{Protocol: &udp, Port: &port8080},
+					},
+				},
+				{
+					IPCidr: "192.168.1.0/24",
+					L4Info: []v1alpha1.Port{
+						{Protocol: &tcp, Port: &port80},
+						{Protocol: &tcp, Port: &port443},
+					},
+				},
+			},
+		},
+		{
+			name: "Sort rules with Except fields preserved",
+			inputRules: []EbpfFirewallRules{
+				{
+					IPCidr: "192.168.1.0/24",
+					Except: []v1alpha1.NetworkAddress{"192.168.1.5/32", "192.168.1.10/32"},
+				},
+				{
+					IPCidr: "10.0.0.0/8",
+					Except: []v1alpha1.NetworkAddress{"10.1.0.0/16"},
+				},
+			},
+			hostMask: "/32",
+			expectedOutput: []EbpfFirewallRules{
+				{
+					IPCidr: "10.0.0.0/8",
+					Except: []v1alpha1.NetworkAddress{"10.1.0.0/16"},
+				},
+				{
+					IPCidr: "192.168.1.0/24",
+					Except: []v1alpha1.NetworkAddress{"192.168.1.5/32", "192.168.1.10/32"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a copy of the input rules to avoid modifying the test data
+			inputCopy := make([]EbpfFirewallRules, len(tt.inputRules))
+			copy(inputCopy, tt.inputRules)
+
+			// Call the function being tested
+			sortFirewallRulesByPrefixLength(inputCopy, tt.hostMask)
+
+			// Check if the result matches the expected output
+			assert.Equal(t, tt.expectedOutput, inputCopy, "Sorted rules do not match expected output")
+		})
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

## Summary
This PR extracts the firewall rule processing logic from the BPF client into a dedicated package for better encapsulation and separation of concerns. The new `fwruleprocessor` package handles all firewall rule processing operations, making the codebase more maintainable and testable. Added test for `sortFirewallRulesByPrefixLength`

## Benefits
- Better separation of concerns: BPF client now focuses on BPF operations while rule processing is handled in a dedicated pkg
- Improved code organization and maintainability
- Enhanced testability with focused test files
- Cleaner interfaces between components

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
