### PR TITLE
Fix GetPodIdentifierFromBPFPinPath for pod names with dots

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -168,8 +168,14 @@ func GetPodIdentifier(podName, podNamespace string) string {
 
 func GetPodIdentifierFromBPFPinPath(pinPath string) (string, string) {
 	pinPathName := strings.Split(pinPath, "/")
-	podIdentifier := strings.Split(pinPathName[7], "_")
-	return podIdentifier[0], podIdentifier[2]
+	parts := strings.Split(pinPathName[7], "_")
+
+	// Format: podIdentifier_handle_direction
+	// parts[len(parts)-2] = "handle", parts[len(parts)-1] = direction
+	podIdentifier := strings.Join(parts[:len(parts)-2], "_")
+	direction := parts[len(parts)-1]
+
+	return podIdentifier, direction
 }
 
 func GetBPFPinPathFromPodIdentifier(podIdentifier string, direction string) string {

--- a/test/agent/go.mod
+++ b/test/agent/go.mod
@@ -1,3 +1,3 @@
 module github.com/aws/aws-network-policy-agent/test/agent
 
-go 1.24
+go 1.25


### PR DESCRIPTION
The bug occurred because GetPodIdentifier() converts dots to underscores, but GetPodIdentifierFromBPFPinPath() was blindly splitting by underscore and assuming podIdentifier[2] was the direction, when it could be 'handle' for pod names with multiple underscores.

Example: ylinux.app-75f4596489-g4x8c (namespace: k8s-omega-aws--nonprod-omega--test)
- Old: returned ('ylinux', 'handle') - WRONG
- New: returns ('ylinux_app-75f4596489-k8s-omega-aws--nonprod-omega--test', 'ingress') - CORRECT

Fixed bug where pod names containing dots (converted to underscores) were incorrectly parsed when extracting from BPF pin paths.

*Issue #, if available:*

Unit Testing:

```
#Load Private Image on to NPA on cluster

(26-01-06 23:45:40) <0> [~/jan6/aws-network-policy-agent]  
dev-dsk-supreeet-2a-b1d3c286 % kubectl describe pod aws-node-gq2g6 -n kube-system | grep  "867344458987.dkr.ecr.us-west-2.amazonaws.com"
    Image:         867344458987.dkr.ecr.us-west-2.amazonaws.com/aws-network-policy-agent-jan6:latest
.
.


#Add a Pod with Dot
(26-01-06 23:45:52) <0> [~/jan6/aws-network-policy-agent]  
dev-dsk-supreeet-2a-b1d3c286 % cat /local/home/supreeet/jan6/aws-network-policy-agent/pod-with-dot.yaml
apiVersion: v1
kind: Pod
metadata:
  name: test.pod
  labels:
    app: test.app
spec:
  containers:
  - name: nginx
    image: nginx:latest
    ports:
    - containerPort: 80


(26-01-06 23:46:20) <0> [~/jan6/aws-network-policy-agent]  
dev-dsk-supreeet-2a-b1d3c286 % kubectl get pod test.pod 
NAME       READY   STATUS    RESTARTS   AGE
test.pod   1/1     Running   0          5m44s

Make sure that The BPF Path is fine:

dev-dsk-supreeet-2a-b1d3c286 % aws ssm start-session --target i-0ef750fb3059489fa

sh-5.2$ sudo ls -lrt /sys/fs/bpf/globals/aws/programs/
total 0
-rw-------. 1 root root 0 Jan  6 23:40 test_pod-default_handle_ingress
-rw-------. 1 root root 0 Jan  6 23:40 test_pod-default_handle_egress
```


From network_policy.log on Node, can see that the conversion happen as expected:
```
{"level":"debug","ts":"2026-01-06T23:40:51.092Z","caller":"rpc/rpc_handler.go:72","msg":"Got the podIdentifierLock for Pod: test.pod, Namespace: default, PodIdentifier: test_pod-default"}
```




Cyclonous Testing:


```

(26-01-12 19:18:45) <0> [~/jan6/aws-network-policy-agent/scripts]  
dev-dsk-supreeet-2a-b1d3c286 % kubectl get daemonset -n kube-system -o jsonpath='{.items[*].spec.template.spec.containers[*].image}' | tr ' ' '\n' | grep -i network
867344458987.dkr.ecr.us-west-2.amazonaws.com/aws-network-policy-agent-jan6:latest

(26-01-12 19:18:51) <0> [~/jan6/aws-network-policy-agent/scripts]  
dev-dsk-supreeet-2a-b1d3c286 % tail result.log 
|  - udp | 16 / 16 = 100% ✅ |
| rule | 27 / 30 = 90% ❌ |
|  - allow-all | 4 / 6 = 66% ❌ |
|  - any-peer | 1 / 2 = 50% ❌ |
|  - any-port-protocol | 2 / 2 = 100% ✅ |
|  - deny-all | 9 / 10 = 90% ❌ |
|  - multi-port/protocol | 14 / 14 = 100% ✅ |
| target | 4 / 6 = 66% ❌ |
|  - target-namespace | 1 / 3 = 33% ❌ |
|  - target-pod-selector | 3 / 3 = 100% ✅ |

(26-01-12 19:19:00) <0> [~/jan6/aws-network-policy-agent/scripts]  
dev-dsk-supreeet-2a-b1d3c286 % python3 lib/verify_test_results.py -f ./result.log -ip IPv4 || TEST_FAILED=true
Test Number:1 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:2 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:3 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:4 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:5 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:6 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:7 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:8 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:9 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:10 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:11 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:12 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:13 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:14 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:15 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:16 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:17 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:18 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:19 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:20 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:21 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:22 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:23 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:24 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:25 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:26 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:27 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:28 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:29 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:30 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:31 | Step 1 | Passed -> Correct:80 Expected:50
Test Number:32 | Step 1 | Passed -> Correct:81 Expected:64
Test Number:33 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:34 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:35 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:36 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:37 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:38 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:39 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:40 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:41 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:42 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:43 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:44 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:45 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:46 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:47 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:48 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:49 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:50 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:51 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:52 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:53 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:54 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:55 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:56 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:57 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:58 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:59 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:60 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:61 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:62 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:63 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:64 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:65 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:66 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:67 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:68 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:69 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:70 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:71 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:72 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:73 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:74 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:75 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:76 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:77 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:78 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:79 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:80 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:81 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:82 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:83 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:84 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:85 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:86 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:87 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:88 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:89 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:90 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:91 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:91 | Step 2 | Passed -> Correct:81 Expected:81
Test Number:92 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:92 | Step 2 | Passed -> Correct:81 Expected:81
Test Number:93 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:93 | Step 2 | Passed -> Correct:121 Expected:121
Test Number:93 | Step 3 | Passed -> Correct:81 Expected:81
Test Number:94 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:94 | Step 2 | Passed -> Correct:81 Expected:81
Test Number:94 | Step 3 | Passed -> Correct:81 Expected:81
Test Number:95 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:95 | Step 2 | Passed -> Correct:100 Expected:100
Test Number:95 | Step 3 | Passed -> Correct:81 Expected:81
Test Number:96 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:96 | Step 2 | Passed -> Correct:81 Expected:81
Test Number:96 | Step 3 | Passed -> Correct:81 Expected:81
Test Number:97 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:98 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:99 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:100 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:101 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:102 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:103 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:104 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:105 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:106 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:107 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:108 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:109 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:110 | Step 1 | Passed -> Correct:81 Expected:81
Test Number:111 | Step 1 | Passed -> Correct:80 Expected:80
Test Number:112 | Step 1 | Passed -> Correct:80 Expected:80

```


```
Unit Testing:

=== RUN   TestPodIdentifierDotConversion
=== RUN   TestPodIdentifierDotConversion/Pod_name_with_single_dot
=== RUN   TestPodIdentifierDotConversion/Pod_name_with_multiple_dots
=== RUN   TestPodIdentifierDotConversion/Pod_name_without_dots
--- PASS: TestPodIdentifierDotConversion (0.00s)
    --- PASS: TestPodIdentifierDotConversion/Pod_name_with_single_dot (0.00s)
    --- PASS: TestPodIdentifierDotConversion/Pod_name_with_multiple_dots (0.00s)
    --- PASS: TestPodIdentifierDotConversion/Pod_name_without_dots (0.00s

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
