### PR TITLE
chore: add metadata lookup hook to policy event logging

### DIFF
--- a/pkg/ebpf/events/events.go
+++ b/pkg/ebpf/events/events.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-network-policy-agent/pkg/logger"
 	"github.com/aws/aws-network-policy-agent/pkg/utils"
 	"github.com/aws/aws-sdk-go-v2/aws"
+    "github.com/aws/aws-network-policy-agent/pkg/metadata"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -24,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/google/uuid"
 	"github.com/spf13/pflag"
+
 )
 
 var (
@@ -223,6 +225,8 @@ func capturePolicyEvents(ctx context.Context, ringbufferdata <-chan []byte, enab
 					log().Errorf("Failed to read from Ring buf %v", err)
 					continue
 				}
+                _ = metadata.LookupByIP(utils.ConvByteToIPv6(rb.SourceIP).String())
+
 
 				protocol := utils.GetProtocol(int(rb.Protocol))
 				verdict := getVerdict(int(rb.Verdict))
@@ -252,6 +256,8 @@ func capturePolicyEvents(ctx context.Context, ringbufferdata <-chan []byte, enab
 					log().Errorf("Failed to read from Ring buf %v", err)
 					continue
 				}
+				_ = metadata.LookupByIP(utils.ConvByteArrayToIP(rb.SourceIP))
+
 				protocol := utils.GetProtocol(int(rb.Protocol))
 				verdict := getVerdict(int(rb.Verdict))
 

--- a/pkg/metadata/cache.go
+++ b/pkg/metadata/cache.go
@@ -1,0 +1,15 @@
+package metadata
+
+// PodMetadata holds Kubernetes metadata for a Pod IP.
+type PodMetadata struct {
+	PodName      string
+	Namespace    string
+	WorkloadKind string
+	WorkloadName string
+}
+
+// LookupByIP returns metadata for a given IP.
+// Currently returns nil as a placeholder.
+func LookupByIP(ip string) *PodMetadata {
+	return nil
+}


### PR DESCRIPTION
This PR introduces a no-op metadata lookup hook in the policy event logging path
for both IPv4 and IPv6 flows.

There is no behavior change. This prepares the codebase for enriching policy logs
with Kubernetes workload metadata (Pod / Namespace / Workload), as discussed in #505.
