### PR TITLE
fix(ebpf): propagate map write errors from update wrappers

### DIFF
--- a/controllers/clusterpolicyendpoints_controller.go
+++ b/controllers/clusterpolicyendpoints_controller.go
@@ -267,7 +267,10 @@ func (r *ClusterPolicyEndpointsReconciler) updateClusterPolicyBPFMaps(podIdentif
 	}
 
 	// TODO: Can be optimized to avoid redundant createIfNotExists calls
-	r.ebpfClient.CreatePodStateEbpfEntryIfNotExists(podIdentifier, ebpf.POD_STATE_MAP_KEY, defaultState)
+	if err := r.ebpfClient.CreatePodStateEbpfEntryIfNotExists(podIdentifier, ebpf.POD_STATE_MAP_KEY, defaultState); err != nil {
+		log().Errorf("Pod-state seed failed for podIdentifier %s: %v", podIdentifier, err)
+		return err
+	}
 	return nil
 }
 

--- a/controllers/policyendpoints_controller.go
+++ b/controllers/policyendpoints_controller.go
@@ -515,7 +515,10 @@ func (r *PolicyEndpointsReconciler) updateeBPFMaps(podIdentifier string,
 		return err
 	}
 
-	r.ebpfClient.CreatePodStateEbpfEntryIfNotExists(podIdentifier, ebpf.CLUSTER_POLICY_POD_STATE_MAP_KEY, ebpf.DEFAULT_ALLOW)
+	if err := r.ebpfClient.CreatePodStateEbpfEntryIfNotExists(podIdentifier, ebpf.CLUSTER_POLICY_POD_STATE_MAP_KEY, ebpf.DEFAULT_ALLOW); err != nil {
+		log().Errorf("Cluster policy pod-state seed failed for podIdentifier %s: %v", podIdentifier, err)
+		return err
+	}
 	return nil
 }
 

--- a/controllers/policyendpoints_controller_test.go
+++ b/controllers/policyendpoints_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 
@@ -1266,4 +1267,117 @@ func TestDeriveFireWallRulesPerPodIdentifier(t *testing.T) {
 			assert.Equal(t, tt.wantErr, gotError)
 		})
 	}
+}
+
+// failClosedTestCase is the table row for fail-closed tests of the bpf-map update wrappers.
+type failClosedTestCase struct {
+	name           string   // human-readable test case name
+	ruleMapErr     error    // error injected on the bpf-client rule-map write; nil = succeed
+	podStateErr    error    // error injected on the bpf-client pod-state write; nil = succeed
+	createEntryErr error    // error injected on the bpf-client createIfNotExists seed; nil = succeed
+	wantErr        error    // expected error, matched with errors.Is; nil = no error
+	wantCalls      []string // expected ordered sequence of bpf-client method names
+}
+
+// runFailClosedTable runs each case as a subtest. invoke wires the variant-specific mock field, builds the reconciler, and calls the function under test.
+func runFailClosedTable(t *testing.T, tests []failClosedTestCase, invoke func(mock *ebpf.MockBpfClient, tt failClosedTestCase) error) {
+	t.Helper()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &ebpf.MockBpfClient{
+				UpdatePodStateEbpfMapsErr:             tt.podStateErr,
+				CreatePodStateEbpfEntryIfNotExistsErr: tt.createEntryErr,
+			}
+			err := invoke(mock, tt)
+
+			if tt.wantErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, tt.wantErr)
+			}
+			assert.Equal(t, tt.wantCalls, mock.CallLog)
+		})
+	}
+}
+
+// TestUpdateeBPFMaps_FailClosed verifies that updateeBPFMaps surfaces
+// errors from the bpf client and short-circuits the pod-state write when
+// the rule-map write fails. wantCalls asserts both the set and the order
+// of bpf-client calls.
+func TestUpdateeBPFMaps_FailClosed(t *testing.T) {
+	ruleMapErr := errors.New("rule map write failed")
+	podStateErr := errors.New("pod state write failed")
+	createEntryErr := errors.New("create entry failed")
+
+	tests := []failClosedTestCase{
+		{
+			name:       "rule-map failure short-circuits before pod-state",
+			ruleMapErr: ruleMapErr,
+			wantErr:    ruleMapErr,
+			wantCalls:  []string{"UpdateEbpfMaps"},
+		},
+		{
+			name:        "pod-state failure surfaces",
+			podStateErr: podStateErr,
+			wantErr:     podStateErr,
+			wantCalls:   []string{"UpdateEbpfMaps", "UpdatePodStateEbpfMaps"},
+		},
+		{
+			name:           "createIfNotExists seed failure surfaces",
+			createEntryErr: createEntryErr,
+			wantErr:        createEntryErr,
+			wantCalls:      []string{"UpdateEbpfMaps", "UpdatePodStateEbpfMaps", "CreatePodStateEbpfEntryIfNotExists"},
+		},
+		{
+			name:      "happy path returns nil and runs the full sequence",
+			wantCalls: []string{"UpdateEbpfMaps", "UpdatePodStateEbpfMaps", "CreatePodStateEbpfEntryIfNotExists"},
+		},
+	}
+
+	runFailClosedTable(t, tests, func(mock *ebpf.MockBpfClient, tt failClosedTestCase) error {
+		mock.UpdateEbpfMapsErr = tt.ruleMapErr
+		r := &PolicyEndpointsReconciler{ebpfClient: mock}
+		return r.updateeBPFMaps("test-pod-id", nil, nil, ebpf.POLICIES_APPLIED)
+	})
+}
+
+// TestUpdateClusterPolicyBPFMaps_FailClosed mirrors TestUpdateeBPFMaps_FailClosed
+// for the ClusterPolicyEndpointsReconciler path: a cluster-policy rule-map
+// failure must short-circuit before pod-state runs, and either failure must
+// surface to the caller.
+func TestUpdateClusterPolicyBPFMaps_FailClosed(t *testing.T) {
+	ruleMapErr := errors.New("cluster rule map write failed")
+	podStateErr := errors.New("cluster pod state write failed")
+	createEntryErr := errors.New("cluster create entry failed")
+
+	tests := []failClosedTestCase{
+		{
+			name:       "cluster rule-map failure short-circuits before pod-state",
+			ruleMapErr: ruleMapErr,
+			wantErr:    ruleMapErr,
+			wantCalls:  []string{"UpdateClusterPolicyEbpfMaps"},
+		},
+		{
+			name:        "cluster pod-state failure surfaces",
+			podStateErr: podStateErr,
+			wantErr:     podStateErr,
+			wantCalls:   []string{"UpdateClusterPolicyEbpfMaps", "UpdatePodStateEbpfMaps"},
+		},
+		{
+			name:           "createIfNotExists seed failure surfaces",
+			createEntryErr: createEntryErr,
+			wantErr:        createEntryErr,
+			wantCalls:      []string{"UpdateClusterPolicyEbpfMaps", "UpdatePodStateEbpfMaps", "CreatePodStateEbpfEntryIfNotExists"},
+		},
+		{
+			name:      "happy path returns nil and runs the full sequence",
+			wantCalls: []string{"UpdateClusterPolicyEbpfMaps", "UpdatePodStateEbpfMaps", "CreatePodStateEbpfEntryIfNotExists"},
+		},
+	}
+
+	runFailClosedTable(t, tests, func(mock *ebpf.MockBpfClient, tt failClosedTestCase) error {
+		mock.UpdateClusterPolicyEbpfMapsErr = tt.ruleMapErr
+		r := &ClusterPolicyEndpointsReconciler{ebpfClient: mock}
+		return r.updateClusterPolicyBPFMaps("test-pod-id", nil, nil)
+	})
 }

--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -447,6 +447,7 @@ func (l *bpfClient) recoverBPFState(bpfTCClient tc.BpfTc, eBPFSDKClient goelf.Bp
 						inMemMap, err := NewInMemoryBpfMap(&ingressVal)
 						if err != nil {
 							log().Errorf("got err for ingress in-mem map for %v, err %v", podIdentifier, err)
+							sdkAPIErr.WithLabelValues("recoverBPFState-ingress").Inc()
 						} else {
 							l.ingressInMemoryMap.Store(podIdentifier, inMemMap)
 							log().Infof("ingress map for %v loaded successfully", podIdentifier)
@@ -462,6 +463,7 @@ func (l *bpfClient) recoverBPFState(bpfTCClient tc.BpfTc, eBPFSDKClient goelf.Bp
 						inMemMap, err := NewInMemoryBpfMap(&cpIngressVal)
 						if err != nil {
 							log().Errorf("got err for cluster policy ingress in-mem map for %v, err %v", podIdentifier, err)
+							sdkAPIErr.WithLabelValues("recoverBPFState-cluster-ingress").Inc()
 						} else {
 							l.clusterPolicyIngressInMemoryMap.Store(podIdentifier, inMemMap)
 							log().Infof("cluster policy ingress map for %v loaded successfully", podIdentifier)
@@ -479,6 +481,7 @@ func (l *bpfClient) recoverBPFState(bpfTCClient tc.BpfTc, eBPFSDKClient goelf.Bp
 						inMemMap, err := NewInMemoryBpfMap(&egressVal)
 						if err != nil {
 							log().Errorf("got err for egress in-mem map for %v, err %v", podIdentifier, err)
+							sdkAPIErr.WithLabelValues("recoverBPFState-egress").Inc()
 						} else {
 							l.egressInMemoryMap.Store(podIdentifier, inMemMap)
 							log().Infof("egress map for %v loaded successfully", podIdentifier)
@@ -494,6 +497,7 @@ func (l *bpfClient) recoverBPFState(bpfTCClient tc.BpfTc, eBPFSDKClient goelf.Bp
 						inMemMap, err := NewInMemoryBpfMap(&cpEgressVal)
 						if err != nil {
 							log().Errorf("got err for cluster policy egress in-mem map for %v, err %v", podIdentifier, err)
+							sdkAPIErr.WithLabelValues("recoverBPFState-cluster-egress").Inc()
 						} else {
 							l.clusterPolicyEgressInMemoryMap.Store(podIdentifier, inMemMap)
 							log().Infof("cluster policy egress map for %v loaded successfully", podIdentifier)
@@ -952,204 +956,297 @@ func (l *bpfClient) loadBPFProgram(fileName string, direction string,
 	return progInfo, progFD, nil
 }
 
+// UpdateEbpfMaps writes the namespaced-policy ingress and egress firewall rule
+// sets for podIdentifier into the kernel TC_INGRESS_MAP / TC_EGRESS_MAP, hydrating
+// the userspace shadow map on first use. Ingress and egress are attempted
+// independently and any errors are returned joined.
 func (l *bpfClient) UpdateEbpfMaps(podIdentifier string, ingressFirewallRules []fwrp.EbpfFirewallRules,
 	egressFirewallRules []fwrp.EbpfFirewallRules) error {
 
 	start := time.Now()
+	var ingressErr, egressErr error
 	value, ok := l.policyEndpointeBPFContext.Load(podIdentifier)
+	if !ok {
+		sdkAPIErr.WithLabelValues("updateEbpfMap-no-context").Inc()
+		return fmt.Errorf("no bpf context registered for pod %s", podIdentifier)
+	}
+	peBPFContext, ok := value.(BPFContext)
+	if !ok {
+		sdkAPIErr.WithLabelValues("updateEbpfMap-bad-context-type").Inc()
+		return fmt.Errorf("unexpected bpf context type %T for pod %s", value, podIdentifier)
+	}
+	ingressProgInfo := peBPFContext.ingressPgmInfo
+	egressProgInfo := peBPFContext.egressPgmInfo
 
-	if ok {
-		peBPFContext := value.(BPFContext)
-		ingressProgInfo := peBPFContext.ingressPgmInfo
-		egressProgInfo := peBPFContext.egressPgmInfo
+	if ingressProgInfo.Program.ProgFD != 0 {
+		ingressProgFD := ingressProgInfo.Program.ProgFD
+		mapToUpdate := ingressProgInfo.Maps[utils.TC_INGRESS_MAP]
+		log().Infof("Pod has an Ingress hook attached. Update the corresponding map progFD: %d, mapName: %s", ingressProgFD, utils.TC_INGRESS_MAP)
 
-		if ingressProgInfo.Program.ProgFD != 0 {
-			ingressProgFD := ingressProgInfo.Program.ProgFD
-			mapToUpdate := ingressProgInfo.Maps[utils.TC_INGRESS_MAP]
-			log().Infof("Pod has an Ingress hook attached. Update the corresponding map progFD: %d, mapName: %s", ingressProgFD, utils.TC_INGRESS_MAP)
-
-			inMemVal, exists := l.ingressInMemoryMap.Load(podIdentifier)
-			if !exists {
-				log().Infof("Ingress in-mem map not found for %v", podIdentifier)
-				inMemMap, err := NewInMemoryBpfMap(&mapToUpdate)
-				if err != nil {
-					log().Errorf("got err for ingress in-mem map for %v, err %v", podIdentifier, err)
-				} else {
-					l.ingressInMemoryMap.Store(podIdentifier, inMemMap)
-					log().Infof("ingress map for %v loaded successfully", podIdentifier)
-					inMemVal = inMemMap
-				}
-			}
-
-			err := l.updateEbpfMap(ingressFirewallRules, inMemVal.(*InMemoryBpfMap))
-			duration := msSince(start)
-			sdkAPILatency.WithLabelValues("updateEbpfMap-ingress", fmt.Sprint(err != nil)).Observe(duration)
+		inMemVal, exists := l.ingressInMemoryMap.Load(podIdentifier)
+		if !exists {
+			log().Infof("Ingress in-mem map not found for %v", podIdentifier)
+			inMemMap, err := NewInMemoryBpfMap(&mapToUpdate)
 			if err != nil {
-				log().Errorf("Ingress Map update failed: %v", err)
-				sdkAPIErr.WithLabelValues("updateEbpfMap-ingress").Inc()
+				ingressErr = fmt.Errorf("ingress in-mem map hydrate: %w", err)
+			} else {
+				l.ingressInMemoryMap.Store(podIdentifier, inMemMap)
+				log().Infof("ingress map for %v loaded successfully", podIdentifier)
+				inMemVal = inMemMap
 			}
 		}
-		if egressProgInfo.Program.ProgFD != 0 {
-			egressProgFD := egressProgInfo.Program.ProgFD
-			mapToUpdate := egressProgInfo.Maps[utils.TC_EGRESS_MAP]
 
-			log().Infof("Pod has an Egress hook attached. Update the corresponding map progFD: %d, mapName: %s", egressProgFD, utils.TC_EGRESS_MAP)
-
-			inMemVal, exists := l.egressInMemoryMap.Load(podIdentifier)
-			if !exists {
-				log().Infof("didn't find egress in-mem map for %v", podIdentifier)
-				inMemMap, err := NewInMemoryBpfMap(&mapToUpdate)
-				if err != nil {
-					log().Errorf("got err for egress in-mem map for %v, err %v", podIdentifier, err)
-				} else {
-					l.egressInMemoryMap.Store(podIdentifier, inMemMap)
-					log().Infof("egress map for %v loaded successfully", podIdentifier)
-					inMemVal = inMemMap
+		if ingressErr == nil {
+			inMemMap, typeOk := inMemVal.(*InMemoryBpfMap)
+			if !typeOk {
+				ingressErr = fmt.Errorf("ingress in-mem map: unexpected type %T", inMemVal)
+			} else {
+				writeErr := l.updateEbpfMap(ingressFirewallRules, inMemMap)
+				duration := msSince(start)
+				sdkAPILatency.WithLabelValues("updateEbpfMap-ingress", fmt.Sprint(writeErr != nil)).Observe(duration)
+				if writeErr != nil {
+					ingressErr = fmt.Errorf("ingress map write: %w", writeErr)
 				}
 			}
-
-			err := l.updateEbpfMap(egressFirewallRules, inMemVal.(*InMemoryBpfMap))
-			duration := msSince(start)
-			sdkAPILatency.WithLabelValues("updateEbpfMap-egress", fmt.Sprint(err != nil)).Observe(duration)
-			if err != nil {
-				log().Errorf("Egress Map update failed: %v", err)
-				sdkAPIErr.WithLabelValues("updateEbpfMap-egress").Inc()
-			}
+		}
+		if ingressErr != nil {
+			log().Errorf("Ingress Map update failed: %v", ingressErr)
+			sdkAPIErr.WithLabelValues("updateEbpfMap-ingress").Inc()
 		}
 	}
-	return nil
+	if egressProgInfo.Program.ProgFD != 0 {
+		egressProgFD := egressProgInfo.Program.ProgFD
+		mapToUpdate := egressProgInfo.Maps[utils.TC_EGRESS_MAP]
+
+		log().Infof("Pod has an Egress hook attached. Update the corresponding map progFD: %d, mapName: %s", egressProgFD, utils.TC_EGRESS_MAP)
+
+		inMemVal, exists := l.egressInMemoryMap.Load(podIdentifier)
+		if !exists {
+			log().Infof("didn't find egress in-mem map for %v", podIdentifier)
+			inMemMap, err := NewInMemoryBpfMap(&mapToUpdate)
+			if err != nil {
+				egressErr = fmt.Errorf("egress in-mem map hydrate: %w", err)
+			} else {
+				l.egressInMemoryMap.Store(podIdentifier, inMemMap)
+				log().Infof("egress map for %v loaded successfully", podIdentifier)
+				inMemVal = inMemMap
+			}
+		}
+
+		if egressErr == nil {
+			inMemMap, typeOk := inMemVal.(*InMemoryBpfMap)
+			if !typeOk {
+				egressErr = fmt.Errorf("egress in-mem map: unexpected type %T", inMemVal)
+			} else {
+				writeErr := l.updateEbpfMap(egressFirewallRules, inMemMap)
+				duration := msSince(start)
+				sdkAPILatency.WithLabelValues("updateEbpfMap-egress", fmt.Sprint(writeErr != nil)).Observe(duration)
+				if writeErr != nil {
+					egressErr = fmt.Errorf("egress map write: %w", writeErr)
+				}
+			}
+		}
+		if egressErr != nil {
+			log().Errorf("Egress Map update failed: %v", egressErr)
+			sdkAPIErr.WithLabelValues("updateEbpfMap-egress").Inc()
+		}
+	}
+	return errors.Join(ingressErr, egressErr)
 }
 
+// UpdateClusterPolicyEbpfMaps writes the cluster-policy ingress and egress
+// firewall rule sets for podIdentifier into the kernel
+// TC_CLUSTER_POLICY_INGRESS_MAP / TC_CLUSTER_POLICY_EGRESS_MAP, hydrating the
+// userspace shadow map on first use. Ingress and egress are attempted
+// independently and any errors are returned joined.
 func (l *bpfClient) UpdateClusterPolicyEbpfMaps(podIdentifier string, ingressFirewallRules []fwrp.EbpfFirewallRules,
 	egressFirewallRules []fwrp.EbpfFirewallRules) error {
 
 	var ingressProgFD, egressProgFD int
 	start := time.Now()
+	var ingressErr, egressErr error
 	value, ok := l.policyEndpointeBPFContext.Load(podIdentifier)
+	if !ok {
+		sdkAPIErr.WithLabelValues("updateClusterPolicyEbpfMap-no-context").Inc()
+		return fmt.Errorf("no bpf context registered for pod %s", podIdentifier)
+	}
+	peBPFContext, ok := value.(BPFContext)
+	if !ok {
+		sdkAPIErr.WithLabelValues("updateClusterPolicyEbpfMap-bad-context-type").Inc()
+		return fmt.Errorf("unexpected bpf context type %T for pod %s", value, podIdentifier)
+	}
+	ingressProgInfo := peBPFContext.ingressPgmInfo
+	egressProgInfo := peBPFContext.egressPgmInfo
 
-	if ok {
-		peBPFContext := value.(BPFContext)
-		ingressProgInfo := peBPFContext.ingressPgmInfo
-		egressProgInfo := peBPFContext.egressPgmInfo
+	if ingressProgInfo.Program.ProgFD != 0 {
+		ingressProgFD = ingressProgInfo.Program.ProgFD
+		mapToUpdate := ingressProgInfo.Maps[utils.TC_CLUSTER_POLICY_INGRESS_MAP]
+		log().Infof("Pod has a ClusterPolicyIngress hook attached. Update the corresponding map progFD: %d, mapName: %s", ingressProgFD, utils.TC_CLUSTER_POLICY_INGRESS_MAP)
 
-		if ingressProgInfo.Program.ProgFD != 0 {
-			ingressProgFD = ingressProgInfo.Program.ProgFD
-			mapToUpdate := ingressProgInfo.Maps[utils.TC_CLUSTER_POLICY_INGRESS_MAP]
-			log().Infof("Pod has a ClusterPolicyIngress hook attached. Update the corresponding map progFD: %d, mapName: %s", ingressProgFD, utils.TC_CLUSTER_POLICY_INGRESS_MAP)
-
-			inMemVal, exists := l.clusterPolicyIngressInMemoryMap.Load(podIdentifier)
-			if !exists {
-				log().Infof("Cluster Policy Ingress in-mem map not found for %v", podIdentifier)
-				inMemMap, err := NewInMemoryBpfMap(&mapToUpdate)
-				if err != nil {
-					log().Errorf("got err for Cluster Policy Ingress in-mem map for %v, err %v", podIdentifier, err)
-				} else {
-					l.clusterPolicyIngressInMemoryMap.Store(podIdentifier, inMemMap)
-					log().Infof("cluster policy ingress map for %v loaded successfully", podIdentifier)
-					inMemVal = inMemMap
-				}
-			}
-			err := l.updateClusterPolicyEbpfMap(ingressFirewallRules, inMemVal.(*InMemoryBpfMap))
-			duration := msSince(start)
-			sdkAPILatency.WithLabelValues("updateClusterPolicyEbpfMap-ingress", fmt.Sprint(err != nil)).Observe(duration)
+		inMemVal, exists := l.clusterPolicyIngressInMemoryMap.Load(podIdentifier)
+		if !exists {
+			log().Infof("Cluster Policy Ingress in-mem map not found for %v", podIdentifier)
+			inMemMap, err := NewInMemoryBpfMap(&mapToUpdate)
 			if err != nil {
-				log().Errorf("Ingress Map update failed: %v", err)
-				sdkAPIErr.WithLabelValues("updateClusterPolicyEbpfMap-ingress").Inc()
+				ingressErr = fmt.Errorf("cluster policy ingress in-mem map hydrate: %w", err)
+			} else {
+				l.clusterPolicyIngressInMemoryMap.Store(podIdentifier, inMemMap)
+				log().Infof("cluster policy ingress map for %v loaded successfully", podIdentifier)
+				inMemVal = inMemMap
 			}
 		}
-		if egressProgInfo.Program.ProgFD != 0 {
-			egressProgFD = egressProgInfo.Program.ProgFD
-			mapToUpdate := egressProgInfo.Maps[utils.TC_CLUSTER_POLICY_EGRESS_MAP]
-
-			log().Infof("Pod has an Egress hook attached. Update the corresponding map progFD: %d, mapName: %s", egressProgFD, utils.TC_CLUSTER_POLICY_EGRESS_MAP)
-
-			inMemVal, exists := l.clusterPolicyEgressInMemoryMap.Load(podIdentifier)
-			if !exists {
-				log().Infof("didn't find cluster policy egress in-mem map for %v", podIdentifier)
-				inMemMap, err := NewInMemoryBpfMap(&mapToUpdate)
-				if err != nil {
-					log().Errorf("got err for cluster policy egress in-mem map for %v, err %v", podIdentifier, err)
-				} else {
-					l.clusterPolicyEgressInMemoryMap.Store(podIdentifier, inMemMap)
-					log().Infof("cluster policy egress map for %v loaded successfully", podIdentifier)
-					inMemVal = inMemMap
+		if ingressErr == nil {
+			inMemMap, typeOk := inMemVal.(*InMemoryBpfMap)
+			if !typeOk {
+				ingressErr = fmt.Errorf("cluster policy ingress in-mem map: unexpected type %T", inMemVal)
+			} else {
+				writeErr := l.updateClusterPolicyEbpfMap(ingressFirewallRules, inMemMap)
+				duration := msSince(start)
+				sdkAPILatency.WithLabelValues("updateClusterPolicyEbpfMap-ingress", fmt.Sprint(writeErr != nil)).Observe(duration)
+				if writeErr != nil {
+					ingressErr = fmt.Errorf("cluster policy ingress map write: %w", writeErr)
 				}
 			}
-
-			err := l.updateClusterPolicyEbpfMap(egressFirewallRules, inMemVal.(*InMemoryBpfMap))
-			duration := msSince(start)
-			sdkAPILatency.WithLabelValues("updateClusterPolicyEbpfMap-egress", fmt.Sprint(err != nil)).Observe(duration)
-			if err != nil {
-				log().Errorf("Cluster Policy Egress Map update failed: %v", err)
-				sdkAPIErr.WithLabelValues("updateClusterPolicyEbpfMap-egress").Inc()
-			}
+		}
+		if ingressErr != nil {
+			log().Errorf("Ingress Map update failed: %v", ingressErr)
+			sdkAPIErr.WithLabelValues("updateClusterPolicyEbpfMap-ingress").Inc()
 		}
 	}
-	return nil
+	if egressProgInfo.Program.ProgFD != 0 {
+		egressProgFD = egressProgInfo.Program.ProgFD
+		mapToUpdate := egressProgInfo.Maps[utils.TC_CLUSTER_POLICY_EGRESS_MAP]
+
+		log().Infof("Pod has an Egress hook attached. Update the corresponding map progFD: %d, mapName: %s", egressProgFD, utils.TC_CLUSTER_POLICY_EGRESS_MAP)
+
+		inMemVal, exists := l.clusterPolicyEgressInMemoryMap.Load(podIdentifier)
+		if !exists {
+			log().Infof("didn't find cluster policy egress in-mem map for %v", podIdentifier)
+			inMemMap, err := NewInMemoryBpfMap(&mapToUpdate)
+			if err != nil {
+				egressErr = fmt.Errorf("cluster policy egress in-mem map hydrate: %w", err)
+			} else {
+				l.clusterPolicyEgressInMemoryMap.Store(podIdentifier, inMemMap)
+				log().Infof("cluster policy egress map for %v loaded successfully", podIdentifier)
+				inMemVal = inMemMap
+			}
+		}
+
+		if egressErr == nil {
+			inMemMap, typeOk := inMemVal.(*InMemoryBpfMap)
+			if !typeOk {
+				egressErr = fmt.Errorf("cluster policy egress in-mem map: unexpected type %T", inMemVal)
+			} else {
+				writeErr := l.updateClusterPolicyEbpfMap(egressFirewallRules, inMemMap)
+				duration := msSince(start)
+				sdkAPILatency.WithLabelValues("updateClusterPolicyEbpfMap-egress", fmt.Sprint(writeErr != nil)).Observe(duration)
+				if writeErr != nil {
+					egressErr = fmt.Errorf("cluster policy egress map write: %w", writeErr)
+				}
+			}
+		}
+		if egressErr != nil {
+			log().Errorf("Cluster Policy Egress Map update failed: %v", egressErr)
+			sdkAPIErr.WithLabelValues("updateClusterPolicyEbpfMap-egress").Inc()
+		}
+	}
+	return errors.Join(ingressErr, egressErr)
 }
 
+// CreatePodStateEbpfEntryIfNotExists seeds the initial pod-state map entry for
+// podIdentifier under both the ingress and egress hooks. Used at probe-attach
+// time to put the pod into a defined default state (DEFAULT_ALLOW or
+// DEFAULT_DENY) before any policy rules are programmed.
 func (l *bpfClient) CreatePodStateEbpfEntryIfNotExists(podIdentifier string, key int, state int) error {
 	keyval := uint32(key)
 	value, ok := l.policyEndpointeBPFContext.Load(podIdentifier)
-
-	if ok {
-		peBPFContext := value.(BPFContext)
-		ingressProgInfo := peBPFContext.ingressPgmInfo
-		egressProgInfo := peBPFContext.egressPgmInfo
-		value := pod_state{state: uint8(state)}
-		if ingressProgInfo.Program.ProgFD != 0 {
-			mapToUpdate := ingressProgInfo.Maps[utils.TC_INGRESS_POD_STATE_MAP]
-			mapToUpdate.CreateMapEntry(uintptr(unsafe.Pointer(&keyval)), uintptr(unsafe.Pointer(&value)))
-		}
-		if egressProgInfo.Program.ProgFD != 0 {
-			mapToUpdate := egressProgInfo.Maps[utils.TC_EGRESS_POD_STATE_MAP]
-			mapToUpdate.CreateMapEntry(uintptr(unsafe.Pointer(&keyval)), uintptr(unsafe.Pointer(&value)))
+	if !ok {
+		sdkAPIErr.WithLabelValues("createPodStateEntry-no-context").Inc()
+		return fmt.Errorf("no bpf context registered for pod %s", podIdentifier)
+	}
+	peBPFContext, ok := value.(BPFContext)
+	if !ok {
+		sdkAPIErr.WithLabelValues("createPodStateEntry-bad-context-type").Inc()
+		return fmt.Errorf("unexpected bpf context type %T for pod %s", value, podIdentifier)
+	}
+	ingressProgInfo := peBPFContext.ingressPgmInfo
+	egressProgInfo := peBPFContext.egressPgmInfo
+	podStateValue := pod_state{state: uint8(state)}
+	var ingressErr, egressErr error
+	// CreateMapEntry uses BPF_NOEXIST and the SDK swallows EEXIST as nil,
+	// so repeated calls are no-ops and this function stays idempotent.
+	if ingressProgInfo.Program.ProgFD != 0 {
+		mapToUpdate := ingressProgInfo.Maps[utils.TC_INGRESS_POD_STATE_MAP]
+		if err := mapToUpdate.CreateMapEntry(uintptr(unsafe.Pointer(&keyval)), uintptr(unsafe.Pointer(&podStateValue))); err != nil {
+			log().Errorf("Ingress Pod State entry create failed: %v", err)
+			sdkAPIErr.WithLabelValues("createPodStateEntry-ingress").Inc()
+			ingressErr = fmt.Errorf("ingress pod state entry create: %w", err)
 		}
 	}
-	return nil
+	if egressProgInfo.Program.ProgFD != 0 {
+		mapToUpdate := egressProgInfo.Maps[utils.TC_EGRESS_POD_STATE_MAP]
+		if err := mapToUpdate.CreateMapEntry(uintptr(unsafe.Pointer(&keyval)), uintptr(unsafe.Pointer(&podStateValue))); err != nil {
+			log().Errorf("Egress Pod State entry create failed: %v", err)
+			sdkAPIErr.WithLabelValues("createPodStateEntry-egress").Inc()
+			egressErr = fmt.Errorf("egress pod state entry create: %w", err)
+		}
+	}
+	return errors.Join(ingressErr, egressErr)
 }
 
+// UpdatePodStateEbpfMaps writes the pod-state value (DEFAULT_ALLOW,
+// DEFAULT_DENY, or POLICIES_APPLIED) for podIdentifier into the
+// TC_INGRESS_POD_STATE_MAP and/or TC_EGRESS_POD_STATE_MAP, gated by the
+// updateIngress and updateEgress flags. Ingress and egress are attempted
+// independently and any errors are returned joined.
 func (l *bpfClient) UpdatePodStateEbpfMaps(podIdentifier string, key int, state int, updateIngress bool, updateEgress bool) error {
 
 	var ingressProgFD, egressProgFD int
 	var mapToUpdate goebpfmaps.BpfMap
-	start := time.Now()
+	var ingressErr, egressErr error
 	keyval := uint32(key)
 	value, ok := l.policyEndpointeBPFContext.Load(podIdentifier)
+	if !ok {
+		sdkAPIErr.WithLabelValues("updateEbpfMap-podstate-no-context").Inc()
+		return fmt.Errorf("no bpf context registered for pod %s", podIdentifier)
+	}
+	peBPFContext, ok := value.(BPFContext)
+	if !ok {
+		sdkAPIErr.WithLabelValues("updateEbpfMap-podstate-bad-context-type").Inc()
+		return fmt.Errorf("unexpected bpf context type %T for pod %s", value, podIdentifier)
+	}
+	ingressProgInfo := peBPFContext.ingressPgmInfo
+	egressProgInfo := peBPFContext.egressPgmInfo
+	podStateValue := pod_state{state: uint8(state)}
 
-	if ok {
-		peBPFContext := value.(BPFContext)
-		ingressProgInfo := peBPFContext.ingressPgmInfo
-		egressProgInfo := peBPFContext.egressPgmInfo
-		value := pod_state{state: uint8(state)} // pod_state_map value
-
-		if updateIngress && ingressProgInfo.Program.ProgFD != 0 {
-			ingressProgFD = ingressProgInfo.Program.ProgFD
-			mapToUpdate = ingressProgInfo.Maps[utils.TC_INGRESS_POD_STATE_MAP]
-			log().Infof("Pod has an Ingress hook attached. Update the corresponding map progFD: %d, mapName: %s, key: %d, value: %d", ingressProgFD, utils.TC_INGRESS_POD_STATE_MAP, keyval, value)
-			err := mapToUpdate.CreateUpdateMapEntry(uintptr(unsafe.Pointer(&keyval)), uintptr(unsafe.Pointer(&value)), 0)
-			duration := msSince(start)
-			sdkAPILatency.WithLabelValues("updateEbpfMap-ingress-podstate", fmt.Sprint(err != nil)).Observe(duration)
-			if err != nil {
-				log().Errorf("Ingress Pod State Map update failed: %v", err)
-				sdkAPIErr.WithLabelValues("updateEbpfMap-ingress-podstate").Inc()
-			}
-		}
-		if updateEgress && egressProgInfo.Program.ProgFD != 0 {
-			egressProgFD = egressProgInfo.Program.ProgFD
-			mapToUpdate = egressProgInfo.Maps[utils.TC_EGRESS_POD_STATE_MAP]
-
-			log().Infof("Pod has an Egress hook attached. Update the corresponding map progFD: %d, mapName: %s, key: %d, value: %d", egressProgFD, utils.TC_EGRESS_POD_STATE_MAP, keyval, value)
-			err := mapToUpdate.CreateUpdateMapEntry(uintptr(unsafe.Pointer(&keyval)), uintptr(unsafe.Pointer(&value)), 0)
-			duration := msSince(start)
-			sdkAPILatency.WithLabelValues("updateEbpfMap-egress-podstate", fmt.Sprint(err != nil)).Observe(duration)
-			if err != nil {
-				log().Errorf("Egress Map update failed: %v", err)
-				sdkAPIErr.WithLabelValues("updateEbpfMap-egress-podstate").Inc()
-			}
+	if updateIngress && ingressProgInfo.Program.ProgFD != 0 {
+		ingressProgFD = ingressProgInfo.Program.ProgFD
+		mapToUpdate = ingressProgInfo.Maps[utils.TC_INGRESS_POD_STATE_MAP]
+		log().Infof("Pod has an Ingress hook attached. Update the corresponding map progFD: %d, mapName: %s, key: %d, value: %d", ingressProgFD, utils.TC_INGRESS_POD_STATE_MAP, keyval, podStateValue.state)
+		start := time.Now()
+		ingressErr = mapToUpdate.CreateUpdateMapEntry(uintptr(unsafe.Pointer(&keyval)), uintptr(unsafe.Pointer(&podStateValue)), 0)
+		sdkAPILatency.WithLabelValues("updateEbpfMap-ingress-podstate", fmt.Sprint(ingressErr != nil)).Observe(msSince(start))
+		if ingressErr != nil {
+			log().Errorf("Ingress Pod State Map update failed: %v", ingressErr)
+			sdkAPIErr.WithLabelValues("updateEbpfMap-ingress-podstate").Inc()
+			ingressErr = fmt.Errorf("ingress pod state map write: %w", ingressErr)
 		}
 	}
-	return nil
+	if updateEgress && egressProgInfo.Program.ProgFD != 0 {
+		egressProgFD = egressProgInfo.Program.ProgFD
+		mapToUpdate = egressProgInfo.Maps[utils.TC_EGRESS_POD_STATE_MAP]
+
+		log().Infof("Pod has an Egress hook attached. Update the corresponding map progFD: %d, mapName: %s, key: %d, value: %d", egressProgFD, utils.TC_EGRESS_POD_STATE_MAP, keyval, podStateValue.state)
+		start := time.Now()
+		egressErr = mapToUpdate.CreateUpdateMapEntry(uintptr(unsafe.Pointer(&keyval)), uintptr(unsafe.Pointer(&podStateValue)), 0)
+		sdkAPILatency.WithLabelValues("updateEbpfMap-egress-podstate", fmt.Sprint(egressErr != nil)).Observe(msSince(start))
+		if egressErr != nil {
+			log().Errorf("Egress Map update failed: %v", egressErr)
+			sdkAPIErr.WithLabelValues("updateEbpfMap-egress-podstate").Inc()
+			egressErr = fmt.Errorf("egress pod state map write: %w", egressErr)
+		}
+	}
+	return errors.Join(ingressErr, egressErr)
 }
 
 func (l *bpfClient) isEBPFProbeAttached(podName string, podNamespace string) (bool, bool) {

--- a/pkg/ebpf/bpf_client_mock.go
+++ b/pkg/ebpf/bpf_client_mock.go
@@ -25,6 +25,13 @@ func NewMockBpfClient() *bpfClient {
 
 type MockBpfClient struct {
 	CallLog []string
+
+	// Injected errors for failure-path tests. Zero values preserve the
+	// original success-path behavior, so existing tests continue to pass.
+	UpdateEbpfMapsErr                     error
+	UpdateClusterPolicyEbpfMapsErr        error
+	UpdatePodStateEbpfMapsErr             error
+	CreatePodStateEbpfEntryIfNotExistsErr error
 }
 
 func (m *MockBpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier string, numInterfaces int) error {
@@ -39,17 +46,17 @@ func (m *MockBpfClient) DeleteBPFProbes(pod types.NamespacedName, podIdentifier 
 
 func (m *MockBpfClient) UpdateEbpfMaps(podIdentifier string, ingressFirewallRules []fwrp.EbpfFirewallRules, egressFirewallRules []fwrp.EbpfFirewallRules) error {
 	m.CallLog = append(m.CallLog, "UpdateEbpfMaps")
-	return nil
+	return m.UpdateEbpfMapsErr
 }
 
 func (m *MockBpfClient) UpdateClusterPolicyEbpfMaps(podIdentifier string, ingressFirewallRules []fwrp.EbpfFirewallRules, egressFirewallRules []fwrp.EbpfFirewallRules) error {
 	m.CallLog = append(m.CallLog, "UpdateClusterPolicyEbpfMaps")
-	return nil
+	return m.UpdateClusterPolicyEbpfMapsErr
 }
 
 func (m *MockBpfClient) UpdatePodStateEbpfMaps(podIdentifier string, key int, state int, updateIngress bool, updateEgress bool) error {
 	m.CallLog = append(m.CallLog, "UpdatePodStateEbpfMaps")
-	return nil
+	return m.UpdatePodStateEbpfMapsErr
 }
 
 func (m *MockBpfClient) IsFirstPodInPodIdentifier(podIdentifier string) bool {
@@ -68,7 +75,7 @@ func (m *MockBpfClient) GetNetworkPolicyMode() string {
 
 func (m *MockBpfClient) CreatePodStateEbpfEntryIfNotExists(podIdentifier string, key int, state int) error {
 	m.CallLog = append(m.CallLog, "CreatePodStateEbpfEntryIfNotExists")
-	return nil
+	return m.CreatePodStateEbpfEntryIfNotExistsErr
 }
 
 func (m *MockBpfClient) ClearDeletedPod(podNamespacedName string) {

--- a/pkg/rpc/rpc_handler_test.go
+++ b/pkg/rpc/rpc_handler_test.go
@@ -15,6 +15,7 @@ package rpc
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 
@@ -182,4 +183,33 @@ func TestEnforceNpToPod_NoPolicies_UpdatesBothPodStateMaps(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 2, updateCount, "should update both pod state map and cluster policy pod state map")
+}
+
+// TestEnforceNpToPod_FailsClosedOnPodStateError verifies that EnforceNpToPod
+// returns an error rather than a success reply when the pod-state map write
+// fails on the no-cached-policies path that seeds default-allow/default-deny.
+// Both reconcilers are wired so the readiness check passes and execution
+// reaches UpdatePodStateEbpfMaps.
+func TestEnforceNpToPod_FailsClosedOnPodStateError(t *testing.T) {
+	injected := errors.New("simulated pod state write failure")
+	mockBpfClient := &ebpf.MockBpfClient{
+		UpdatePodStateEbpfMapsErr: injected,
+	}
+	reconciler := controllers.NewPolicyEndpointsReconciler(nil, "10.0.0.1", mockBpfClient, false)
+	clusterReconciler := controllers.NewClusterPolicyEndpointsReconciler(nil, "10.0.0.1", mockBpfClient)
+
+	s := &server{
+		policyReconciler:        reconciler,
+		clusterPolicyReconciler: clusterReconciler,
+	}
+
+	resp, err := s.EnforceNpToPod(context.Background(), &rpc.EnforceNpRequest{
+		K8S_POD_NAME:        "nginx-abc123",
+		K8S_POD_NAMESPACE:   "default",
+		NETWORK_POLICY_MODE: "standard",
+		InterfaceCount:      1,
+	})
+
+	assert.ErrorIs(t, err, injected)
+	assert.Nil(t, resp, "rpc must not return a success reply when the pod-state write fails")
 }


### PR DESCRIPTION
UpdateEbpfMaps, UpdateClusterPolicyEbpfMaps, UpdatePodStateEbpfMaps, and CreatePodStateEbpfEntryIfNotExists now return errors via errors.Join instead of swallowing them, so callers fail closed and don't signal POLICIES_APPLIED on map-write failure. Missing BPF context (Load !ok) is now an error rather than silent success. Hydration failures bail out before the type assertion that would panic; type assertions use comma-ok to fail closed on type mismatch. Latency observation moved into the kernel-write block so the metric reflects what its label says.

Adds fail-closed regression tests for PolicyEndpointsReconciler, ClusterPolicyEndpointsReconciler, and EnforceNpToPod.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


## Manual upgrade validation — eBPF map error propagation

- Functional sanity: created a 3-replica nginx Deployment plus a
   deny-all NetworkPolicy in a dedicated test namespace; scaled
   replicas 3 → 10 → 1 → 2; deleted the Deployment and NetworkPolicy;
   recreated the Deployment.
- Churn regression: submitted 100 Kubernetes Jobs in parallel, each
   running a 1-second busybox container then exiting. This stresses
   every wrapper this PR touches (UpdateEbpfMaps, UpdatePodStateEbpfMaps,
   CreatePodStateEbpfEntryIfNotExists) at high create/delete frequency.
- Snapshotted NPA pod state and logs before vs after; greped for
   panic/fatal, the new fail-closed log strings, and any map-update
   error.

### Results

| Check                                     | Expected           | Observed                  |
|-------------------------------------------|--------------------|---------------------------|
| Rollout completion                        | success            | rolled out cleanly        |
| NPA pod readiness after upgrade           | 3/3 pods 2/2       | confirmed                 |
| NPA agent crashes during test             | 0                  | RESTARTS=0 on all 3 pods  |
| Functional Deployment+NP create / delete  | clean              | scale/delete/recreate ok  |
| Churn — 100 short-lived Jobs              | succeeded=100      | succeeded=100, failed=0   |
| panic / fatal / runtime error log lines   | none               | none on any NPA pod       |
| Fail-closed paths fired (no-context,      | none expected on   | none observed             |
|  bad-context-type, map write failed, etc) | happy path         |                           |
| Generic "Map update failed" log lines     | none               | none                      |

