### PR TITLE
Removing CPE CRD checks as the CRD should be installed by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
-	"time"
 
 	cnirpc "github.com/aws/amazon-vpc-cni-k8s/rpc"
 	"github.com/aws/aws-network-policy-agent/pkg/ebpf"
@@ -39,7 +38,7 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
-	"k8s.io/client-go/discovery"
+
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	policyk8sawsv1 "github.com/aws/aws-network-policy-agent/api/v1alpha1"
@@ -104,33 +103,10 @@ func main() {
 
 	ctx := ctrl.SetupSignalHandler()
 
-	disc, err := discovery.NewDiscoveryClientForConfig(restCFG)
-	if err != nil {
-		log.Errorf("unable to create discovery client %v", err)
-		os.Exit(1)
-	}
 	var policyEndpointController *controllers.PolicyEndpointsReconciler
 	var clusterPolicyEndpointController *controllers.ClusterPolicyEndpointsReconciler
 	if ctrlConfig.EnableNetworkPolicy {
-		log.Info("Network Policy is enabled, checking CRDs...")
-		// Check if required CRDs exist. Need to remove this eventually when the CPE CRD is available everywhere
-		requiredGV := "networking.k8s.aws/v1alpha1"
-		requiredResource := "clusterpolicyendpoints"
-
-		skipCPEController := true
-
-		resources, err := disc.ServerResourcesForGroupVersion(requiredGV)
-		if err != nil {
-			log.Errorf("Cannot list resources in the cluster in GVK %s, err %v", requiredGV, err)
-		} else {
-			for _, r := range resources.APIResources {
-				if r.Name == requiredResource {
-					log.Infof("CRD found in the required GVK resource %s", requiredResource)
-					skipCPEController = false
-					break
-				}
-			}
-		}
+		log.Info("Network Policy is enabled, registering controllers...")
 
 		var nodeIP string
 		if !ctrlConfig.EnableIPv6 {
@@ -151,35 +127,14 @@ func main() {
 			log.Errorf("unable to create controller PolicyEndpoints %v", err)
 			os.Exit(1)
 		}
-		if !skipCPEController {
-			log.Info("ClusterPolicyEndpoint CRD found, registering the controller clusterpolicyendpoints controller")
-			clusterPolicyEndpointController = controllers.NewClusterPolicyEndpointsReconciler(mgr.GetClient(), nodeIP, ebpfClient)
-			if err = clusterPolicyEndpointController.SetupWithManager(ctx, mgr); err != nil {
-				log.Errorf("unable to create controller ClusterPolicyEndpoints %v", err)
-				os.Exit(1)
-			}
-		} else {
-			log.Info("ClusterPolicyEndpoint CRD not found, skip registering the controller clusterpolicyendpoints controller")
-			// Start goroutine to monitor CRD availability. This can be removed after CPE CRD is available everywhere
-			go func() {
-				log.Infof("Starting CRD availability monitor for %s", requiredResource)
-				for {
-					time.Sleep(30 * time.Second)
-					discovererdResources, err := disc.ServerResourcesForGroupVersion(requiredGV)
-					if err == nil {
-						for _, r := range discovererdResources.APIResources {
-							if r.Name == requiredResource {
-								log.Infof("CRD now available, restarting agent: %s", requiredResource)
-								os.Exit(0)
-							}
-						}
-					}
-					log.Infof("CRD still not available, continuing to monitor: %s, %v", requiredResource, err)
-				}
-			}()
+
+		clusterPolicyEndpointController = controllers.NewClusterPolicyEndpointsReconciler(mgr.GetClient(), nodeIP, ebpfClient)
+		if err = clusterPolicyEndpointController.SetupWithManager(ctx, mgr); err != nil {
+			log.Errorf("unable to create controller ClusterPolicyEndpoints %v", err)
+			os.Exit(1)
 		}
 	} else {
-		log.Info("Network Policy is disabled, skip the policyEndpointController registration")
+		log.Info("Network Policy is disabled, skip the controller registration")
 	}
 
 	//+kubebuilder:scaffold:builder

--- a/pkg/rpc/rpc_handler.go
+++ b/pkg/rpc/rpc_handler.go
@@ -49,17 +49,30 @@ type server struct {
 
 // EnforceNpToPod processes CNI Enforce NP network request
 func (s *server) EnforceNpToPod(ctx context.Context, in *rpc.EnforceNpRequest) (*rpc.EnforceNpReply, error) {
-	// TODO: Add the clusterPolicyReconciler nil check here once cluster policies CRDs are available everywhere
-	if s.policyReconciler == nil || s.policyReconciler.GeteBPFClient() == nil {
+	// If NPA is disabled, controllers are nil. The gRPC server still runs to serve CNI requests,
+	// so return success without enforcing any policy.
+	var err error
+	peReconcilerReady := s.policyReconciler != nil && s.policyReconciler.GeteBPFClient() != nil
+	cpeReconcilerReady := s.clusterPolicyReconciler != nil && s.clusterPolicyReconciler.GeteBPFClient() != nil
+
+	if !peReconcilerReady && !cpeReconcilerReady {
 		log().Debug("Network policy is disabled, returning success")
-		success := rpc.EnforceNpReply{
+		response := rpc.EnforceNpReply{
 			Success: true,
 		}
-		return &success, nil
+		return &response, nil
+	}
+
+	if peReconcilerReady != cpeReconcilerReady {
+		err = errors.New("One of the policy reconcilers is not ready")
+		log().Errorf("One of the policy reconcilers is not ready, policyReconcilerReady: %t, clusterPolicyReconcilerReady: %t", peReconcilerReady, cpeReconcilerReady)
+		response := rpc.EnforceNpReply{
+			Success: false,
+		}
+		return &response, err
 	}
 
 	log().Infof("Received Enforce Network Policy Request for Pod: %s Namespace: %s Mode: %s", in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, in.NETWORK_POLICY_MODE)
-	var err error
 
 	if !utils.IsValidNetworkPolicyEnforcingMode(in.NETWORK_POLICY_MODE) {
 		err = errors.New("Invalid Network Policy Mode")
@@ -95,7 +108,7 @@ func (s *server) EnforceNpToPod(ctx context.Context, in *rpc.EnforceNpRequest) (
 	// Check if there are active policies against the new pod and if there are other pods on the local node that share
 	// the eBPF firewall maps with the newly launched pod, if already present we can skip the map update and return
 	policiesAvailableInLocalCache := s.policyReconciler.ArePoliciesAvailableInLocalCache(podIdentifier)
-	clusterPolicyAvailableInLocalCache := s.clusterPolicyReconciler != nil && s.clusterPolicyReconciler.ArePoliciesAvailableInLocalCache(podIdentifier)
+	clusterPolicyAvailableInLocalCache := s.clusterPolicyReconciler.ArePoliciesAvailableInLocalCache(podIdentifier)
 
 	if (policiesAvailableInLocalCache || clusterPolicyAvailableInLocalCache) && isFirstPodInPodIdentifier {
 		// If we're here, then the local agent knows the list of active policies that apply to this pod and
@@ -109,20 +122,20 @@ func (s *server) EnforceNpToPod(ctx context.Context, in *rpc.EnforceNpRequest) (
 
 			err = s.policyReconciler.GeteBPFClient().UpdateEbpfMaps(podIdentifier, ingressRules, egressRules)
 			if err != nil {
-				log().Errorf("Map update(s) failed for podIdentifier: %s, error: %v", podIdentifier, err)
+				log().Errorf("Network Policy map update(s) failed for podIdentifier: %s, error: %v", podIdentifier, err)
 				return nil, err
 			}
 			podState = ebpf.POLICIES_APPLIED
 		}
 
-		if clusterPolicyAvailableInLocalCache && s.clusterPolicyReconciler != nil {
+		if clusterPolicyAvailableInLocalCache {
 
 			clusterIngressRules, clusterEgressRules, _ :=
 				s.clusterPolicyReconciler.DeriveClusterPolicyFireWallRulesPerPodIdentifier(ctx, podIdentifier)
 
 			err = s.clusterPolicyReconciler.GeteBPFClient().UpdateClusterPolicyEbpfMaps(podIdentifier, clusterIngressRules, clusterEgressRules)
 			if err != nil {
-				log().Errorf("Map update(s) failed for podIdentifier: %s, error: %v", podIdentifier, err)
+				log().Errorf("Cluster Policy map update(s) failed for podIdentifier: %s, error: %v", podIdentifier, err)
 				return nil, err
 			}
 			clusterPolicyState = ebpf.POLICIES_APPLIED
@@ -130,16 +143,14 @@ func (s *server) EnforceNpToPod(ctx context.Context, in *rpc.EnforceNpRequest) (
 
 		err = s.policyReconciler.GeteBPFClient().UpdatePodStateEbpfMaps(podIdentifier, ebpf.POD_STATE_MAP_KEY, podState, true, true)
 		if err != nil {
-			log().Errorf("Pod state map update failed for podIdentifier: %s, error: %v", podIdentifier, err)
+			log().Errorf("Pod state map update failed for podIdentifier: %s, while updating network policy state, error: %v", podIdentifier, err)
 			return nil, err
 		}
 
-		if s.clusterPolicyReconciler != nil && s.clusterPolicyReconciler.GeteBPFClient() != nil {
-			err = s.clusterPolicyReconciler.GeteBPFClient().UpdatePodStateEbpfMaps(podIdentifier, ebpf.CLUSTER_POLICY_POD_STATE_MAP_KEY, clusterPolicyState, true, true)
-			if err != nil {
-				log().Errorf("Map update failed for podIdentifier: %s, error: %v", podIdentifier, err)
-				return nil, err
-			}
+		err = s.clusterPolicyReconciler.GeteBPFClient().UpdatePodStateEbpfMaps(podIdentifier, ebpf.CLUSTER_POLICY_POD_STATE_MAP_KEY, clusterPolicyState, true, true)
+		if err != nil {
+			log().Errorf("Pod state map update failed for podIdentifier: %s updating cluster network policy state, error: %v", podIdentifier, err)
+			return nil, err
 		}
 
 	} else {
@@ -147,22 +158,21 @@ func (s *server) EnforceNpToPod(ctx context.Context, in *rpc.EnforceNpRequest) (
 		if !(policiesAvailableInLocalCache || clusterPolicyAvailableInLocalCache) {
 
 			log().Debugf("No active policies present for podIdentifier: %s", podIdentifier)
-			log().Infof("Updating pod_state map to default allow/default deny for podIdentifier: %s, state: %d", podIdentifier, podState)
-
+			log().Infof("Updating pod_state map to default allow/default deny for podIdentifier: %s for network policy state, value: %d", podIdentifier, podState)
 			err = s.policyReconciler.GeteBPFClient().UpdatePodStateEbpfMaps(podIdentifier, ebpf.POD_STATE_MAP_KEY, podState, true, true)
 			if err != nil {
-				log().Errorf("Map update(s) failed for podIdentifier: %s, error: %v", podIdentifier, err)
+				log().Errorf("Pod state map update failed for podIdentifier: %s, while updating network policy state, error: %v", podIdentifier, err)
 				return nil, err
 			}
 
+			log().Infof("Updating pod_state map to default allow for podIdentifier: %s, for cluster network policy state, value: %d", podIdentifier, ebpf.DEFAULT_ALLOW)
 			// No concept of default deny for cluster policies. Either we have a rule that allows or denies traffic
-			if s.clusterPolicyReconciler != nil && s.clusterPolicyReconciler.GeteBPFClient() != nil {
-				err = s.clusterPolicyReconciler.GeteBPFClient().UpdatePodStateEbpfMaps(podIdentifier, ebpf.CLUSTER_POLICY_POD_STATE_MAP_KEY, ebpf.DEFAULT_ALLOW, true, true)
-				if err != nil {
-					log().Errorf("Map update(s) failed for podIdentifier: %s, error: %v", podIdentifier, err)
-					return nil, err
-				}
+			err = s.clusterPolicyReconciler.GeteBPFClient().UpdatePodStateEbpfMaps(podIdentifier, ebpf.CLUSTER_POLICY_POD_STATE_MAP_KEY, ebpf.DEFAULT_ALLOW, true, true)
+			if err != nil {
+				log().Errorf("Pod state map update failed for podIdentifier: %s while updating cluster network policy state, error: %v", podIdentifier, err)
+				return nil, err
 			}
+
 		} else {
 			log().Info("Pod shares the eBPF firewall maps with other local pods. No Map update required..")
 		}
@@ -176,6 +186,7 @@ func (s *server) EnforceNpToPod(ctx context.Context, in *rpc.EnforceNpRequest) (
 
 // DeletePodNp processes CNI Delete Pod NP network request
 func (s *server) DeletePodNp(ctx context.Context, in *rpc.DeleteNpRequest) (*rpc.DeleteNpReply, error) {
+	// We don't need CPE reconciler check here, since we only need one client during the deletion flow to delete the relevant BPF probes and map entries from bpfclient
 	if s.policyReconciler == nil || s.policyReconciler.GeteBPFClient() == nil {
 		log().Debug("Network policy is disabled, returning success")
 		success := rpc.DeleteNpReply{

--- a/pkg/rpc/rpc_handler_test.go
+++ b/pkg/rpc/rpc_handler_test.go
@@ -52,9 +52,11 @@ func TestRunRPCHandler_StaleSocketCleanup(t *testing.T) {
 func TestEnforceNpToPod_ClearDeletedPodBeforeAttach(t *testing.T) {
 	mockBpfClient := &ebpf.MockBpfClient{}
 	reconciler := controllers.NewPolicyEndpointsReconciler(nil, "10.0.0.1", mockBpfClient, false)
+	clusterReconciler := controllers.NewClusterPolicyEndpointsReconciler(nil, "10.0.0.1", mockBpfClient)
 
 	s := &server{
-		policyReconciler: reconciler,
+		policyReconciler:        reconciler,
+		clusterPolicyReconciler: clusterReconciler,
 	}
 
 	resp, err := s.EnforceNpToPod(context.Background(), &rpc.EnforceNpRequest{
@@ -69,4 +71,115 @@ func TestEnforceNpToPod_ClearDeletedPodBeforeAttach(t *testing.T) {
 	// ClearDeletedPod must appear before AttacheBPFProbes
 	assert.Equal(t, "ClearDeletedPod", mockBpfClient.CallLog[1])
 	assert.Equal(t, "AttacheBPFProbes", mockBpfClient.CallLog[2])
+}
+
+func TestEnforceNpToPod_NilClusterPolicyReconciler_ReturnsError(t *testing.T) {
+	mockBpfClient := &ebpf.MockBpfClient{}
+	reconciler := controllers.NewPolicyEndpointsReconciler(nil, "10.0.0.1", mockBpfClient, false)
+
+	s := &server{
+		policyReconciler:        reconciler,
+		clusterPolicyReconciler: nil,
+	}
+
+	resp, err := s.EnforceNpToPod(context.Background(), &rpc.EnforceNpRequest{
+		K8S_POD_NAME:        "nginx-abc123",
+		K8S_POD_NAMESPACE:   "default",
+		NETWORK_POLICY_MODE: "standard",
+		InterfaceCount:      1,
+	})
+	assert.Error(t, err)
+	assert.False(t, resp.Success)
+	assert.Empty(t, mockBpfClient.CallLog)
+}
+
+func TestEnforceNpToPod_NilClusterPolicyEBPFClient_ReturnsError(t *testing.T) {
+	mockBpfClient := &ebpf.MockBpfClient{}
+	reconciler := controllers.NewPolicyEndpointsReconciler(nil, "10.0.0.1", mockBpfClient, false)
+	// clusterReconciler with nil eBPF client
+	clusterReconciler := controllers.NewClusterPolicyEndpointsReconciler(nil, "10.0.0.1", nil)
+
+	s := &server{
+		policyReconciler:        reconciler,
+		clusterPolicyReconciler: clusterReconciler,
+	}
+
+	resp, err := s.EnforceNpToPod(context.Background(), &rpc.EnforceNpRequest{
+		K8S_POD_NAME:        "nginx-abc123",
+		K8S_POD_NAMESPACE:   "default",
+		NETWORK_POLICY_MODE: "standard",
+		InterfaceCount:      1,
+	})
+	assert.Error(t, err)
+	assert.False(t, resp.Success)
+	assert.Empty(t, mockBpfClient.CallLog)
+}
+
+func TestEnforceNpToPod_OneReconcilerReady_ReturnsError(t *testing.T) {
+	// Reverse case: clusterPolicyReconciler is ready but policyReconciler is nil
+	mockBpfClient := &ebpf.MockBpfClient{}
+	clusterReconciler := controllers.NewClusterPolicyEndpointsReconciler(nil, "10.0.0.1", mockBpfClient)
+
+	s := &server{
+		policyReconciler:        nil,
+		clusterPolicyReconciler: clusterReconciler,
+	}
+
+	resp, err := s.EnforceNpToPod(context.Background(), &rpc.EnforceNpRequest{
+		K8S_POD_NAME:        "nginx-abc123",
+		K8S_POD_NAMESPACE:   "default",
+		NETWORK_POLICY_MODE: "standard",
+		InterfaceCount:      1,
+	})
+	assert.Error(t, err)
+	assert.False(t, resp.Success)
+	assert.Contains(t, err.Error(), "One of the policy reconcilers is not ready")
+	assert.Empty(t, mockBpfClient.CallLog)
+}
+
+func TestEnforceNpToPod_BothReconcilersNil_ReturnsSuccess(t *testing.T) {
+	s := &server{
+		policyReconciler:        nil,
+		clusterPolicyReconciler: nil,
+	}
+
+	resp, err := s.EnforceNpToPod(context.Background(), &rpc.EnforceNpRequest{
+		K8S_POD_NAME:        "nginx-abc123",
+		K8S_POD_NAMESPACE:   "default",
+		NETWORK_POLICY_MODE: "standard",
+		InterfaceCount:      1,
+	})
+	assert.NoError(t, err)
+	assert.True(t, resp.Success)
+}
+
+func TestEnforceNpToPod_NoPolicies_UpdatesBothPodStateMaps(t *testing.T) {
+	mockBpfClient := &ebpf.MockBpfClient{}
+	reconciler := controllers.NewPolicyEndpointsReconciler(nil, "10.0.0.1", mockBpfClient, false)
+	clusterReconciler := controllers.NewClusterPolicyEndpointsReconciler(nil, "10.0.0.1", mockBpfClient)
+
+	s := &server{
+		policyReconciler:        reconciler,
+		clusterPolicyReconciler: clusterReconciler,
+	}
+
+	resp, err := s.EnforceNpToPod(context.Background(), &rpc.EnforceNpRequest{
+		K8S_POD_NAME:        "nginx-abc123",
+		K8S_POD_NAMESPACE:   "default",
+		NETWORK_POLICY_MODE: "standard",
+		InterfaceCount:      1,
+	})
+	assert.NoError(t, err)
+	assert.True(t, resp.Success)
+
+	// With no policies and IsFirstPodInPodIdentifier returning false,
+	// the "no active policies" branch fires and calls UpdatePodStateEbpfMaps twice:
+	// once for POD_STATE_MAP_KEY and once for CLUSTER_POLICY_POD_STATE_MAP_KEY
+	updateCount := 0
+	for _, call := range mockBpfClient.CallLog {
+		if call == "UpdatePodStateEbpfMaps" {
+			updateCount++
+		}
+	}
+	assert.Equal(t, 2, updateCount, "should update both pod state map and cluster policy pod state map")
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This was introduced to protect the agent when CPE CRD is not installed in the cluster. However Network Policy Controller install this CRD by default via a reconciler, so this check should no longer be needed. 

Testing - 

TC1 - 
If NP is not enabled and the CRD is not installed, the controller just continues to run in background and doesn't crash
  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
