### PR TITLE
Fix race condition with attach and delete concurrency

### DIFF
--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -107,18 +107,8 @@ type BpfClient interface {
 	DeleteBPFProbes(pod types.NamespacedName, podIdentifier string) error
 	UpdateEbpfMaps(podIdentifier string, ingressFirewallRules []fwrp.EbpfFirewallRules, egressFirewallRules []fwrp.EbpfFirewallRules) error
 	UpdatePodStateEbpfMaps(podIdentifier string, state int, updateIngress bool, updateEgress bool) error
-	IsEBPFProbeAttached(podName string, podNamespace string) (bool, bool)
 	IsFirstPodInPodIdentifier(podIdentifier string) bool
-	IsProgFdShared(targetPodName string, targetPodNamespace string) (bool, error)
-	GetIngressPodToProgMap() *sync.Map
-	GetEgressPodToProgMap() *sync.Map
-	GetIngressProgToPodsMap() *sync.Map
-	GetEgressProgToPodsMap() *sync.Map
-	DeletePodFromIngressProgPodCaches(podName string, podNamespace string)
-	DeletePodFromEgressProgPodCaches(podName string, podNamespace string)
 	ReAttachEbpfProbes() error
-	DeleteBPFProgramAndMaps(podIdentifier string) error
-	GetPodIdentifierLockMap() *sync.Map
 	GetNetworkPolicyMode() string
 }
 
@@ -135,12 +125,12 @@ func NewBpfClient(nodeIP string, enablePolicyEventLogs, enableCloudWatchLogs boo
 	ebpfClient := &bpfClient{
 		// Maps PolicyEndpoint resource to it's eBPF context
 		policyEndpointeBPFContext: new(sync.Map),
-		IngressPodToProgMap:       new(sync.Map),
-		EgressPodToProgMap:        new(sync.Map),
-		GlobalMaps:                new(sync.Map),
-		IngressProgToPodsMap:      new(sync.Map),
-		EgressProgToPodsMap:       new(sync.Map),
-		PodIdentifierLock:         new(sync.Map),
+		ingressPodToProgMap:       new(sync.Map),
+		egressPodToProgMap:        new(sync.Map),
+		globalMaps:                new(sync.Map),
+		ingressProgToPodsMap:      new(sync.Map),
+		egressProgToPodsMap:       new(sync.Map),
+		podIdentifierLock:         new(sync.Map),
 		podNameToInterfaceCount:   new(sync.Map),
 		networkPolicyMode:         networkPolicyMode,
 		isMultiNICEnabled:         isMultiNICEnabled,
@@ -193,7 +183,7 @@ func NewBpfClient(nodeIP string, enablePolicyEventLogs, enableCloudWatchLogs boo
 	var interfaceNametoEgressPinPath map[string]string
 	eventBufferFD := 0
 	isConntrackMapPresent, isPolicyEventsMapPresent, eventBufferFD, interfaceNametoIngressPinPath, interfaceNametoEgressPinPath, err = ebpfClient.recoverBPFState(ebpfClient.bpfTCClient, ebpfClient.bpfSDKClient, ebpfClient.policyEndpointeBPFContext,
-		ebpfClient.GlobalMaps, ingressUpdateRequired, egressUpdateRequired, eventsUpdateRequired)
+		ebpfClient.globalMaps, ingressUpdateRequired, egressUpdateRequired, eventsUpdateRequired)
 	if err != nil {
 		//Log the error and move on
 		log().Errorf("Failed to recover the BPF state error: %v", err)
@@ -241,7 +231,7 @@ func NewBpfClient(nodeIP string, enablePolicyEventLogs, enableCloudWatchLogs boo
 	}
 
 	if isConntrackMapPresent {
-		recoveredConntrackMap, ok := ebpfClient.GlobalMaps.Load(CONNTRACK_MAP_PIN_PATH)
+		recoveredConntrackMap, ok := ebpfClient.globalMaps.Load(CONNTRACK_MAP_PIN_PATH)
 		if ok {
 			conntrackMap = recoveredConntrackMap.(goebpfmaps.BpfMap)
 			log().Info("Derived existing ConntrackMap identifier")
@@ -298,11 +288,11 @@ type bpfClient struct {
 	// Stores eBPF Ingress and Egress context per policyEndpoint resource
 	policyEndpointeBPFContext *sync.Map
 	// Stores the Ingress eBPF Prog FD per pod
-	IngressPodToProgMap *sync.Map
+	ingressPodToProgMap *sync.Map
 	// Stores the Egress eBPF Prog FD per pod
-	EgressPodToProgMap *sync.Map
+	egressPodToProgMap *sync.Map
 	// Stores info on the global maps the agent creates
-	GlobalMaps *sync.Map
+	globalMaps *sync.Map
 	// Ingress eBPF probe binary
 	ingressBinary string
 	// Egress eBPF probe binary
@@ -316,11 +306,11 @@ type bpfClient struct {
 	// eBPF TC Client
 	bpfTCClient tc.BpfTc
 	// Stores the Ingress eBPF Prog FD to pods mapping
-	IngressProgToPodsMap *sync.Map
+	ingressProgToPodsMap *sync.Map
 	// Stores the Egress eBPF Prog FD to pods mapping
-	EgressProgToPodsMap *sync.Map
+	egressProgToPodsMap *sync.Map
 	// Stores podIdentifier to operations lock mapping
-	PodIdentifierLock *sync.Map
+	podIdentifierLock *sync.Map
 	// This is only updated and used for probe binary updates during initialization
 	interfaceNametoIngressPinPath map[string]string
 	// This is only updated and used for probe binary updates during initialization
@@ -562,26 +552,6 @@ func (l *bpfClient) ReAttachEbpfProbes() error {
 	return nil
 }
 
-func (l *bpfClient) GetIngressPodToProgMap() *sync.Map {
-	return l.IngressPodToProgMap
-}
-
-func (l *bpfClient) GetEgressPodToProgMap() *sync.Map {
-	return l.EgressPodToProgMap
-}
-
-func (l *bpfClient) GetIngressProgToPodsMap() *sync.Map {
-	return l.IngressProgToPodsMap
-}
-
-func (l *bpfClient) GetEgressProgToPodsMap() *sync.Map {
-	return l.EgressProgToPodsMap
-}
-
-func (l *bpfClient) GetPodIdentifierLockMap() *sync.Map {
-	return l.PodIdentifierLock
-}
-
 func (l *bpfClient) GetNetworkPolicyMode() string {
 	return l.networkPolicyMode
 }
@@ -658,7 +628,7 @@ func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier str
 
 	// Two go routines can try to attach the probes at the same time
 	// Locking will help updating all the datastructures correctly
-	value, _ := l.PodIdentifierLock.LoadOrStore(podIdentifier, &sync.Mutex{})
+	value, _ := l.podIdentifierLock.LoadOrStore(podIdentifier, &sync.Mutex{})
 	podIdentifierLock := value.(*sync.Mutex)
 	podIdentifierLock.Lock()
 	log().Debugf("Got the podIdentifierLock for Pod: %s, Namespace: %s, PodIdentifier: %s", pod.Name, pod.Namespace, podIdentifier)
@@ -666,7 +636,7 @@ func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier str
 
 	// Check if an eBPF probe is already attached on both ingress and egress direction(s) for this pod.
 	// If yes, then skip probe attach flow for this pod.
-	isIngressProbeAttached, isEgressProbeAttached := l.IsEBPFProbeAttached(pod.Name, pod.Namespace)
+	isIngressProbeAttached, isEgressProbeAttached := l.isEBPFProbeAttached(pod.Name, pod.Namespace)
 	if isIngressProbeAttached && isEgressProbeAttached {
 		return nil
 	}
@@ -717,14 +687,14 @@ func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier str
 		}
 	}
 	if !isIngressProbeAttached {
-		l.IngressPodToProgMap.Store(podNamespacedName, ingressProgFD)
-		currentPodSet, _ := l.IngressProgToPodsMap.LoadOrStore(ingressProgFD, make(map[string]struct{}))
+		l.ingressPodToProgMap.Store(podNamespacedName, ingressProgFD)
+		currentPodSet, _ := l.ingressProgToPodsMap.LoadOrStore(ingressProgFD, make(map[string]struct{}))
 		currentPodSet.(map[string]struct{})[podNamespacedName] = struct{}{}
 	}
 
 	if !isEgressProbeAttached {
-		l.EgressPodToProgMap.Store(podNamespacedName, egressProgFD)
-		currentPodSet, _ := l.EgressProgToPodsMap.LoadOrStore(egressProgFD, make(map[string]struct{}))
+		l.egressPodToProgMap.Store(podNamespacedName, egressProgFD)
+		currentPodSet, _ := l.egressProgToPodsMap.LoadOrStore(egressProgFD, make(map[string]struct{}))
 		currentPodSet.(map[string]struct{})[podNamespacedName] = struct{}{}
 	}
 	return nil
@@ -806,28 +776,28 @@ func (l *bpfClient) attachEgressBPFProbe(hostVethName string, podIdentifier stri
 }
 
 func (l *bpfClient) DeleteBPFProbes(pod types.NamespacedName, podIdentifier string) error {
-	value, _ := l.PodIdentifierLock.LoadOrStore(podIdentifier, &sync.Mutex{})
+	value, _ := l.podIdentifierLock.LoadOrStore(podIdentifier, &sync.Mutex{})
 	podIdentifierLock := value.(*sync.Mutex)
 	podIdentifierLock.Lock()
 	defer podIdentifierLock.Unlock()
 	log().Debugf("Got the podIdentifierLock for Pod: %s Namespace: %s PodIdentifier: %s", pod.Name, pod.Namespace, podIdentifier)
 
-	isProgFdShared, err := l.IsProgFdShared(pod.Name, pod.Namespace)
-	l.DeletePodFromIngressProgPodCaches(pod.Name, pod.Namespace)
-	l.DeletePodFromEgressProgPodCaches(pod.Name, pod.Namespace)
+	isProgFdShared, err := l.isProgFdShared(pod.Name, pod.Namespace)
+	l.deletePodFromIngressProgPodCaches(pod.Name, pod.Namespace)
+	l.deletePodFromEgressProgPodCaches(pod.Name, pod.Namespace)
 
 	if err == nil && !isProgFdShared {
-		err := l.DeleteBPFProgramAndMaps(podIdentifier)
+		err := l.deleteBPFProbes(podIdentifier)
 		if err != nil {
 			log().Errorf("BPF programs and Maps delete failed for podIdentifier: %s, error: %v", podIdentifier, err)
 			return err
 		}
-		l.PodIdentifierLock.Delete(podIdentifier)
+		l.podIdentifierLock.Delete(podIdentifier)
 	}
 	return nil
 }
 
-func (l *bpfClient) DeleteBPFProgramAndMaps(podIdentifier string) error {
+func (l *bpfClient) deleteBPFProbes(podIdentifier string) error {
 	start := time.Now()
 	err := l.deleteBPFProgramAndMaps(podIdentifier, "ingress")
 	duration := msSince(start)
@@ -1031,13 +1001,13 @@ func (l *bpfClient) UpdatePodStateEbpfMaps(podIdentifier string, state int, upda
 	return nil
 }
 
-func (l *bpfClient) IsEBPFProbeAttached(podName string, podNamespace string) (bool, bool) {
+func (l *bpfClient) isEBPFProbeAttached(podName string, podNamespace string) (bool, bool) {
 	ingress, egress := false, false
-	if _, ok := l.IngressPodToProgMap.Load(utils.GetPodNamespacedName(podName, podNamespace)); ok {
+	if _, ok := l.ingressPodToProgMap.Load(utils.GetPodNamespacedName(podName, podNamespace)); ok {
 		log().Infof("Pod already has Ingress Probe attached - Name: %s, Namespace: %s", podName, podNamespace)
 		ingress = true
 	}
-	if _, ok := l.EgressPodToProgMap.Load(utils.GetPodNamespacedName(podName, podNamespace)); ok {
+	if _, ok := l.egressPodToProgMap.Load(utils.GetPodNamespacedName(podName, podNamespace)); ok {
 		log().Infof("Pod already has Egress Probe attached - Name: %s, Namespace: %s", podName, podNamespace)
 		egress = true
 	}
@@ -1063,11 +1033,11 @@ func (l *bpfClient) IsFirstPodInPodIdentifier(podIdentifier string) bool {
 	return firstPodInPodIdentifier
 }
 
-func (l *bpfClient) IsProgFdShared(targetPodName string, targetPodNamespace string) (bool, error) {
+func (l *bpfClient) isProgFdShared(targetPodName string, targetPodNamespace string) (bool, error) {
 	targetpodNamespacedName := utils.GetPodNamespacedName(targetPodName, targetPodNamespace)
 	// check ingress caches
-	if targetProgFD, ok := l.IngressPodToProgMap.Load(targetpodNamespacedName); ok {
-		if currentList, ok := l.IngressProgToPodsMap.Load(targetProgFD); ok {
+	if targetProgFD, ok := l.ingressPodToProgMap.Load(targetpodNamespacedName); ok {
+		if currentList, ok := l.ingressProgToPodsMap.Load(targetProgFD); ok {
 			podsList, ok := currentList.(map[string]struct{})
 			if ok {
 				if len(podsList) > 1 {
@@ -1080,8 +1050,8 @@ func (l *bpfClient) IsProgFdShared(targetPodName string, targetPodNamespace stri
 	}
 
 	// Check Egress Maps if not found in Ingress
-	if targetProgFD, ok := l.EgressPodToProgMap.Load(targetpodNamespacedName); ok {
-		if currentList, ok := l.EgressProgToPodsMap.Load(targetProgFD); ok {
+	if targetProgFD, ok := l.egressPodToProgMap.Load(targetpodNamespacedName); ok {
+		if currentList, ok := l.egressProgToPodsMap.Load(targetProgFD); ok {
 			podsList, ok := currentList.(map[string]struct{})
 			if ok {
 				if len(podsList) > 1 {
@@ -1118,29 +1088,29 @@ func (l *bpfClient) updateEbpfMap(firewallRules []fwrp.EbpfFirewallRules, inMemM
 	return nil
 }
 
-func (l *bpfClient) DeletePodFromIngressProgPodCaches(podName string, podNamespace string) {
+func (l *bpfClient) deletePodFromIngressProgPodCaches(podName string, podNamespace string) {
 	podNamespacedName := utils.GetPodNamespacedName(podName, podNamespace)
-	if progFD, ok := l.IngressPodToProgMap.Load(podNamespacedName); ok {
-		l.IngressPodToProgMap.Delete(podNamespacedName)
-		if currentSet, ok := l.IngressProgToPodsMap.Load(progFD); ok {
+	if progFD, ok := l.ingressPodToProgMap.Load(podNamespacedName); ok {
+		l.ingressPodToProgMap.Delete(podNamespacedName)
+		if currentSet, ok := l.ingressProgToPodsMap.Load(progFD); ok {
 			set := currentSet.(map[string]struct{})
 			delete(set, podNamespacedName)
 			if len(set) == 0 {
-				l.IngressProgToPodsMap.Delete(progFD)
+				l.ingressProgToPodsMap.Delete(progFD)
 			}
 		}
 	}
 }
 
-func (l *bpfClient) DeletePodFromEgressProgPodCaches(podName string, podNamespace string) {
+func (l *bpfClient) deletePodFromEgressProgPodCaches(podName string, podNamespace string) {
 	podNamespacedName := utils.GetPodNamespacedName(podName, podNamespace)
-	if progFD, ok := l.EgressPodToProgMap.Load(podNamespacedName); ok {
-		l.EgressPodToProgMap.Delete(podNamespacedName)
-		if currentSet, ok := l.EgressProgToPodsMap.Load(progFD); ok {
+	if progFD, ok := l.egressPodToProgMap.Load(podNamespacedName); ok {
+		l.egressPodToProgMap.Delete(podNamespacedName)
+		if currentSet, ok := l.egressProgToPodsMap.Load(progFD); ok {
 			set := currentSet.(map[string]struct{})
 			delete(set, podNamespacedName)
 			if len(set) == 0 {
-				l.EgressProgToPodsMap.Delete(progFD)
+				l.egressProgToPodsMap.Delete(progFD)
 			}
 		}
 	}

--- a/pkg/ebpf/bpf_client_mock.go
+++ b/pkg/ebpf/bpf_client_mock.go
@@ -39,10 +39,6 @@ func (m *MockBpfClient) UpdatePodStateEbpfMaps(podIdentifier string, state int, 
 	return nil
 }
 
-func (m *MockBpfClient) IsEBPFProbeAttached(podName string, podNamespace string) (bool, bool) {
-	return false, false
-}
-
 func (m *MockBpfClient) IsFirstPodInPodIdentifier(podIdentifier string) bool {
 	return false
 }

--- a/pkg/ebpf/bpf_client_mock.go
+++ b/pkg/ebpf/bpf_client_mock.go
@@ -69,7 +69,7 @@ func (m *MockBpfClient) DeleteBPFProgramAndMaps(podIdentifier string) error {
 	return nil
 }
 
-func (m *MockBpfClient) GetDeletePodIdentifierLockMap() *sync.Map {
+func (m *MockBpfClient) GetPodIdentifierLockMap() *sync.Map {
 	return nil
 }
 

--- a/pkg/ebpf/bpf_client_mock.go
+++ b/pkg/ebpf/bpf_client_mock.go
@@ -12,11 +12,11 @@ import (
 func NewMockBpfClient() *bpfClient {
 	return &bpfClient{
 		policyEndpointeBPFContext: new(sync.Map),
-		IngressPodToProgMap:       new(sync.Map),
-		EgressPodToProgMap:        new(sync.Map),
-		IngressProgToPodsMap:      new(sync.Map),
-		EgressProgToPodsMap:       new(sync.Map),
-		GlobalMaps:                new(sync.Map),
+		ingressPodToProgMap:       new(sync.Map),
+		egressPodToProgMap:        new(sync.Map),
+		ingressProgToPodsMap:      new(sync.Map),
+		egressProgToPodsMap:       new(sync.Map),
+		globalMaps:                new(sync.Map),
 		hostMask:                  "/32",
 	}
 }
@@ -47,37 +47,7 @@ func (m *MockBpfClient) IsFirstPodInPodIdentifier(podIdentifier string) bool {
 	return false
 }
 
-func (m *MockBpfClient) IsProgFdShared(targetPodName string, targetPodNamespace string) (bool, error) {
-	return false, nil
-}
-func (m *MockBpfClient) GetIngressPodToProgMap() *sync.Map {
-	return nil
-}
-func (m *MockBpfClient) GetEgressPodToProgMap() *sync.Map {
-	return nil
-}
-func (m *MockBpfClient) GetIngressProgToPodsMap() *sync.Map {
-	return nil
-}
-func (m *MockBpfClient) GetEgressProgToPodsMap() *sync.Map {
-	return nil
-}
-
-func (m *MockBpfClient) DeletePodFromIngressProgPodCaches(podName string, podNamespace string) {
-}
-
-func (m *MockBpfClient) DeletePodFromEgressProgPodCaches(podName string, podNamespace string) {
-}
-
 func (m *MockBpfClient) ReAttachEbpfProbes() error {
-	return nil
-}
-
-func (m *MockBpfClient) DeleteBPFProgramAndMaps(podIdentifier string) error {
-	return nil
-}
-
-func (m *MockBpfClient) GetPodIdentifierLockMap() *sync.Map {
 	return nil
 }
 

--- a/pkg/ebpf/bpf_client_mock.go
+++ b/pkg/ebpf/bpf_client_mock.go
@@ -27,6 +27,10 @@ func (m *MockBpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier
 	return nil
 }
 
+func (m *MockBpfClient) DeleteBPFProbes(pod types.NamespacedName, podIdentifier string) error {
+	return nil
+}
+
 func (m *MockBpfClient) UpdateEbpfMaps(podIdentifier string, ingressFirewallRules []fwrp.EbpfFirewallRules, egressFirewallRules []fwrp.EbpfFirewallRules) error {
 	return nil
 }
@@ -41,6 +45,10 @@ func (m *MockBpfClient) IsEBPFProbeAttached(podName string, podNamespace string)
 
 func (m *MockBpfClient) IsFirstPodInPodIdentifier(podIdentifier string) bool {
 	return false
+}
+
+func (m *MockBpfClient) IsProgFdShared(targetPodName string, targetPodNamespace string) (bool, error) {
+	return false, nil
 }
 func (m *MockBpfClient) GetIngressPodToProgMap() *sync.Map {
 	return nil

--- a/pkg/ebpf/bpf_client_test.go
+++ b/pkg/ebpf/bpf_client_test.go
@@ -395,7 +395,7 @@ func TestBpfClient_AttacheBPFProbes(t *testing.T) {
 			EgressPodToProgMap:        new(sync.Map),
 			IngressProgToPodsMap:      new(sync.Map),
 			EgressProgToPodsMap:       new(sync.Map),
-			AttachProbesToPodLock:     new(sync.Map),
+			PodIdentifierLock:         new(sync.Map),
 		}
 
 		sampleBPFContext := BPFContext{
@@ -427,7 +427,7 @@ func TestBpfClient_AttacheBPFProbes(t *testing.T) {
 				EgressPodToProgMap:        new(sync.Map),
 				IngressProgToPodsMap:      new(sync.Map),
 				EgressProgToPodsMap:       new(sync.Map),
-				AttachProbesToPodLock:     new(sync.Map),
+				PodIdentifierLock:         new(sync.Map),
 				isMultiNICEnabled:         tt.isMultiNICEnabled,
 				podNameToInterfaceCount:   new(sync.Map),
 			}
@@ -806,7 +806,7 @@ func TestBpfClient_AttacheBPFProbes_MultipleInterfacesFlow(t *testing.T) {
 		EgressPodToProgMap:        new(sync.Map),
 		IngressProgToPodsMap:      new(sync.Map),
 		EgressProgToPodsMap:       new(sync.Map),
-		AttachProbesToPodLock:     new(sync.Map),
+		PodIdentifierLock:         new(sync.Map),
 		isMultiNICEnabled:         true,
 		ingressBinary:             "tc.v4ingress.bpf.o",
 		egressBinary:              "tc.v4egress.bpf.o",

--- a/pkg/ebpf/bpf_client_test.go
+++ b/pkg/ebpf/bpf_client_test.go
@@ -80,19 +80,19 @@ func TestBpfClient_IsEBPFProbeAttached(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			testBpfClient := &bpfClient{
 				hostMask:            "/32",
-				IngressPodToProgMap: new(sync.Map),
-				EgressPodToProgMap:  new(sync.Map),
+				ingressPodToProgMap: new(sync.Map),
+				egressPodToProgMap:  new(sync.Map),
 			}
 
 			if tt.ingressAttached {
 				podIdentifier := utils.GetPodNamespacedName(tt.podName, tt.podNamespace)
-				testBpfClient.IngressPodToProgMap.Store(podIdentifier, ingressProgFD)
+				testBpfClient.ingressPodToProgMap.Store(podIdentifier, ingressProgFD)
 			}
 			if tt.egressAttached {
 				podIdentifier := utils.GetPodNamespacedName(tt.podName, tt.podNamespace)
-				testBpfClient.EgressPodToProgMap.Store(podIdentifier, egressProgFD)
+				testBpfClient.egressPodToProgMap.Store(podIdentifier, egressProgFD)
 			}
-			gotIngress, gotEgress := testBpfClient.IsEBPFProbeAttached(tt.podName, tt.podNamespace)
+			gotIngress, gotEgress := testBpfClient.isEBPFProbeAttached(tt.podName, tt.podNamespace)
 			assert.Equal(t, tt.want.ingress, gotIngress)
 			assert.Equal(t, tt.want.egress, gotEgress)
 		})
@@ -391,11 +391,11 @@ func TestBpfClient_AttacheBPFProbes(t *testing.T) {
 			policyEndpointeBPFContext: new(sync.Map),
 			bpfSDKClient:              mockBpfClient,
 			bpfTCClient:               mockTCClient,
-			IngressPodToProgMap:       new(sync.Map),
-			EgressPodToProgMap:        new(sync.Map),
-			IngressProgToPodsMap:      new(sync.Map),
-			EgressProgToPodsMap:       new(sync.Map),
-			PodIdentifierLock:         new(sync.Map),
+			ingressPodToProgMap:       new(sync.Map),
+			egressPodToProgMap:        new(sync.Map),
+			ingressProgToPodsMap:      new(sync.Map),
+			egressProgToPodsMap:       new(sync.Map),
+			podIdentifierLock:         new(sync.Map),
 		}
 
 		sampleBPFContext := BPFContext{
@@ -423,11 +423,11 @@ func TestBpfClient_AttacheBPFProbes(t *testing.T) {
 				policyEndpointeBPFContext: new(sync.Map),
 				bpfSDKClient:              mockBpfClient,
 				bpfTCClient:               mockTCClient,
-				IngressPodToProgMap:       new(sync.Map),
-				EgressPodToProgMap:        new(sync.Map),
-				IngressProgToPodsMap:      new(sync.Map),
-				EgressProgToPodsMap:       new(sync.Map),
-				PodIdentifierLock:         new(sync.Map),
+				ingressPodToProgMap:       new(sync.Map),
+				egressPodToProgMap:        new(sync.Map),
+				ingressProgToPodsMap:      new(sync.Map),
+				egressProgToPodsMap:       new(sync.Map),
+				podIdentifierLock:         new(sync.Map),
 				isMultiNICEnabled:         tt.isMultiNICEnabled,
 				podNameToInterfaceCount:   new(sync.Map),
 			}
@@ -802,11 +802,11 @@ func TestBpfClient_AttacheBPFProbes_MultipleInterfacesFlow(t *testing.T) {
 		policyEndpointeBPFContext: new(sync.Map),
 		bpfSDKClient:              mockBpfClient,
 		bpfTCClient:               mockTCClient,
-		IngressPodToProgMap:       new(sync.Map),
-		EgressPodToProgMap:        new(sync.Map),
-		IngressProgToPodsMap:      new(sync.Map),
-		EgressProgToPodsMap:       new(sync.Map),
-		PodIdentifierLock:         new(sync.Map),
+		ingressPodToProgMap:       new(sync.Map),
+		egressPodToProgMap:        new(sync.Map),
+		ingressProgToPodsMap:      new(sync.Map),
+		egressProgToPodsMap:       new(sync.Map),
+		podIdentifierLock:         new(sync.Map),
 		isMultiNICEnabled:         true,
 		ingressBinary:             "tc.v4ingress.bpf.o",
 		egressBinary:              "tc.v4egress.bpf.o",
@@ -820,8 +820,8 @@ func TestBpfClient_AttacheBPFProbes_MultipleInterfacesFlow(t *testing.T) {
 	assert.NoError(t, err)
 
 	podNamespacedName := utils.GetPodNamespacedName(testPod.Name, testPod.Namespace)
-	_, ingressExists := testBpfClient.IngressPodToProgMap.Load(podNamespacedName)
-	_, egressExists := testBpfClient.EgressPodToProgMap.Load(podNamespacedName)
+	_, ingressExists := testBpfClient.ingressPodToProgMap.Load(podNamespacedName)
+	_, egressExists := testBpfClient.egressPodToProgMap.Load(podNamespacedName)
 	assert.True(t, ingressExists)
 	assert.True(t, egressExists)
 }
@@ -944,4 +944,61 @@ func TestBpfClient_getInterfaceCountFromBackupFile(t *testing.T) {
 
 func Int32Ptr(i int32) *int32 {
 	return &i
+}
+
+func TestIsProgFdShared(t *testing.T) {
+	type want struct {
+		isProgFdShared bool
+	}
+	podToProgFd := map[string]int{
+		"pod1A": 2,
+		"pod2A": 2,
+		"pod1B": 15,
+	}
+	tests := []struct {
+		name         string
+		podName      string
+		podNamespace string
+		want         want
+		wantErr      error
+	}{
+		{
+			name:         "ProgFD Shared",
+			podName:      "pod1",
+			podNamespace: "A",
+			want: want{
+				isProgFdShared: true,
+			},
+			wantErr: nil,
+		},
+		{
+			name:         "ProgFD Not Shared",
+			podName:      "pod1",
+			podNamespace: "B",
+			want: want{
+				isProgFdShared: false,
+			},
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testBpfClient := &bpfClient{
+				ingressPodToProgMap:  new(sync.Map),
+				egressPodToProgMap:   new(sync.Map),
+				ingressProgToPodsMap: new(sync.Map),
+				egressProgToPodsMap:  new(sync.Map),
+			}
+
+			// Set up test data
+			for pod, progFd := range podToProgFd {
+				testBpfClient.ingressPodToProgMap.Store(pod, progFd)
+				currentPodSet, _ := testBpfClient.ingressProgToPodsMap.LoadOrStore(progFd, make(map[string]struct{}))
+				currentPodSet.(map[string]struct{})[pod] = struct{}{}
+			}
+
+			isProgFdShared, _ := testBpfClient.isProgFdShared(tt.podName, tt.podNamespace)
+			assert.Equal(t, tt.want.isProgFdShared, isProgFdShared)
+		})
+	}
 }


### PR DESCRIPTION
*Issue #, if available:*

This is extreme corner case which can be triggered with very short lived pods (10secs) with high pod churn 
In attachEgressProbes Func, we store ebpfContext in local value and update it back to main map
```
value, ok := l.policyEndpointeBPFContext.Load(podIdentifier)
    if ok {
        peBPFContext = value.(BPFContext)
    }

    if peBPFContext.egressPgmInfo.Program.ProgFD != 0 {
        log().Info("Found an existing instance, let's derive the egress context..")
        egressEbpfProgEntry := peBPFContext.egressPgmInfo
        progFD = egressEbpfProgEntry.Program.ProgFD
    } else {
        egressProgInfo, progFD, err = l.loadBPFProgram(l.egressBinary, "egress", podIdentifier)
        pinPath := utils.GetBPFPinPathFromPodIdentifier(podIdentifier, "egress")
        peBPFContext.egressPgmInfo = egressProgInfo[pinPath]
        l.policyEndpointeBPFContext.Store(podIdentifier, peBPFContext)
    }
```
During same time we are getting DeletePodRequest which is deleting ebpf programs and clearing the caches. Now when we hit line "l.policyEndpointeBPFContext.Store(podIdentifier, peBPFContext)" in attach probes method we are adding back the stale information while underlying bpf programs were deleted by DeleteBpfPrograms Path

When we try to attach probes after this, there is entry in policyEndpointeBPFContext (Stale info), we retrieve the progFD and try to attach probes again - fails with invalid argument as no prog with such FD exists on the node

*Description of changes:*
Instead of using diff locks for attach and delete flow, we need to use the same lock for per pod identifier operations

*Testing*
Verified we won't hit the above issue after the fix 
Integration tests passed 
Cyclonus tests passed 
```
Test Number:1 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:2 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:3 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:4 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:5 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:6 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:7 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:8 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:9 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:10 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:11 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:12 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:13 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:14 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:15 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:16 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:17 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:18 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:19 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:20 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:21 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:22 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:23 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:24 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:25 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:26 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:27 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:28 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:29 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:30 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:31 | Step 1 | Passed -> Correct:80 Expected:50
Test Number:32 | Step 1 | Passed -> Correct:81 Expected:64
Test Number:33 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:34 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:35 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:36 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:37 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:38 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:39 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:40 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:41 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:42 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:43 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:44 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:45 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:46 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:47 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:48 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:49 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:50 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:51 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:52 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:53 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:54 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:55 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:56 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:57 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:58 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:59 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:60 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:61 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:62 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:63 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:64 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:65 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:66 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:67 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:68 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:69 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:70 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:71 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:72 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:73 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:74 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:75 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:76 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:77 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:78 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:79 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:80 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:81 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:82 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:83 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:84 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:85 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:86 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:87 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:88 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:89 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:90 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:91 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:91 | Step 2 | Passed -> Correct:81 Expected:81
Test Number:92 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:92 | Step 2 | Passed -> Correct:81 Expected:81
Test Number:93 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:93 | Step 2 | Passed -> Correct:121 Expected:121
Test Number:93 | Step 3 | Passed -> Correct:81 Expected:81
Test Number:94 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:94 | Step 2 | Passed -> Correct:81 Expected:81
Test Number:94 | Step 3 | Passed -> Correct:81 Expected:81
Test Number:95 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:95 | Step 2 | Passed -> Correct:100 Expected:100
Test Number:95 | Step 3 | Passed -> Correct:81 Expected:81
Test Number:96 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:96 | Step 2 | Passed -> Correct:81 Expected:81
Test Number:96 | Step 3 | Passed -> Correct:81 Expected:81
Test Number:97 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:98 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:99 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:100 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:101 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:102 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:103 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:104 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:105 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:106 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:107 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:108 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:109 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:110 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:111 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:112 | Step 1 | Passed -> Correct:80 Expected:80
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
