### PR TITLE
using in-mem ebpf map for syscall reduction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.4
 
 require (
 	github.com/aws/amazon-vpc-cni-k8s v1.19.3-rc1
-	github.com/aws/aws-ebpf-sdk-go v1.0.12
+	github.com/aws/aws-ebpf-sdk-go v1.0.13
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/aws/amazon-vpc-cni-k8s v1.19.3-rc1 h1:xhW7QKlgA5fWK8zLmRU0R47eunOH7DL6IU/mWVSDjwQ=
 github.com/aws/amazon-vpc-cni-k8s v1.19.3-rc1/go.mod h1:WzIsGmsfmDQa6NG+9kQhHZ+Ot1sClEzjNsxcmQnnOHg=
-github.com/aws/aws-ebpf-sdk-go v1.0.12 h1:ceFVCvTptFZKm9PToVQJZY4uZx9dt5Thj0ZinKhw6GI=
-github.com/aws/aws-ebpf-sdk-go v1.0.12/go.mod h1:iOJ9wFCFfBJK1UGFwIY6KR/xXtESnPPUf5mLJGyJus0=
+github.com/aws/aws-ebpf-sdk-go v1.0.13 h1:xDBITkyKmiMMKy6Y2P/WbJuxd8OHG7rWUgLZ0zNOJv8=
+github.com/aws/aws-ebpf-sdk-go v1.0.13/go.mod h1:iOJ9wFCFfBJK1UGFwIY6KR/xXtESnPPUf5mLJGyJus0=
 github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
 github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/ebpf/bpf_client_mock.go
+++ b/pkg/ebpf/bpf_client_mock.go
@@ -9,7 +9,7 @@ import (
 
 // NewMockBpfClient is an exported helper for tests that returns a mock implementation of BpfClient.
 // This function is intended for use in tests in other packages.
-func NewMockBpfClient() BpfClient {
+func NewMockBpfClient() *bpfClient {
 	return &bpfClient{
 		policyEndpointeBPFContext: new(sync.Map),
 		IngressPodToProgMap:       new(sync.Map),

--- a/pkg/ebpf/bpf_client_test.go
+++ b/pkg/ebpf/bpf_client_test.go
@@ -546,7 +546,7 @@ func TestRecoverBPFState(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			policyEndpointeBPFContext := new(sync.Map)
 			globapMaps := new(sync.Map)
-			gotIsConntrackMapPresent, gotIsPolicyEventsMapPresent, gotEventsMapFD, _, _, gotError := recoverBPFState(mockTCClient, mockBpfClient, policyEndpointeBPFContext, globapMaps,
+			gotIsConntrackMapPresent, gotIsPolicyEventsMapPresent, gotEventsMapFD, _, _, gotError := NewMockBpfClient().recoverBPFState(mockTCClient, mockBpfClient, policyEndpointeBPFContext, globapMaps,
 				tt.updateIngressProbe, tt.updateEgressProbe, tt.updateEventsProbe)
 			assert.Equal(t, tt.want.isConntrackMapPresent, gotIsConntrackMapPresent)
 			assert.Equal(t, tt.want.isPolicyEventsMapPresent, gotIsPolicyEventsMapPresent)

--- a/pkg/ebpf/bpf_mem_map.go
+++ b/pkg/ebpf/bpf_mem_map.go
@@ -1,0 +1,275 @@
+package ebpf
+
+import (
+	"bytes"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/aws/aws-ebpf-sdk-go/pkg/maps"
+)
+
+// InMemoryBpfMap provides an in-memory representation of an eBPF map
+// with synchronized updates to the underlying kernel map
+type InMemoryBpfMap struct {
+	// Underlying BPF map
+	bpfMap *maps.BpfMap
+	// In-memory representation of the map contents
+	contents map[string][]byte
+	// Mutex for thread safety
+	mutex sync.RWMutex
+}
+
+// NewInMemoryBpfMap creates a new in-memory representation of an eBPF map
+// and optionally loads the initial state from the kernel
+func NewInMemoryBpfMap(bpfMap *maps.BpfMap) (*InMemoryBpfMap, error) {
+	m := &InMemoryBpfMap{
+		bpfMap:   bpfMap,
+		contents: make(map[string][]byte),
+	}
+
+	log().Infof("creating new In memory map via loading bpfmap: %+v", bpfMap)
+	if err := m.loadFromKernel(); err != nil {
+		return nil, err
+	}
+	log().Infof("created in mem map for bpfmap: %+v", bpfMap)
+
+	return m, nil
+}
+
+// loadFromKernel loads the current state of the eBPF map from the kernel
+func (m *InMemoryBpfMap) loadFromKernel() error {
+	startTime := time.Now()
+
+	defer func() {
+		totalTime := time.Since(startTime)
+		log().Infof("loadFromKernel completed in %v ms, loaded %d entries from kernel map",
+			totalTime.Milliseconds(), len(m.contents))
+	}()
+
+	log().Infof("Starting loadFromKernel operation")
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	// Clear current contents
+	m.contents = make(map[string][]byte)
+
+	// todo - ensure ebpf-sdk-go dependency is updated for correct behavior
+	// Get all keys from the kernel map
+	keys, err := m.bpfMap.GetAllMapKeys()
+	if err != nil {
+		log().Errorf("Failed to get keys from kernel map: %v", err)
+		return err
+	}
+
+	// For each key, get the value and store in memory
+	for _, key := range keys {
+		keyByte := []byte(key)
+		keyPtr := uintptr(unsafe.Pointer(&keyByte[0]))
+
+		// Create a buffer for the value based on map's value size
+		value := make([]byte, m.bpfMap.MapMetaData.ValueSize)
+		valuePtr := uintptr(unsafe.Pointer(&value[0]))
+
+		if err := m.bpfMap.GetMapEntry(keyPtr, valuePtr); err != nil {
+			log().Errorf("Failed to get value for key %s: %v", key, err)
+			return err
+		}
+
+		m.contents[key] = value
+	}
+
+	log().Infof("Loaded %d entries from kernel map", len(m.contents))
+	return nil
+}
+
+// Get retrieves a value from the in-memory map
+// Note: The returned byte slice should not be modified by the caller
+func (m *InMemoryBpfMap) Get(key string) ([]byte, bool) {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	value, exists := m.contents[key]
+	return value, exists
+}
+
+// Update updates both in-memory and kernel map
+// Note: The map takes ownership of the value slice, which should not be modified after calling this method
+func (m *InMemoryBpfMap) Update(key string, value []byte) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	// Store the value directly without copying
+	m.contents[key] = value
+
+	// Update kernel map immediately
+	keyByte := []byte(key)
+	keyPtr := uintptr(unsafe.Pointer(&keyByte[0]))
+	valuePtr := uintptr(unsafe.Pointer(&value[0]))
+
+	if err := m.bpfMap.UpdateMapEntry(keyPtr, valuePtr); err != nil {
+		log().Errorf("Failed to update kernel map for key %s: %v", key, err)
+		return err
+	}
+
+	return nil
+}
+
+// Delete removes an entry from both in-memory and kernel map
+func (m *InMemoryBpfMap) Delete(key string) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	// Delete from kernel map
+	keyByte := []byte(key)
+	keyPtr := uintptr(unsafe.Pointer(&keyByte[0]))
+	if err := m.bpfMap.DeleteMapEntry(keyPtr); err != nil {
+		log().Errorf("Failed to delete from kernel map for key %s: %v", key, err)
+		return err
+	}
+
+	// Delete from in-memory representation
+	delete(m.contents, key)
+
+	return nil
+}
+
+// BulkUpdate efficiently updates multiple entries with optimized kernel updates
+func (m *InMemoryBpfMap) BulkUpdate(updates map[string][]byte) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	// Calculate changes by comparing with current in-memory state
+	toAdd := make(map[string][]byte)
+
+	for k, v := range updates {
+		currentVal, exists := m.contents[k]
+		if !exists || !bytes.Equal(currentVal, v) {
+			// Only update if the key doesn't exist or value has changed
+			toAdd[k] = v
+			m.contents[k] = v
+		}
+	}
+
+	// Apply only the necessary updates to kernel
+	for k, v := range toAdd {
+		keyByte := []byte(k)
+		keyPtr := uintptr(unsafe.Pointer(&keyByte[0]))
+		valuePtr := uintptr(unsafe.Pointer(&v[0]))
+
+		if err := m.bpfMap.UpdateMapEntry(keyPtr, valuePtr); err != nil {
+			log().Errorf("Failed to update kernel map during bulk update for key %s: %v", k, err)
+			return err
+		}
+	}
+
+	log().Infof("Bulk updated %d entries in kernel map", len(toAdd))
+	return nil
+}
+
+// BulkRefresh efficiently handles both additions and deletions in a single operation
+func (m *InMemoryBpfMap) BulkRefresh(newMapContents map[string][]byte) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	// Find entries to add or update
+	toAdd := make(map[string][]byte)
+	for k, v := range newMapContents {
+		currentVal, exists := m.contents[k]
+		if !exists || !bytes.Equal(currentVal, v) {
+			toAdd[k] = v
+		}
+	}
+
+	// Find entries to delete
+	toDelete := make([]string, 0)
+	for k := range m.contents {
+		if _, exists := newMapContents[k]; !exists {
+			toDelete = append(toDelete, k)
+		}
+	}
+
+	// Apply updates to kernel
+	for k, v := range toAdd {
+		keyByte := []byte(k)
+		keyPtr := uintptr(unsafe.Pointer(&keyByte[0]))
+		valuePtr := uintptr(unsafe.Pointer(&v[0]))
+
+		if err := m.bpfMap.UpdateMapEntry(keyPtr, valuePtr); err != nil {
+			log().Errorf("Failed to update kernel map during bulk refresh for key %s: %v", k, err)
+			return err
+		}
+
+		// Update in-memory after successful kernel update
+		m.contents[k] = v
+	}
+
+	// Apply deletes to kernel
+	for _, k := range toDelete {
+		keyByte := []byte(k)
+		keyPtr := uintptr(unsafe.Pointer(&keyByte[0]))
+
+		if err := m.bpfMap.DeleteMapEntry(keyPtr); err != nil {
+			log().Errorf("Failed to delete from kernel map for key %s: %v", k, err)
+			// Continue with other deletions
+		}
+
+		// Remove from in-memory regardless of kernel operation result
+		delete(m.contents, k)
+	}
+
+	log().Infof("Bulk refresh: added/updated %d entries, deleted %d entries", len(toAdd), len(toDelete))
+	return nil
+}
+
+// GetAllKeys returns all keys in the in-memory map
+func (m *InMemoryBpfMap) GetAllKeys() []string {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	keys := make([]string, 0, len(m.contents))
+	for k := range m.contents {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// GetAllEntries returns all entries in the in-memory map
+// Note: The returned map and byte slices should not be modified by the caller
+func (m *InMemoryBpfMap) GetAllEntries() map[string][]byte {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	// Return a copy of the map but not the values
+	entries := make(map[string][]byte, len(m.contents))
+	for k, v := range m.contents {
+		entries[k] = v
+	}
+	return entries
+}
+
+// Size returns the number of entries in the in-memory map
+func (m *InMemoryBpfMap) Size() int {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	return len(m.contents)
+}
+
+// Clear removes all entries from both in-memory and kernel maps
+func (m *InMemoryBpfMap) Clear() error {
+	keys := m.GetAllKeys()
+
+	for _, k := range keys {
+		if err := m.Delete(k); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// GetUnderlyingMap returns the underlying BpfMap
+func (m *InMemoryBpfMap) GetUnderlyingMap() *maps.BpfMap {
+	return m.bpfMap
+}


### PR DESCRIPTION
*Issue #, if available:*
High CPU usage https://github.com/aws/aws-network-policy-agent/issues/417

This PR solved part of the problem to optimize ebpf map writing

*Description of changes:*
- upgraded ebpf-go dependency for fd re-use
- in-mem ebpf to make incremental changes to ebpf map

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
