### PR TITLE
Allow ACCEPT policy decisions to not be sent to cloudwatch logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ Network Policy agent can operate in either IPv4 or IPv6 mode. Setting this flag 
 
 **Note:** VPC CNI by default creates an egress only IPv4 interface for IPv6 pods and this network interface will not be secured by the Network policy feature. Network policies will only be enforced on the Pod's primary interface (i.e.,) `eth0`. If you want to block the egress IPv4 access, please disable the interface creation via [ENABLE_V4_EGRESS](https://github.com/aws/amazon-vpc-cni-k8s#enable_v4_egress-v1151) flag in VPC CNI. 
 
+#### `cloudwatch-log-level`
+
+Type: String
+
+Default: debug
+
+Sets the logging verbosity for the policy stream toCloudwatch. Valid options are: debug, info, warn, error.
+
+DENY flow logs are always logged, regardless of the log level.
+ACCEPT flow logs are logged only at debug level, and only if --enable-policy-event-logs and -- enable-cloudwatch-logs is set to true
+
 #### `log-level`
 
 Type: String

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func main() {
 		}
 
 		ebpfClient := lo.Must1(ebpf.NewBpfClient(nodeIP, ctrlConfig.EnablePolicyEventLogs, ctrlConfig.EnableCloudWatchLogs,
-			ctrlConfig.EnableIPv6, ctrlConfig.ConntrackCacheCleanupPeriod, ctrlConfig.ConntrackCacheTableSize))
+			ctrlConfig.EnableIPv6, ctrlConfig.ConntrackCacheCleanupPeriod, ctrlConfig.ConntrackCacheTableSize, ctrlConfig.CloudwatchLogLevel))
 		ebpfClient.ReAttachEbpfProbes()
 
 		policyEndpointController = controllers.NewPolicyEndpointsReconciler(mgr.GetClient(), nodeIP, ebpfClient)

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -9,11 +9,13 @@ import (
 )
 
 const (
+	flagCloudwatchLogLevel             = "cloudwatch-log-level"
 	flagLogLevel                       = "log-level"
 	flagLogFile                        = "log-file"
 	flagLogFileMaxSize                 = "log-file-max-size"
 	flagLogFileMaxBackups              = "log-file-max-backups"
 	flagMaxConcurrentReconciles        = "max-concurrent-reconciles"
+	defaultCloudwatchLogLevel          = "debug"
 	defaultLogLevel                    = "debug"
 	defaultLogFile                     = "/var/log/aws-routed-eni/network-policy-agent.log"
 	defaultLogFileMaxSize              = logger.DEFAULT_LOG_FILE_MAX_SIZE
@@ -31,6 +33,8 @@ const (
 
 // ControllerConfig contains the controller configuration
 type ControllerConfig struct {
+	// Log level for the cloudwatch logs
+	CloudwatchLogLevel string
 	// Log level for the controller logs
 	LogLevel string
 	// Local log file for Network Policy Agent
@@ -58,6 +62,8 @@ type ControllerConfig struct {
 }
 
 func (cfg *ControllerConfig) BindFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&cfg.CloudwatchLogLevel, flagCloudwatchLogLevel, defaultCloudwatchLogLevel,
+		"Set the cloudwatch log level - info, debug")
 	fs.StringVar(&cfg.LogLevel, flagLogLevel, defaultLogLevel,
 		"Set the controller log level - info, debug")
 	fs.StringVar(&cfg.LogFile, flagLogFile, defaultLogFile, ""+

--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -130,7 +130,7 @@ type BPFContext struct {
 }
 
 func NewBpfClient(nodeIP string, enablePolicyEventLogs, enableCloudWatchLogs bool,
-	enableIPv6 bool, conntrackTTL int, conntrackTableSize int) (*bpfClient, error) {
+	enableIPv6 bool, conntrackTTL int, conntrackTableSize int, cloudwatchLogLevel string) (*bpfClient, error) {
 	var conntrackMap goebpfmaps.BpfMap
 
 	ebpfClient := &bpfClient{
@@ -253,7 +253,7 @@ func NewBpfClient(nodeIP string, enablePolicyEventLogs, enableCloudWatchLogs boo
 	log().Info("Initialized Conntrack client")
 
 	if enablePolicyEventLogs {
-		err = events.ConfigurePolicyEventsLogging(enableCloudWatchLogs, eventBufferFD, enableIPv6)
+		err = events.ConfigurePolicyEventsLogging(enableCloudWatchLogs, eventBufferFD, enableIPv6, cloudwatchLogLevel)
 		if err != nil {
 			log().Errorf("unable to initialize event buffer for Policy event exiting..error: %v", err)
 			sdkAPIErr.WithLabelValues("ConfigurePolicyEventsLogging").Inc()

--- a/pkg/ebpf/events/events.go
+++ b/pkg/ebpf/events/events.go
@@ -82,7 +82,7 @@ type ringBufferDataV6_t struct {
 	IsEgress   uint8
 }
 
-func ConfigurePolicyEventsLogging(enableCloudWatchLogs bool, mapFD int, enableIPv6 bool) error {
+func ConfigurePolicyEventsLogging(enableCloudWatchLogs bool, mapFD int, enableIPv6 bool, cloudwatchLogLevel string) error {
 	// Enable logging and setup ring buffer
 	if mapFD <= 0 {
 		log().Errorf("MapFD is invalid %d", mapFD)
@@ -106,7 +106,7 @@ func ConfigurePolicyEventsLogging(enableCloudWatchLogs bool, mapFD int, enableIP
 			}
 		}
 		log().Debug("Configure Event loop ... ")
-		capturePolicyEvents(eventChanList[mapFD], enableCloudWatchLogs, enableIPv6)
+		capturePolicyEvents(eventChanList[mapFD], enableCloudWatchLogs, enableIPv6, cloudwatchLogLevel)
 	}
 	return nil
 }
@@ -187,7 +187,7 @@ func publishDataToCloudwatch(logQueue []*cloudwatchlogs.InputLogEvent, message s
 	return true
 }
 
-func capturePolicyEvents(ringbufferdata <-chan []byte, enableCloudWatchLogs bool, enableIPv6 bool) {
+func capturePolicyEvents(ringbufferdata <-chan []byte, enableCloudWatchLogs bool, enableIPv6 bool, cloudwatchLogLevel string) {
 	nodeName := os.Getenv("MY_NODE_NAME")
 	// Read from ringbuffer channel, perf buffer support is not there and 5.10 kernel is needed.
 	go func(ringbufferdata <-chan []byte) {
@@ -195,6 +195,7 @@ func capturePolicyEvents(ringbufferdata <-chan []byte, enableCloudWatchLogs bool
 		for record := range ringbufferdata {
 			var logQueue []*cloudwatchlogs.InputLogEvent
 			var message string
+			publishCloudwatchMessage := false
 			direction := "egress"
 			if enableIPv6 {
 				var rb ringBufferDataV6_t
@@ -216,6 +217,7 @@ func capturePolicyEvents(ringbufferdata <-chan []byte, enableCloudWatchLogs bool
 					dropBytesTotal.WithLabelValues(direction).Add(float64(rb.PacketSz))
 					log().Infof("Flow Info: Src IP: %s Src Port: %d Dest IP: %s Dest Port: %d Proto: %s Verdict: %s Direction: %s", utils.ConvByteToIPv6(rb.SourceIP).String(), rb.SourcePort,
 						utils.ConvByteToIPv6(rb.DestIP).String(), rb.DestPort, protocol, string(verdict), string(direction))
+					publishCloudwatchMessage = true
 				} else {
 					log().Debugf("Flow Info: Src IP: %s Src Port: %d Dest IP: %s Dest Port: %d Proto: %s Verdict: %s Direction: %s", utils.ConvByteToIPv6(rb.SourceIP).String(), rb.SourcePort,
 						utils.ConvByteToIPv6(rb.DestIP).String(), rb.DestPort, protocol, string(verdict), string(direction))
@@ -241,6 +243,7 @@ func capturePolicyEvents(ringbufferdata <-chan []byte, enableCloudWatchLogs bool
 					dropBytesTotal.WithLabelValues(direction).Add(float64(rb.PacketSz))
 					log().Infof("Flow Info: Src IP: %s Src Port: %d Dest IP: %s Dest Port: %d Proto %s Verdict %s Direction %s", utils.ConvByteArrayToIP(rb.SourceIP), rb.SourcePort,
 						utils.ConvByteArrayToIP(rb.DestIP), rb.DestPort, protocol, string(verdict), string(direction))
+					publishCloudwatchMessage = true
 				} else {
 					log().Debugf("Flow Info: Src IP: %s Src Port: %d Dest IP: %s Dest Port: %d Proto %s Verdict %s Direction %s", utils.ConvByteArrayToIP(rb.SourceIP), rb.SourcePort,
 						utils.ConvByteArrayToIP(rb.DestIP), rb.DestPort, protocol, string(verdict), string(direction))
@@ -249,7 +252,11 @@ func capturePolicyEvents(ringbufferdata <-chan []byte, enableCloudWatchLogs bool
 				message = "Node: " + nodeName + ";" + "SIP: " + utils.ConvByteArrayToIP(rb.SourceIP) + ";" + "SPORT: " + strconv.Itoa(int(rb.SourcePort)) + ";" + "DIP: " + utils.ConvByteArrayToIP(rb.DestIP) + ";" + "DPORT: " + strconv.Itoa(int(rb.DestPort)) + ";" + "PROTOCOL: " + protocol + ";" + "PolicyVerdict: " + verdict
 			}
 
-			if enableCloudWatchLogs {
+			if cloudwatchLogLevel == "debug" {
+				publishCloudwatchMessage = true
+			}
+
+			if enableCloudWatchLogs && publishCloudwatchMessage {
 				done = publishDataToCloudwatch(logQueue, message)
 				if done {
 					break


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-network-policy-agent/issues/427

*Description of changes:*
Allow log level to be set for cloudwatch logs to match functionality of controller log level setting to avoid unnecessary logs to be sent to cloudwatch causing extra logging that is not always desired.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
