### PR TITLE
Only allow owners/maintainers to trigger automation workflow

### DIFF
--- a/.github/workflows/pr-cyclonus-tests.yaml
+++ b/.github/workflows/pr-cyclonus-tests.yaml
@@ -21,7 +21,7 @@ jobs:
       github.repository == 'aws/aws-network-policy-agent' &&
       github.event.issue.pull_request != null &&
       startsWith(github.event.comment.body, '/test cyclonus') &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      contains(fromJSON('["OWNER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     outputs:
       pr-sha: ${{ steps.pr-info.outputs.sha }}


### PR DESCRIPTION
*Issue #, if available:* workflow can be triggered by any AWS memeber

*Description of changes:*

Restricting access to only owners/maintainers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
