### PR TITLE
Migrate base images to AL23 (latest-al23)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY . ./
 RUN make vmlinuxh
 
 # Build BPF
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 as bpfbuilder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as bpfbuilder
 WORKDIR /bpfbuilder
 RUN yum update -y && \
     yum install -y iproute procps-ng && \
@@ -45,7 +45,7 @@ COPY --from=vmlinuxbuilder /vmlinuxbuilder/pkg/ebpf/c/vmlinux.h ./pkg/ebpf/c/
 RUN make build-bpf
 
 # Container base image
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest.2
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest-al23
 
 WORKDIR /
 COPY --from=builder /workspace/controller .

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ IMAGE ?= amazon/aws-network-policy-agent
 VERSION ?= $(shell git describe --tags --always --dirty || echo "unknown")
 IMAGE_NAME ?= $(IMAGE)$(IMAGE_ARCH_SUFFIX):$(VERSION)
 GOLANG_VERSION ?= $(shell cat .go-version)
-GOLANG_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/golang:$(GOLANG_VERSION)-gcc-al2
+GOLANG_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/golang:$(GOLANG_VERSION)-gcc-al23
 # TEST_IMAGE is the testing environment container image.
 TEST_IMAGE = aws-network-policy-agent-test
 TEST_IMAGE_NAME = $(TEST_IMAGE)$(IMAGE_ARCH_SUFFIX):$(VERSION)

--- a/test/agent/Dockerfile
+++ b/test/agent/Dockerfile
@@ -18,7 +18,7 @@ COPY cmd cmd
 RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build \
     -a -o check-bpf-cleanup-agent cmd/check-bpf-cleanup-agent/main.go
 
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest.2
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest-al23
 
 WORKDIR /
 COPY --from=builder /workspace/ .


### PR DESCRIPTION
﻿**Issue #, if applicable:**
Fixes #533

**What does this PR do / Why do we need it?**

Migrates base images used by aws-network-policy-agent off AL2 (EOL June 26, 2026) to AL23. Mirrors the pattern applied in the sister PR aws/amazon-vpc-cni-k8s#3661.

**Changes:**

- `Dockerfile` (`bpfbuilder` stage): `amazonlinux:2` → `amazonlinux:2023`
- `Dockerfile` (final container base): `eks-distro-minimal-base-glibc:latest.2` → `latest-al23`
- `test/agent/Dockerfile`: `eks-distro-minimal-base-iptables:latest.2` → `latest-al23`
- `Makefile`: `GOLANG_IMAGE` builder tag `gcc-al2` → `gcc-al23`

The `vmlinuxbuilder` stage in `Dockerfile` was already on `amazonlinux:2023` and is unchanged.

**Testing done on this change:**

Configuration-only change. The package set used in the `bpfbuilder` stage (`iproute`, `procps-ng`, `llvm`, `clang`, `make`, `gcc`, `kernel-devel`, `elfutils-libelf-devel`, `zlib-devel`, `libbpf-devel`) is available in AL2023 (`yum` remains as a `dnf` wrapper in AL2023; package names are unchanged). CI image build will validate end-to-end.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
