### PR TITLE
fix(logger): correct caller skip configuration for controller-runtime

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -51,6 +51,11 @@ func Get() Logger {
 }
 
 func GetControllerRuntimeLogger() logr.Logger {
-	zapSugared := Get().(*structuredLogger).zapLogger
-	return zapr.NewLogger(zapSugared.Desugar())
+	inputLogConfig := &Configuration{
+		LogLevel:          DEFAULT_LOG_LEVEL,
+		LogLocation:       DEFAULT_LOG_LOCATION,
+		LogFileMaxSize:    DEFAULT_LOG_FILE_MAX_SIZE,
+		LogFileMaxBackups: DEFAULT_LOG_FILE_MAX_BACKUPS,
+	}
+	return zapr.NewLogger(inputLogConfig.newZapLoggerForControllerRuntime())
 }


### PR DESCRIPTION
Create separate logger initialization for controller-runtime that omits AddCallerSkip since zapr handles caller skip internally. This fixes incorrect file/line reporting in controller-runtime logs.

*Issue #, if available:*
#489 


*Description of changes:*
Removed following logs from stdout
```
2025-12-19 07:09:56.486813989 +0000 UTC Logger.check error: failed to get caller
2025-12-19 07:09:56.48724075 +0000 UTC Logger.check error: failed to get caller
```

Can see controller runtime logs in network-policy-agent.log
```
{"level":"info","ts":"2025-12-19T07:52:20.612Z","caller":"controller/controller.go:353","msg":"Starting EventSource","controller":"policyendpoint","controllerGroup":"networking.k8s.aws","controllerKind":"PolicyEndpoint","source":"kind source: *v1alpha1.PolicyEndpoint"}
{"level":"info","ts":"2025-12-19T07:52:20.613Z","caller":"controller/controller.go:353","msg":"Starting EventSource","controller":"clusterpolicyendpoint","controllerGroup":"networking.k8s.aws","controllerKind":"ClusterPolicyEndpoint","source":"kind source: *v1alpha1.ClusterPolicyEndpoint"}
{"level":"info","ts":"2025-12-19T07:52:20.723Z","caller":"controller/controller.go:286","msg":"Starting Controller","controller":"clusterpolicyendpoint","controllerGroup":"networking.k8s.aws","controllerKind":"ClusterPolicyEndpoint"}
{"level":"info","ts":"2025-12-19T07:52:20.724Z","caller":"controller/controller.go:289","msg":"Starting workers","controller":"clusterpolicyendpoint","controllerGroup":"networking.k8s.aws","controllerKind":"ClusterPolicyEndpoint","worker count":1}
{"level":"info","ts":"2025-12-19T07:52:20.723Z","caller":"controller/controller.go:286","msg":"Starting Controller","controller":"policyendpoint","controllerGroup":"networking.k8s.aws","controllerKind":"PolicyEndpoint"}
{"level":"info","ts":"2025-12-19T07:52:20.724Z","caller":"controller/controller.go:289","msg":"Starting workers","controller":"policyendpoint","controllerGroup":"networking.k8s.aws","controllerKind":"PolicyEndpoint","worker count":1}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
