### PR TITLE
decoupling flow logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ func main() {
 		initLogger.Errorf("unable to load policy endpoint controller config %v", err)
 		os.Exit(1)
 	}
+	logger.SetGlobalLogLevel(ctrlConfig.LogLevel)
 	log := logger.New(ctrlConfig.LogLevel, ctrlConfig.LogFile, ctrlConfig.LogFileMaxSize, ctrlConfig.LogFileMaxBackups)
 	log.Infof("Starting network policy agent with log level: %s", ctrlConfig.LogLevel)
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -28,7 +28,21 @@ const (
 	DEFAULT_LOG_LOCATION         = "/var/log/aws-routed-eni/network-policy-agent.log"
 	DEFAULT_LOG_FILE_MAX_SIZE    = 200
 	DEFAULT_LOG_FILE_MAX_BACKUPS = 8
+	DEFAULT_FLOW_LOG_LOCATION    = "/var/log/aws-routed-eni/network-policy-agent-flow.log"
 )
+
+var globalLogLevel string
+
+func SetGlobalLogLevel(level string) {
+	globalLogLevel = level
+}
+
+func GetGlobalLogLevel() string {
+	if globalLogLevel != "" {
+		return globalLogLevel
+	}
+	return DEFAULT_LOG_LEVEL
+}
 
 func New(logLevel string, logLocation string, logFileMaxSize int, logFileMaxBackups int) Logger {
 	inputLogConfig := &Configuration{
@@ -43,11 +57,21 @@ func New(logLevel string, logLocation string, logFileMaxSize int, logFileMaxBack
 
 func Get() Logger {
 	if log == nil {
-		log = New(DEFAULT_LOG_LEVEL, DEFAULT_LOG_LOCATION,
+		log = New(GetGlobalLogLevel(), DEFAULT_LOG_LOCATION,
 			DEFAULT_LOG_FILE_MAX_SIZE, DEFAULT_LOG_FILE_MAX_BACKUPS)
 		log.Warn("Logger was not initialized explicitly, using default logger.")
 	}
 	return log
+}
+
+func NewFlowLogger() Logger {
+	inputLogConfig := &Configuration{
+		LogLevel:          GetGlobalLogLevel(),
+		LogLocation:       DEFAULT_FLOW_LOG_LOCATION,
+		LogFileMaxSize:    DEFAULT_LOG_FILE_MAX_SIZE,
+		LogFileMaxBackups: DEFAULT_LOG_FILE_MAX_BACKUPS,
+	}
+	return inputLogConfig.newZapLogger()
 }
 
 func GetControllerRuntimeLogger() logr.Logger {


### PR DESCRIPTION
*Issue #, if available:*
#467 
*Description of changes:*
Added separate flow logger for network policy events that writes to dedicated log file. Implemented global log level configuration to ensure all loggers respect runtime flags. 

Pending test:

Test cloudwatch logs pushing from this logs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
