### PR TITLE
fix #456: add IPv6 catchAll entry implicitly if no egress rule and no egress isolation

### DIFF
--- a/controllers/policyendpoints_controller_test.go
+++ b/controllers/policyendpoints_controller_test.go
@@ -44,7 +44,7 @@ func TestPolicyEndpointReconcile(t *testing.T) {
 
 	t.Run("Reconcile call for Create PolicyEndpoint with PodEndpoint local to Node", func(t *testing.T) {
 		mockClient := mock_client.NewMockClient(ctrl)
-		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, nodeIp, &ebpf.MockBpfClient{})
+		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, nodeIp, &ebpf.MockBpfClient{}, false)
 
 		policyEndpoint := getPolicyEndpoint("allow-all-egress", "my-namespace", []policyendpoint.PodEndpoint{p1N1, p2N1})
 
@@ -90,7 +90,7 @@ func TestPolicyEndpointReconcile(t *testing.T) {
 
 	t.Run("Reconcile for Create and Delete PE", func(t *testing.T) {
 		mockClient := mock_client.NewMockClient(ctrl)
-		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, nodeIp, &ebpf.MockBpfClient{})
+		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, nodeIp, &ebpf.MockBpfClient{}, false)
 
 		policyEndpoint := getPolicyEndpoint("allow-all-egress", "my-namespace", []policyendpoint.PodEndpoint{p1N1, p2N1})
 
@@ -500,7 +500,7 @@ func TestDeriveIngressAndEgressFirewallRules(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockClient := mock_client.NewMockClient(ctrl)
-		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, "", nil)
+		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, "", nil, false)
 		var policyEndpointsList []string
 		policyEndpointsList = append(policyEndpointsList, tt.policyEndpointName)
 		policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Store(tt.podIdentifier, policyEndpointsList)
@@ -757,8 +757,7 @@ func TestAddCatchAllEntry(t *testing.T) {
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			policyEndpointReconciler.addCatchAllEntry(context.Background(),
-				&tt.firewallRules)
+			policyEndpointReconciler.addCatchAllEntry(&tt.firewallRules)
 			assert.Equal(t, tt.want, sampleFirewallRulesWithCatchAllEntry)
 		})
 	}
@@ -915,7 +914,7 @@ func TestArePoliciesAvailableInLocalCache(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockClient := mock_client.NewMockClient(ctrl)
-		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, "", nil)
+		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, "", nil, false)
 		var policyEndpointsList []string
 		policyEndpointsList = append(policyEndpointsList, tt.policyEndpointName...)
 		policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Store(tt.podIdentifier, policyEndpointsList)
@@ -1160,7 +1159,7 @@ func TestDeriveFireWallRulesPerPodIdentifier(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockClient := mock_client.NewMockClient(ctrl)
-		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, "", nil)
+		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, "", nil, false)
 		var policyEndpointsList []string
 		policyEndpointsList = append(policyEndpointsList, tt.policyEndpointName)
 		policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Store(tt.podIdentifier, policyEndpointsList)

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func main() {
 			ctrlConfig.EnableIPv6, ctrlConfig.ConntrackCacheCleanupPeriod, ctrlConfig.ConntrackCacheTableSize, npMode, isMultiNICEnabled))
 		ebpfClient.ReAttachEbpfProbes()
 
-		policyEndpointController = controllers.NewPolicyEndpointsReconciler(mgr.GetClient(), nodeIP, ebpfClient)
+		policyEndpointController = controllers.NewPolicyEndpointsReconciler(mgr.GetClient(), nodeIP, ebpfClient, ctrlConfig.EnableIPv6)
 
 		if err = policyEndpointController.SetupWithManager(ctx, mgr); err != nil {
 			log.Errorf("unable to create controller PolicyEndpoints %v", err)


### PR DESCRIPTION
*Issue #, if available:*
fixes https://github.com/aws/aws-network-policy-agent/issues/456

There was a regression where IPv6 catchAll entry was not being added into ebpf maps when there was no rule and isolation. Earlier logic was adding a IPv6 catchAll even if PE gives a IPv4 catchAll entry.

*Description of changes:*
- Modified the policy endpoints controller to automatically add IPv6 catchAll entries when:
  - No explicit egress rules are defined
  - No egress isolation is configured
- Updated test coverage to validate the new IPv6 catchAll behavior
- Enhanced firewall rule processor tests with comprehensive IPv6 scenarios

Manual test to verify that behavior is fixed and ran IPv6 cyclonus test
```
Test Number:104 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:105 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:106 | Step 1 | Failed -> Try results: [[1, 80, 0], [1, 80, 0], [1, 80, 0]] Expected:81
Test Number:107 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:108 | Step 1 | Failed -> Try results: [[1, 80, 0], [1, 80, 0], [1, 80, 0]] Expected:81
Test Number:109 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:110 | Step 1 | Passed -> Correct:81 Expected:81

these 2 i remember were failing in some old PR also https://github.com/aws/aws-network-policy-agent/pull/423 (we can investigate those failures separately)
```

```
added a deny all ingress policy

ebpf map states before

[root@ip-192-168-21-181 bin]# ./aws-eks-na-cli ebpf dump-maps 9 (ingress)
Key : IP/Prefixlen - 2600:1f18:2f0a:4600:5eb8:6047:ddbd:ebdf/128
-------------------
Value Entry :  0
Protocol -  ANY PROTOCOL
StartPort -  0
Endport -  0
-------------------
*******************************
Done reading all entries

[root@ip-192-168-21-181 bin]# ./aws-eks-na-cli ebpf dump-maps 7 (egress)
Key : IP/Prefixlen - 2600:1f18:2f0a:4600:5eb8:6047:ddbd:ebdf/128
-------------------
Value Entry :  0
Protocol -  ANY PROTOCOL
StartPort -  0
Endport -  0
-------------------
*******************************
Done reading all entries


ebpf map states after

[root@ip-192-168-10-239 bin]# ./aws-eks-na-cli ebpf dump-maps 45 (ingress)
Key : IP/Prefixlen - 2600:1f13:17c:7a00:c786:79fb:86df:7a2/128
-------------------
Value Entry :  0
Protocol -  ANY PROTOCOL
StartPort -  0
Endport -  0
-------------------
*******************************
Done reading all entries

[root@ip-192-168-10-239 bin]# ./aws-eks-na-cli ebpf dump-maps 55 (egress)
Key : IP/Prefixlen - 2600:1f13:17c:7a00:c786:79fb:86df:7a2/128
-------------------
Value Entry :  0
Protocol -  ANY PROTOCOL
StartPort -  0
Endport -  0
-------------------
*******************************
Key : IP/Prefixlen - ::/0
-------------------
Value Entry :  0
Protocol -  ANY PROTOCOL
StartPort -  0
Endport -  0
-------------------
*******************************
Done reading all entries

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
