### PR TITLE
fixed map pointer mangling issue

### DIFF
--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -448,7 +448,7 @@ func (l *bpfClient) recoverBPFState(bpfTCClient tc.BpfTc, eBPFSDKClient goelf.Bp
 				}
 				cpIngressVal, found := bpfEntry.Maps[utils.TC_CLUSTER_POLICY_INGRESS_MAP]
 				if found {
-					log().Infof("found cluster policy ingress ebpf map for %v, map %+v", podIdentifier, ingressVal)
+					log().Infof("found cluster policy ingress ebpf map for %v, map %+v", podIdentifier, cpIngressVal)
 
 					_, ok := l.clusterPolicyIngressInMemoryMap.Load(podIdentifier)
 					if !ok {
@@ -480,7 +480,7 @@ func (l *bpfClient) recoverBPFState(bpfTCClient tc.BpfTc, eBPFSDKClient goelf.Bp
 				}
 				cpEgressVal, found := bpfEntry.Maps[utils.TC_CLUSTER_POLICY_EGRESS_MAP]
 				if found {
-					log().Infof("found cluster policy egress ebpf map for %v, map %+v", podIdentifier, egressVal)
+					log().Infof("found cluster policy egress ebpf map for %v, map %+v", podIdentifier, cpEgressVal)
 
 					_, ok := l.clusterPolicyEgressInMemoryMap.Load(podIdentifier)
 					if !ok {


### PR DESCRIPTION
*Issue #, if available:*

Currently during recovery `cp_ingress/cp_egress` maps recovery is overriding the ref of `ingress/egress`

*Description of changes:*
this avoid the overriding of pointer of `ingress/egress` maps by `cp_ingress/cp_egress`

```
Ran CNP integration tests

Ran 12 of 19 Specs in 306.796 seconds
SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 7 Skipped
PASS
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
