### PR TITLE
fix: making cyclonus job resilient to Node restart

### DIFF
--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -15,5 +15,5 @@ runs:
     - name: Set up eksctl
       shell: bash
       run: |
-        curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+        curl --silent --location "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
         sudo mv /tmp/eksctl /usr/local/bin/

--- a/scripts/lib/tests.sh
+++ b/scripts/lib/tests.sh
@@ -15,10 +15,9 @@ kind: Job
 metadata:
   name: cyclonus
 spec:
-  backoffLimit: 0
   template:
     spec:
-      restartPolicy: Never
+      restartPolicy: OnFailure
       serviceAccount: cyclonus
       containers:
         - name: cyclonus


### PR DESCRIPTION
*Issue #, if available:*

Conformance tests in GH Actions are failing https://github.com/aws/aws-network-policy-agent/actions/runs/16510731887 

Replicated failure on test cluster. Node restart causes the cyclonus job to fails.

*Description of changes:*

Making job resilient to Node reboots.

Tested on test cluster, jobs succeeds even after Node restarts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
