### PR TITLE
Fixed GH E2E conformance test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ amazon-network-policy-controller-k8s
 test/build/
 
 results.log
+eks-cluster.yaml

--- a/scripts/lib/cleanup.sh
+++ b/scripts/lib/cleanup.sh
@@ -1,11 +1,14 @@
 
 function check_path_cleanup(){
 
+    TEST_AGENT_IMAGE_REPOSITORY=${TEST_IMAGE_REGISTRY}/networking-e2e-test-images
+    export TEST_AGENT_IMAGE_REPOSITORY
+
     local worker_nodes=$(kubectl get nodes -o custom-columns=NAME:.metadata.name --no-headers)
     for node in $worker_nodes
     do
         export NODE=$node
-        envsubst '$NODE' < ${DIR}/test/check-cleanup-pod.yaml > ${DIR}/test/check-cleanup-pod-$node.yaml
+        envsubst '$NODE $TEST_AGENT_IMAGE_REPOSITORY' < ${DIR}/test/check-cleanup-pod.yaml > ${DIR}/test/check-cleanup-pod-$node.yaml
         kubectl apply -f ${DIR}/test/check-cleanup-pod-$node.yaml -n default
         rm -rf ${DIR}/test/check-cleanup-pod-$node.yaml
     done

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -50,4 +50,6 @@ check_path_cleanup
 if [[ $TEST_FAILED == "true" ]]; then
   echo "Test run failed, check failures"
   exit 1
+else
+  echo "Test run succeeded"
 fi

--- a/scripts/test/check-cleanup-pod.yaml
+++ b/scripts/test/check-cleanup-pod.yaml
@@ -6,7 +6,7 @@ spec:
     restartPolicy: Never
     nodeName: $NODE
     containers:
-      - image: public.ecr.aws/r7y6e9p2/test-agent:latest
+      - image: ${TEST_IMAGE_REGISTRY}/aws-network-policy-test-agent:latest
         name: check-bpf-cleanup
         command: ["./check-bpf-cleanup-agent"]
         volumeMounts:

--- a/test/agent/Dockerfile
+++ b/test/agent/Dockerfile
@@ -1,6 +1,6 @@
 ARG golang_image
 
-FROM $golang_image as builder
+FROM $golang_image AS builder
 
 WORKDIR /workspace
 ENV GOPROXY direct

--- a/test/agent/go.mod
+++ b/test/agent/go.mod
@@ -1,3 +1,3 @@
 module github.com/aws/aws-network-policy-agent/test/agent
 
-go 1.20
+go 1.24


### PR DESCRIPTION
*Issue #, if available:*
test image of agent for path cleanup check was not available in arm64 architecture which was failing the conformance test in  graviton instances

*Description of changes:*
I have pushed arm64 arch image in test repo and verified test running fine on graviton instances 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
