### PR TITLE
Fix attach-state collision in GetPodNamespacedName

### DIFF
--- a/pkg/ebpf/bpf_client_test.go
+++ b/pkg/ebpf/bpf_client_test.go
@@ -100,6 +100,28 @@ func TestBpfClient_IsEBPFProbeAttached(t *testing.T) {
 	}
 }
 
+// Pre-attach pod ("ab", "c") and verify pod ("a", "bc") does not inherit
+// attachment state — the buggy raw concatenation aliased these to the same key.
+func TestBpfClient_IsEBPFProbeAttached_NoCollisionAcrossPods(t *testing.T) {
+	ingressProgFD, egressProgFD := 12, 13
+	testBpfClient := &bpfClient{
+		hostMask:            "/32",
+		ingressPodToProgMap: new(sync.Map),
+		egressPodToProgMap:  new(sync.Map),
+	}
+
+	// Pod A: ("ab", "c") is the first pod attached.
+	attachedKey := utils.GetPodNamespacedName("ab", "c")
+	testBpfClient.ingressPodToProgMap.Store(attachedKey, ingressProgFD)
+	testBpfClient.egressPodToProgMap.Store(attachedKey, egressProgFD)
+
+	// Pod B: ("a", "bc") arrives next; under the buggy concatenation both
+	// pods produced key "abc" and Pod B inherited Pod A's attachment state.
+	gotIngress, gotEgress := testBpfClient.isEBPFProbeAttached("a", "bc")
+	assert.False(t, gotIngress, "pod (a, bc) must not see pod (ab, c)'s ingress attachment")
+	assert.False(t, gotEgress, "pod (a, bc) must not see pod (ab, c)'s egress attachment")
+}
+
 func TestLoadBPFProgram(t *testing.T) {
 	var wantErr error
 	ctrl := gomock.NewController(t)
@@ -733,7 +755,7 @@ func TestBpfClient_getInterfaceCountForPod(t *testing.T) {
 			name:                        "Multi-NIC enabled with IPAM cache data",
 			providedCount:               0,
 			isMultiNICEnabled:           true,
-			podNameToInterfaceCountData: map[string]int{"testPodtestNS": 2},
+			podNameToInterfaceCountData: map[string]int{"testPod_testNS": 2},
 			wantCount:                   2,
 			wantErr:                     nil,
 		},
@@ -859,8 +881,8 @@ func TestBpfClient_loadIPAMData(t *testing.T) {
 			}`,
 			wantErr: false,
 			wantCached: map[string]int{
-				"test-poddefault":      2,
-				"multi-podkube-system": 3,
+				"test-pod_default":      2,
+				"multi-pod_kube-system": 3,
 			},
 		},
 		{
@@ -913,7 +935,7 @@ func TestBpfClient_getInterfaceCountFromBackupFile(t *testing.T) {
 	}{
 		{
 			name:      "Interface count found in cache",
-			cacheData: map[string]int{"test-poddefault": 2},
+			cacheData: map[string]int{"test-pod_default": 2},
 			wantCount: 2,
 			wantErr:   false,
 		},
@@ -955,9 +977,9 @@ func TestIsProgFdShared(t *testing.T) {
 		isProgFdShared bool
 	}
 	podToProgFd := map[string]int{
-		"pod1A": 2,
-		"pod2A": 2,
-		"pod1B": 15,
+		"pod1_A": 2,
+		"pod2_A": 2,
+		"pod1_B": 15,
 	}
 	tests := []struct {
 		name         string

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -150,7 +150,11 @@ func (t Tier) Index() int {
 }
 
 func GetPodNamespacedName(podName, podNamespace string) string {
-	return podName + podNamespace
+	// "_" is forbidden in DNS-1123 pod names and namespaces, so this separator
+	// makes the key injective on (podName, podNamespace). "_" is also pin-path
+	// safe (no filesystem meaning), matching the convention used in
+	// GetPodIdentifier where "." is substituted with "_" for the same reason.
+	return podName + "_" + podNamespace
 }
 
 func GetPodIdentifier(podName, podNamespace string) string {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -350,7 +350,23 @@ func TestGetPodNamespacedName(t *testing.T) {
 				podName:      "testPod",
 				podNamespace: "testNamespace",
 			},
-			want: "testPodtestNamespace",
+			want: "testPod_testNamespace",
+		},
+		{
+			name: "Collision-prone pair (ab, c) is distinguishable",
+			args: args{
+				podName:      "ab",
+				podNamespace: "c",
+			},
+			want: "ab_c",
+		},
+		{
+			name: "Collision-prone pair (a, bc) is distinguishable",
+			args: args{
+				podName:      "a",
+				podNamespace: "bc",
+			},
+			want: "a_bc",
 		},
 	}
 	for _, tt := range tests {
@@ -358,6 +374,21 @@ func TestGetPodNamespacedName(t *testing.T) {
 			got := GetPodNamespacedName(tt.args.podName, tt.args.podNamespace)
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+// Distinct (podName, podNamespace) pairs that aliased to the same string under
+// raw concatenation must produce different keys after the delimiter fix.
+func TestGetPodNamespacedName_NoCollisionAcrossDistinctPods(t *testing.T) {
+	pairs := [][2][2]string{
+		{{"ab", "c"}, {"a", "bc"}},
+		{{"a-b", "c-d"}, {"a", "b-c-d"}},
+		{{"foo", "bar-baz"}, {"foo-bar", "baz"}},
+	}
+	for _, p := range pairs {
+		left := GetPodNamespacedName(p[0][0], p[0][1])
+		right := GetPodNamespacedName(p[1][0], p[1][1])
+		assert.NotEqual(t, left, right, "distinct pods must not collide: %v vs %v", p[0], p[1])
 	}
 }
 


### PR DESCRIPTION
Pods ("ab","c") and ("a","bc") produced the same in-memory key "abc", causing isEBPFProbeAttached to false-positive and AttacheBPFProbes to skip TC hook installation for the second pod — a policy bypass.

"_" is forbidden in DNS-1123 names and namespaces, making the key injective. Change is in-process only; kernel state is keyed by GetPodIdentifier and unaffected, so no migration is required.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
