### PR TITLE
fixed unbound variable error

### DIFF
--- a/scripts/lib/tests.sh
+++ b/scripts/lib/tests.sh
@@ -48,7 +48,7 @@ function run_cyclonus_tests(){
     while true; do
       STATUS=$(kubectl get job.batch/cyclonus -n netpol  -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}')
       if [ "$STATUS" == "True" ]; then
-        echo "Job $JOB_NAME has failed. Exiting."
+        echo "Job cyclonus has failed. Exiting."
         break
       fi
 


### PR DESCRIPTION
*Issue #, if available:*
```
++ kubectl get job.batch/cyclonus -n netpol -o 'jsonpath={.status.conditions[?(@.type=="Failed")].status}'
+ STATUS=True
+ '[' True == True ']'
/home/runner/work/aws-network-policy-agent/aws-network-policy-agent/scripts/lib/tests.sh: line 51: JOB_NAME: unbound variable
++ cleanup
++ [[ false == \t\r\u\e ]]
++ delete_cluster
```

https://github.com/aws/aws-network-policy-agent/actions/runs/15765031040/job/44439654432#step:5:252

*Description of changes:*
Fixed unbound var error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
