### PR TITLE
Adding integration tests for policy rule combination

### DIFF
--- a/test/integration/policy/npc_rule_combination_test.go
+++ b/test/integration/policy/npc_rule_combination_test.go
@@ -1,0 +1,246 @@
+package policy
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/aws/aws-network-policy-agent/test/framework/manifest"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	network "k8s.io/api/networking/v1"
+)
+
+// PolicyEndpoint simplified struct for parsing kubectl output
+type PolicyEndpointEgress struct {
+	CIDR   string                 `json:"cidr"`
+	Except []string               `json:"except"`
+	Ports  []map[string]interface{} `json:"ports"`
+}
+
+type PolicyEndpointSpec struct {
+	Egress []PolicyEndpointEgress `json:"egress"`
+}
+
+type PolicyEndpointItem struct {
+	Spec PolicyEndpointSpec `json:"spec"`
+}
+
+type PolicyEndpointList struct {
+	Items []PolicyEndpointItem `json:"items"`
+}
+
+// test to validate NPC's combining logic
+var _ = Describe("Rules Combining Validation", func() {
+
+	Context("Single NetworkPolicy with 2 rules: same CIDR+exceptions, different ports", func() {
+		var (
+			np             *network.NetworkPolicy
+			testNamespace  = "test-combining"
+		)
+
+		BeforeEach(func() {
+			By("Creating test namespace")
+			err := fw.NamespaceManager.CreateNamespace(ctx, testNamespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating NetworkPolicy with 2 egress rules (ports 80 and 443)")
+			// Rule 1: Port 80 to 10.0.0.0/8 except 10.1.0.0/16
+			rule1 := manifest.NewEgressRuleBuilder().
+				AddPeer(nil, nil, "10.0.0.0/8", "10.1.0.0/16").
+				AddPort(80, v1.ProtocolTCP).
+				Build()
+
+			// Rule 2: Port 443 to 10.0.0.0/8 except 10.1.0.0/16
+			rule2 := manifest.NewEgressRuleBuilder().
+				AddPeer(nil, nil, "10.0.0.0/8", "10.1.0.0/16").
+				AddPort(443, v1.ProtocolTCP).
+				Build()
+
+			np = manifest.NewNetworkPolicyBuilder().
+				Namespace(testNamespace).
+				Name("test-combining-policy").
+				PodSelector("app", "testpod").
+				SetPolicyType(false, true).
+				AddEgressRule(rule1).
+				AddEgressRule(rule2).
+				Build()
+
+			err = fw.NetworkPolicyManager.CreateNetworkPolicy(ctx, np)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating test pod to trigger PolicyEndpoint creation")
+			container := manifest.NewBusyBoxContainerBuilder().
+				ImageRepository(fw.Options.TestImageRegistry).
+				Command([]string{"/bin/sh", "-c"}).
+				Args([]string{"sleep 3600"}).
+				Build()
+
+			pod := manifest.NewDefaultPodBuilder().
+				Name("testpod").
+				Namespace(testNamespace).
+				AddLabel("app", "testpod").
+				Container(container).
+				Build()
+
+			_, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, pod, 2*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should combine rules with same CIDR+exceptions into single PolicyEndpoint entry", func() {
+			By("Waiting for PolicyEndpoints to be created")
+			time.Sleep(10 * time.Second)
+
+			By("Getting PolicyEndpoints using kubectl")
+			cmd := exec.Command("kubectl", "get", "policyendpoints", "-n", testNamespace, "-o", "json")
+			output, err := cmd.CombinedOutput()
+			Expect(err).ToNot(HaveOccurred())
+
+			var peList PolicyEndpointList
+			err = json.Unmarshal(output, &peList)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(peList.Items)).To(BeNumerically(">", 0))
+
+			By("Searching for target rule with CIDR=10.0.0.0/8 and Exception=10.1.0.0/16")
+			var targetPorts []map[string]interface{}
+			var foundTargetRule bool
+			
+			for _, pe := range peList.Items {
+				for _, egress := range pe.Spec.Egress {
+					if egress.CIDR == "10.0.0.0/8" && len(egress.Except) == 1 && egress.Except[0] == "10.1.0.0/16" {
+						foundTargetRule = true
+						targetPorts = egress.Ports
+						fmt.Printf("\nFound target rule: CIDR=%s, Exceptions=%v, Ports=%d\n", 
+							egress.CIDR, egress.Except, len(egress.Ports))
+						break
+					}
+				}
+			}
+			
+			By("Validating both ports 80 and 443 are in the combined entry")
+			var foundPort80, foundPort443 bool
+			for _, port := range targetPorts {
+				if portNum, ok := port["port"].(float64); ok {
+					if int(portNum) == 80 {
+						foundPort80 = true
+					}
+					if int(portNum) == 443 {
+						foundPort443 = true
+					}
+				}
+			}
+			
+			Expect(foundTargetRule).To(BeTrue(), "Should find target rule")
+			Expect(foundPort80).To(BeTrue(), "Should have port 80")
+			Expect(foundPort443).To(BeTrue(), "Should have port 443")
+			
+			fmt.Printf("Ports: 80=%v, 443=%v\n", foundPort80, foundPort443)
+			fmt.Printf("TEST PASSED: Rules combined\n\n")
+		})
+
+		AfterEach(func() {
+			fw.NetworkPolicyManager.DeleteNetworkPolicy(ctx, np)
+			fw.NamespaceManager.DeleteAndWaitTillNamespaceDeleted(ctx, testNamespace)
+		})
+	})
+
+	Context("NetworkPolicy with all-ports wildcard", func() {
+		var (
+			np             *network.NetworkPolicy
+			testNamespace  = "test-allports"
+		)
+
+		BeforeEach(func() {
+			By("Creating test namespace")
+			err := fw.NamespaceManager.CreateNamespace(ctx, testNamespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating NetworkPolicy with 2 rules: port-specific + all-ports wildcard")
+			// Rule 1: Port 53 to 172.16.0.0/12 except 172.17.0.0/16
+			rule1 := manifest.NewEgressRuleBuilder().
+				AddPeer(nil, nil, "172.16.0.0/12", "172.17.0.0/16").
+				AddPort(53, v1.ProtocolUDP).
+				Build()
+
+			// Rule 2: ALL PORTS to 172.16.0.0/12 except 172.17.0.0/16 (no ports = wildcard)
+			rule2 := manifest.NewEgressRuleBuilder().
+				AddPeer(nil, nil, "172.16.0.0/12", "172.17.0.0/16").
+				Build()
+
+			np = manifest.NewNetworkPolicyBuilder().
+				Namespace(testNamespace).
+				Name("test-allports-policy").
+				PodSelector("app", "testpod").
+				SetPolicyType(false, true).
+				AddEgressRule(rule1).
+				AddEgressRule(rule2).
+				Build()
+
+			err = fw.NetworkPolicyManager.CreateNetworkPolicy(ctx, np)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating test pod to trigger PolicyEndpoint creation")
+			container := manifest.NewBusyBoxContainerBuilder().
+				ImageRepository(fw.Options.TestImageRegistry).
+				Command([]string{"/bin/sh", "-c"}).
+				Args([]string{"sleep 3600"}).
+				Build()
+
+			pod := manifest.NewDefaultPodBuilder().
+				Name("testpod").
+				Namespace(testNamespace).
+				AddLabel("app", "testpod").
+				Container(container).
+				Build()
+
+			_, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, pod, 2*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should preserve all-ports rule - empty ports wins over port-specific", func() {
+			By("Waiting for PolicyEndpoints to be created")
+			time.Sleep(10 * time.Second)
+
+			By("Getting PolicyEndpoints")
+			cmd := exec.Command("kubectl", "get", "policyendpoints", "-n", testNamespace, "-o", "json")
+			output, err := cmd.CombinedOutput()
+			Expect(err).ToNot(HaveOccurred())
+
+			var peList PolicyEndpointList
+			err = json.Unmarshal(output, &peList)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(peList.Items)).To(BeNumerically(">", 0))
+
+			By("Searching for target rule with CIDR=172.16.0.0/12 and Exception=172.17.0.0/16")
+			var foundTargetWithEmptyPorts bool
+			
+			for _, pe := range peList.Items {
+				for _, egress := range pe.Spec.Egress {
+					if egress.CIDR == "172.16.0.0/12" && len(egress.Except) == 1 && egress.Except[0] == "172.17.0.0/16" {
+						fmt.Printf("\n✓ Found target rule: CIDR=%s, Exceptions=%v, Ports=%d\n", 
+							egress.CIDR, egress.Except, len(egress.Ports))
+						
+						if len(egress.Ports) == 0 {
+							foundTargetWithEmptyPorts = true
+							fmt.Printf("  [] - ALL PORTS present\n")
+						} else {
+							fmt.Printf("  Has %d ports\n", len(egress.Ports))
+						}
+						break
+					}
+				}
+			}
+			
+			Expect(foundTargetWithEmptyPorts).To(BeTrue(), "Should find entry with empty ports (all-ports wildcard)")
+			
+			fmt.Printf(" TEST PASSED: All-ports preserved\n\n")
+		})
+
+		AfterEach(func() {
+			fw.NetworkPolicyManager.DeleteNetworkPolicy(ctx, np)
+			fw.NamespaceManager.DeleteAndWaitTillNamespaceDeleted(ctx, testNamespace)
+		})
+	})
+})


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

What this Does: Adds integration tests for NPC rule combination fix
Test 1: Validates port combining for rules with same CIDR+exceptions
Test 2: Validates all-ports wildcard preserved (Bridgewater case)


Tested locally:

```
(26-03-11 0:52:40) <0> [~/bridgewater]  
dev-dsk-supreeet-2a-b1d3c286 % cd ~/bridgewater/aws-network-policy-agent/test/integration/policy && ~/go/bin/ginkgo -v --foc
us="Rules Combining" -- --cluster-kubeconfig=/home/supreeet/.kube/config --cluster-name=jan9 --aws-region=us-west-2
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.27.2
  Mismatched package versions found:
    2.27.1 used by policy

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: Network Policy Test Suite - /home/supreeet/bridgewater/aws-network-policy-agent/test/integration/policy
======================================================================================================================
Random Seed: 1773190360

Will run 2 of 8 specs
------------------------------
[BeforeSuite] 
/home/supreeet/bridgewater/aws-network-policy-agent/test/integration/policy/policy_suite_test.go:23
[BeforeSuite] PASSED [0.827 seconds]
------------------------------
SSSSSS
------------------------------
Rules Combining Validation Single NetworkPolicy with 2 rules: same CIDR+exceptions, different ports should combine rules with same CIDR+exceptions into single PolicyEndpoint entry
/home/supreeet/bridgewater/aws-network-policy-agent/test/integration/policy/npc_rule_combination_test.go:92
  STEP: Creating test namespace @ 03/11/26 00:52:43.027
  STEP: Creating NetworkPolicy with 2 egress rules (ports 80 and 443) @ 03/11/26 00:52:43.035
  STEP: Creating test pod to trigger PolicyEndpoint creation @ 03/11/26 00:52:43.045
  STEP: Waiting for PolicyEndpoints to be created @ 03/11/26 00:52:45.09
  STEP: Getting PolicyEndpoints using kubectl @ 03/11/26 00:52:55.092
  STEP: Searching for target rule with CIDR=10.0.0.0/8 and Exception=10.1.0.0/16 @ 03/11/26 00:52:55.935

Found target rule: CIDR=10.0.0.0/8, Exceptions=[10.1.0.0/16], Ports=2
  STEP: Validating both ports 80 and 443 are in the combined entry @ 03/11/26 00:52:55.935
Ports: 80=true, 443=true
TEST PASSED: Rules combined

• [32.947 seconds]
------------------------------
Rules Combining Validation NetworkPolicy with all-ports wildcard should preserve all-ports rule - empty ports wins over port-specific
/home/supreeet/bridgewater/aws-network-policy-agent/test/integration/policy/npc_rule_combination_test.go:202
  STEP: Creating test namespace @ 03/11/26 00:53:15.974
  STEP: Creating NetworkPolicy with 2 rules: port-specific + all-ports wildcard @ 03/11/26 00:53:15.981
  STEP: Creating test pod to trigger PolicyEndpoint creation @ 03/11/26 00:53:15.993
  STEP: Waiting for PolicyEndpoints to be created @ 03/11/26 00:53:18.028
  STEP: Getting PolicyEndpoints @ 03/11/26 00:53:28.03
  STEP: Searching for target rule with CIDR=172.16.0.0/12 and Exception=172.17.0.0/16 @ 03/11/26 00:53:28.812

✓ Found target rule: CIDR=172.16.0.0/12, Exceptions=[172.17.0.0/16], Ports=0
  [] - ALL PORTS present
 TEST PASSED: All-ports preserved

• [36.883 seconds]
------------------------------
[AfterSuite] 
/home/supreeet/bridgewater/aws-network-policy-agent/test/integration/policy/policy_suite_test.go:31
[AfterSuite] PASSED [6.020 seconds]
------------------------------

Ran 2 of 8 Specs in 76.678 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 6 Skipped
PASS


Ginkgo ran 1 suite in 1m18.062067527s
Test Suite Passed
```




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
