### PR TITLE
add liveness and readiness probe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/aws-network-policy-agent
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/aws/amazon-vpc-cni-k8s v1.20.0

--- a/main.go
+++ b/main.go
@@ -49,7 +49,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -140,18 +139,32 @@ func main() {
 
 	//+kubebuilder:scaffold:builder
 
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		log.Errorf("unable to set up health check %v", err)
+	// Liveness probe: gRPC server responsiveness.
+	if err := mgr.AddHealthzCheck("grpc-socket", rpc.NewGRPCSocketLivenessCheck(npaSocketPath)); err != nil {
+		log.Errorf("unable to set up gRPC socket health check %v", err)
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		log.Errorf("unable to set up ready check %v", err)
+
+	// Readiness probe: gRPC server responsiveness and BPF map pins (when
+	// network policy is enabled).
+	if err := mgr.AddReadyzCheck("grpc-socket", rpc.NewGRPCSocketLivenessCheck(npaSocketPath)); err != nil {
+		log.Errorf("unable to set up grpc-socket readiness check %v", err)
 		os.Exit(1)
+	}
+
+	if ctrlConfig.EnableNetworkPolicy {
+		readyzPaths := []string{ebpf.CONNTRACK_MAP_PIN_PATH}
+		if ctrlConfig.EnablePolicyEventLogs {
+			readyzPaths = append(readyzPaths, ebpf.POLICY_EVENTS_MAP_PIN_PATH)
+		}
+		if err := mgr.AddReadyzCheck("bpf-maps", ebpf.NewGlobalMapsReadinessCheck(readyzPaths)); err != nil {
+			log.Errorf("unable to set up bpf-maps readiness check %v", err)
+			os.Exit(1)
+		}
 	}
 
 	// CNI makes rpc calls to NP agent regardless NP is enabled or not
 	// need to start rpc always
-	// todo: add a liveness probe to this gRPC server and remove closing based on this errCh, liveness probe will check and re-start this container
 	errCh, err := rpc.RunRPCHandler(policyEndpointController, clusterPolicyEndpointController, npaSocketPath)
 	if err != nil {
 		log.Errorf("Failed to set up gRPC Handler %v", err)

--- a/main.go
+++ b/main.go
@@ -134,8 +134,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		readyzPaths := []string{ebpf.CONNTRACK_MAP_PIN_PATH}
-		readyzPaths = append(readyzPaths, ebpf.POLICY_EVENTS_MAP_PIN_PATH)
+		readyzPaths := []string{ebpf.CONNTRACK_MAP_PIN_PATH, ebpf.POLICY_EVENTS_MAP_PIN_PATH}
 		if err := mgr.AddReadyzCheck("bpf-maps", ebpf.NewGlobalMapsReadinessCheck(readyzPaths)); err != nil {
 			log.Errorf("unable to set up bpf-maps readiness check %v", err)
 			os.Exit(1)
@@ -152,13 +151,21 @@ func main() {
 	//+kubebuilder:scaffold:builder
 
 	// The gRPC server runs whether or not network policy is enabled, so its
-	// health checks are registered unconditionally.
-	if err := mgr.AddHealthzCheck("grpc-socket", rpc.NewGRPCSocketHealthCheck(npaSocketPath)); err != nil {
+	// health checks are registered unconditionally. The checker is created once
+	// and shared between the liveness and readiness probes.
+	grpcHealthChecker, err := rpc.NewGRPCSocketHealthChecker(npaSocketPath)
+	if err != nil {
+		log.Errorf("unable to set up gRPC socket health checker %v", err)
+		os.Exit(1)
+	}
+	defer grpcHealthChecker.Close()
+
+	if err := mgr.AddHealthzCheck("grpc-socket", grpcHealthChecker.Check); err != nil {
 		log.Errorf("unable to set up gRPC socket health check %v", err)
 		os.Exit(1)
 	}
 
-	if err := mgr.AddReadyzCheck("grpc-socket", rpc.NewGRPCSocketHealthCheck(npaSocketPath)); err != nil {
+	if err := mgr.AddReadyzCheck("grpc-socket", grpcHealthChecker.Check); err != nil {
 		log.Errorf("unable to set up grpc-socket readiness check %v", err)
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -135,9 +135,7 @@ func main() {
 		}
 
 		readyzPaths := []string{ebpf.CONNTRACK_MAP_PIN_PATH}
-		if ctrlConfig.EnablePolicyEventLogs {
-			readyzPaths = append(readyzPaths, ebpf.POLICY_EVENTS_MAP_PIN_PATH)
-		}
+		readyzPaths = append(readyzPaths, ebpf.POLICY_EVENTS_MAP_PIN_PATH)
 		if err := mgr.AddReadyzCheck("bpf-maps", ebpf.NewGlobalMapsReadinessCheck(readyzPaths)); err != nil {
 			log.Errorf("unable to set up bpf-maps readiness check %v", err)
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -133,26 +133,7 @@ func main() {
 			log.Errorf("unable to create controller ClusterPolicyEndpoints %v", err)
 			os.Exit(1)
 		}
-	} else {
-		log.Info("Network Policy is disabled, skip the controller registration")
-	}
 
-	//+kubebuilder:scaffold:builder
-
-	// Liveness probe: gRPC server responsiveness.
-	if err := mgr.AddHealthzCheck("grpc-socket", rpc.NewGRPCSocketLivenessCheck(npaSocketPath)); err != nil {
-		log.Errorf("unable to set up gRPC socket health check %v", err)
-		os.Exit(1)
-	}
-
-	// Readiness probe: gRPC server responsiveness and BPF map pins (when
-	// network policy is enabled).
-	if err := mgr.AddReadyzCheck("grpc-socket", rpc.NewGRPCSocketLivenessCheck(npaSocketPath)); err != nil {
-		log.Errorf("unable to set up grpc-socket readiness check %v", err)
-		os.Exit(1)
-	}
-
-	if ctrlConfig.EnableNetworkPolicy {
 		readyzPaths := []string{ebpf.CONNTRACK_MAP_PIN_PATH}
 		if ctrlConfig.EnablePolicyEventLogs {
 			readyzPaths = append(readyzPaths, ebpf.POLICY_EVENTS_MAP_PIN_PATH)
@@ -161,10 +142,32 @@ func main() {
 			log.Errorf("unable to set up bpf-maps readiness check %v", err)
 			os.Exit(1)
 		}
+
+		if err := mgr.AddReadyzCheck("bpf-fs", ebpf.NewBpfFsReadinessCheck(ebpf.BPF_FS_ROOT)); err != nil {
+			log.Errorf("unable to set up bpf-fs readiness check %v", err)
+			os.Exit(1)
+		}
+	} else {
+		log.Info("Network Policy is disabled, skip the controller registration")
+	}
+
+	//+kubebuilder:scaffold:builder
+
+	// The gRPC server runs whether or not network policy is enabled, so its
+	// health checks are registered unconditionally.
+	if err := mgr.AddHealthzCheck("grpc-socket", rpc.NewGRPCSocketLivenessCheck(npaSocketPath)); err != nil {
+		log.Errorf("unable to set up gRPC socket health check %v", err)
+		os.Exit(1)
+	}
+
+	if err := mgr.AddReadyzCheck("grpc-socket", rpc.NewGRPCSocketLivenessCheck(npaSocketPath)); err != nil {
+		log.Errorf("unable to set up grpc-socket readiness check %v", err)
+		os.Exit(1)
 	}
 
 	// CNI makes rpc calls to NP agent regardless NP is enabled or not
 	// need to start rpc always
+	// todo: add a liveness probe to this gRPC server and remove closing based on this errCh, liveness probe will check and re-start this container
 	errCh, err := rpc.RunRPCHandler(policyEndpointController, clusterPolicyEndpointController, npaSocketPath)
 	if err != nil {
 		log.Errorf("Failed to set up gRPC Handler %v", err)

--- a/main.go
+++ b/main.go
@@ -155,12 +155,12 @@ func main() {
 
 	// The gRPC server runs whether or not network policy is enabled, so its
 	// health checks are registered unconditionally.
-	if err := mgr.AddHealthzCheck("grpc-socket", rpc.NewGRPCSocketLivenessCheck(npaSocketPath)); err != nil {
+	if err := mgr.AddHealthzCheck("grpc-socket", rpc.NewGRPCSocketHealthCheck(npaSocketPath)); err != nil {
 		log.Errorf("unable to set up gRPC socket health check %v", err)
 		os.Exit(1)
 	}
 
-	if err := mgr.AddReadyzCheck("grpc-socket", rpc.NewGRPCSocketLivenessCheck(npaSocketPath)); err != nil {
+	if err := mgr.AddReadyzCheck("grpc-socket", rpc.NewGRPCSocketHealthCheck(npaSocketPath)); err != nil {
 		log.Errorf("unable to set up grpc-socket readiness check %v", err)
 		os.Exit(1)
 	}

--- a/pkg/ebpf/healthcheck.go
+++ b/pkg/ebpf/healthcheck.go
@@ -1,0 +1,35 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ebpf
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+)
+
+// NewGlobalMapsReadinessCheck returns a health check that verifies the given
+// BPF map pin paths exist.
+func NewGlobalMapsReadinessCheck(paths []string) func(_ *http.Request) error {
+	return func(_ *http.Request) error {
+		for _, p := range paths {
+			if _, err := os.Stat(p); err != nil {
+				err = fmt.Errorf("required BPF map pin missing: %s: %w", p, err)
+				log().Errorf("bpf-maps check failed: %v", err)
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/pkg/ebpf/healthcheck.go
+++ b/pkg/ebpf/healthcheck.go
@@ -17,7 +17,12 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+
+	"golang.org/x/sys/unix"
 )
+
+// BPF_FS_ROOT is the mount point the agent pins its programs and maps under.
+const BPF_FS_ROOT = "/sys/fs/bpf"
 
 // NewGlobalMapsReadinessCheck returns a health check that verifies the given
 // BPF map pin paths exist.
@@ -29,6 +34,32 @@ func NewGlobalMapsReadinessCheck(paths []string) func(_ *http.Request) error {
 				log().Errorf("bpf-maps check failed: %v", err)
 				return err
 			}
+		}
+		return nil
+	}
+}
+
+// NewBpfFsReadinessCheck returns a readiness check that verifies the BPF
+// filesystem at root is mounted as bpffs and is not mounted read-only. Without
+// a writable bpffs the agent cannot pin programs or maps, so it should not be
+// reported ready even if the process and gRPC server are up.
+func NewBpfFsReadinessCheck(root string) func(_ *http.Request) error {
+	return func(_ *http.Request) error {
+		var st unix.Statfs_t
+		if err := unix.Statfs(root, &st); err != nil {
+			err = fmt.Errorf("statfs %s failed: %w", root, err)
+			log().Errorf("bpf-fs check failed: %v", err)
+			return err
+		}
+		if st.Type != unix.BPF_FS_MAGIC {
+			err := fmt.Errorf("%s is not a bpffs mount (fs magic 0x%x)", root, st.Type)
+			log().Errorf("bpf-fs check failed: %v", err)
+			return err
+		}
+		if st.Flags&unix.ST_RDONLY != 0 {
+			err := fmt.Errorf("bpf filesystem at %s is mounted read-only", root)
+			log().Errorf("bpf-fs check failed: %v", err)
+			return err
 		}
 		return nil
 	}

--- a/pkg/ebpf/healthcheck_test.go
+++ b/pkg/ebpf/healthcheck_test.go
@@ -1,0 +1,73 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ebpf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewGlobalMapsReadinessCheck(t *testing.T) {
+	dir := t.TempDir()
+	present := filepath.Join(dir, "global_aws_conntrack_map")
+	assert.NoError(t, os.WriteFile(present, []byte("x"), 0o644))
+	missing := filepath.Join(dir, "does_not_exist")
+
+	tests := []struct {
+		name    string
+		paths   []string
+		wantErr bool
+	}{
+		{name: "no paths passes", paths: nil, wantErr: false},
+		{name: "all present passes", paths: []string{present}, wantErr: false},
+		{name: "one missing fails", paths: []string{present, missing}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewGlobalMapsReadinessCheck(tt.paths)(nil)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewBpfFsReadinessCheck(t *testing.T) {
+	t.Run("non-existent path fails statfs", func(t *testing.T) {
+		err := NewBpfFsReadinessCheck(filepath.Join(t.TempDir(), "nope"))(nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("regular dir is not bpffs", func(t *testing.T) {
+		// A normal tmpfs/ext4 dir has a non-BPF_FS_MAGIC fs type, so the
+		// check must reject it. This is the realistic "bpffs failed to mount,
+		// agent is pinning into the root fs" failure mode.
+		err := NewBpfFsReadinessCheck(t.TempDir())(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not a bpffs mount")
+	})
+
+	t.Run("real bpffs passes when mounted", func(t *testing.T) {
+		// Only meaningful where /sys/fs/bpf is actually a bpffs mount (e.g.
+		// CI/dev hosts with BPF). Skip otherwise so the suite stays hermetic.
+		if err := NewBpfFsReadinessCheck(BPF_FS_ROOT)(nil); err != nil {
+			t.Skipf("%s is not a writable bpffs in this environment: %v", BPF_FS_ROOT, err)
+		}
+	})
+}

--- a/pkg/ebpf/healthcheck_test.go
+++ b/pkg/ebpf/healthcheck_test.go
@@ -62,12 +62,4 @@ func TestNewBpfFsReadinessCheck(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "not a bpffs mount")
 	})
-
-	t.Run("real bpffs passes when mounted", func(t *testing.T) {
-		// Only meaningful where /sys/fs/bpf is actually a bpffs mount (e.g.
-		// CI/dev hosts with BPF). Skip otherwise so the suite stays hermetic.
-		if err := NewBpfFsReadinessCheck(BPF_FS_ROOT)(nil); err != nil {
-			t.Skipf("%s is not a writable bpffs in this environment: %v", BPF_FS_ROOT, err)
-		}
-	})
 }

--- a/pkg/rpc/healthcheck.go
+++ b/pkg/rpc/healthcheck.go
@@ -1,0 +1,68 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package rpc
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+const livenessCheckTimeout = 10 * time.Second
+
+// NewGRPCSocketLivenessCheck returns a health check that issues a gRPC
+// Health/Check RPC against the NPA Unix socket at socketPath.
+func NewGRPCSocketLivenessCheck(socketPath string) func(_ *http.Request) error {
+	return func(_ *http.Request) error {
+		ctx, cancel := context.WithTimeout(context.Background(), livenessCheckTimeout)
+		defer cancel()
+
+		conn, err := grpc.NewClient(
+			"unix://"+socketPath,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", socketPath)
+			}),
+		)
+		if err != nil {
+			err = fmt.Errorf("grpc NewClient for %s failed: %w", socketPath, err)
+			log().Errorf("grpc-socket check failed: %v", err)
+			return err
+		}
+		defer conn.Close()
+
+		client := healthpb.NewHealthClient(conn)
+		resp, err := client.Check(ctx, &healthpb.HealthCheckRequest{
+			Service: grpcHealthServiceName,
+		})
+		if err != nil {
+			err = fmt.Errorf("grpc health check failed: %w", err)
+			log().Errorf("grpc-socket check failed: %v", err)
+			return err
+		}
+		if resp.GetStatus() != healthpb.HealthCheckResponse_SERVING {
+			err = fmt.Errorf("grpc health check returned non-serving status: %s", resp.GetStatus())
+			log().Errorf("grpc-socket check failed: %v", err)
+			return err
+		}
+		return nil
+	}
+}

--- a/pkg/rpc/healthcheck.go
+++ b/pkg/rpc/healthcheck.go
@@ -25,48 +25,63 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
-const livenessCheckTimeout = 10 * time.Second
+const grpcCheckTimeout = 10 * time.Second
 
-// NewGRPCSocketHealthCheck returns a health check that issues a gRPC
-// Health/Check RPC against the NPA Unix socket at socketPath.
-func NewGRPCSocketHealthCheck(socketPath string) func(r *http.Request) error {
-	return func(r *http.Request) error {
-		baseCtx := context.Background()
-		if r != nil {
-			baseCtx = r.Context()
-		}
-		ctx, cancel := context.WithTimeout(baseCtx, livenessCheckTimeout)
-		defer cancel()
+// GRPCSocketHealthChecker issues gRPC Health/Check RPCs against the NPA Unix
+// socket. It holds a single long-lived gRPC client reused across probe
+// invocations rather than rebuilding one per call.
+type GRPCSocketHealthChecker struct {
+	conn   *grpc.ClientConn
+	client healthpb.HealthClient
+}
 
-		conn, err := grpc.NewClient(
-			"unix://"+socketPath,
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
-				var d net.Dialer
-				return d.DialContext(ctx, "unix", socketPath)
-			}),
-		)
-		if err != nil {
-			err = fmt.Errorf("grpc NewClient for %s failed: %w", socketPath, err)
-			log().Errorf("grpc-socket check failed: %v", err)
-			return err
-		}
-		defer conn.Close()
-
-		client := healthpb.NewHealthClient(conn)
-		resp, err := client.Check(ctx, &healthpb.HealthCheckRequest{
-			Service: grpcHealthServiceName,
-		})
-		if err != nil {
-			err = fmt.Errorf("grpc health check failed: %w", err)
-			log().Errorf("grpc-socket check failed: %v", err)
-			return err
-		}
-		if resp.GetStatus() != healthpb.HealthCheckResponse_SERVING {
-			err = fmt.Errorf("grpc health check returned non-serving status: %s", resp.GetStatus())
-			log().Errorf("grpc-socket check failed: %v", err)
-			return err
-		}
-		return nil
+// NewGRPCSocketHealthChecker creates a health checker for the Unix socket at
+// socketPath. grpc.NewClient performs no I/O and connects lazily on the first
+// Check, so this succeeds even when the server is not yet listening.
+func NewGRPCSocketHealthChecker(socketPath string) (*GRPCSocketHealthChecker, error) {
+	conn, err := grpc.NewClient(
+		"unix://"+socketPath,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, "unix", socketPath)
+		}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("grpc NewClient for %s failed: %w", socketPath, err)
 	}
+	return &GRPCSocketHealthChecker{
+		conn:   conn,
+		client: healthpb.NewHealthClient(conn),
+	}, nil
+}
+
+// Check implements the controller-runtime healthz.Checker signature.
+func (c *GRPCSocketHealthChecker) Check(r *http.Request) error {
+	baseCtx := context.Background()
+	if r != nil {
+		baseCtx = r.Context()
+	}
+	ctx, cancel := context.WithTimeout(baseCtx, grpcCheckTimeout)
+	defer cancel()
+
+	resp, err := c.client.Check(ctx, &healthpb.HealthCheckRequest{
+		Service: grpcHealthServiceName,
+	})
+	if err != nil {
+		err = fmt.Errorf("grpc health check failed: %w", err)
+		log().Errorf("grpc-socket check failed: %v", err)
+		return err
+	}
+	if resp.GetStatus() != healthpb.HealthCheckResponse_SERVING {
+		err = fmt.Errorf("grpc health check returned non-serving status: %s", resp.GetStatus())
+		log().Errorf("grpc-socket check failed: %v", err)
+		return err
+	}
+	return nil
+}
+
+// Close releases the underlying gRPC client connection.
+func (c *GRPCSocketHealthChecker) Close() error {
+	return c.conn.Close()
 }

--- a/pkg/rpc/healthcheck.go
+++ b/pkg/rpc/healthcheck.go
@@ -27,11 +27,15 @@ import (
 
 const livenessCheckTimeout = 10 * time.Second
 
-// NewGRPCSocketLivenessCheck returns a health check that issues a gRPC
+// NewGRPCSocketHealthCheck returns a health check that issues a gRPC
 // Health/Check RPC against the NPA Unix socket at socketPath.
-func NewGRPCSocketLivenessCheck(socketPath string) func(_ *http.Request) error {
-	return func(_ *http.Request) error {
-		ctx, cancel := context.WithTimeout(context.Background(), livenessCheckTimeout)
+func NewGRPCSocketHealthCheck(socketPath string) func(r *http.Request) error {
+	return func(r *http.Request) error {
+		baseCtx := context.Background()
+		if r != nil {
+			baseCtx = r.Context()
+		}
+		ctx, cancel := context.WithTimeout(baseCtx, livenessCheckTimeout)
 		defer cancel()
 
 		conn, err := grpc.NewClient(

--- a/pkg/rpc/healthcheck.go
+++ b/pkg/rpc/healthcheck.go
@@ -25,7 +25,7 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
-const grpcCheckTimeout = 10 * time.Second
+const grpcCheckTimeout = 5 * time.Second
 
 // GRPCSocketHealthChecker issues gRPC Health/Check RPCs against the NPA Unix
 // socket. It holds a single long-lived gRPC client reused across probe

--- a/pkg/rpc/healthcheck_test.go
+++ b/pkg/rpc/healthcheck_test.go
@@ -1,0 +1,83 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package rpc
+
+import (
+	"net"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// startTestHealthServer starts a gRPC server with the standard health service
+// registered on a Unix socket at socketPath, reporting status for
+// grpcHealthServiceName. It returns a stop function to shut the server down.
+func startTestHealthServer(t *testing.T, socketPath string, status healthpb.HealthCheckResponse_ServingStatus) func() {
+	t.Helper()
+
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+
+	grpcServer := grpc.NewServer()
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus(grpcHealthServiceName, status)
+	healthpb.RegisterHealthServer(grpcServer, healthServer)
+
+	go func() {
+		_ = grpcServer.Serve(listener)
+	}()
+
+	return func() {
+		grpcServer.Stop()
+		_ = os.Remove(socketPath)
+	}
+}
+
+func TestNewGRPCSocketHealthCheck_Serving(t *testing.T) {
+	socketPath := "/tmp/test-healthcheck-serving.sock"
+	_ = os.Remove(socketPath)
+	stop := startTestHealthServer(t, socketPath, healthpb.HealthCheckResponse_SERVING)
+	defer stop()
+
+	check := NewGRPCSocketHealthCheck(socketPath)
+	assert.NoError(t, check(nil))
+}
+
+func TestNewGRPCSocketHealthCheck_NotServing(t *testing.T) {
+	socketPath := "/tmp/test-healthcheck-notserving.sock"
+	_ = os.Remove(socketPath)
+	stop := startTestHealthServer(t, socketPath, healthpb.HealthCheckResponse_NOT_SERVING)
+	defer stop()
+
+	check := NewGRPCSocketHealthCheck(socketPath)
+	err := check(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "non-serving status")
+}
+
+func TestNewGRPCSocketHealthCheck_MissingSocket(t *testing.T) {
+	socketPath := "/tmp/test-healthcheck-missing.sock"
+	// Ensure nothing is listening at this path.
+	_ = os.Remove(socketPath)
+
+	check := NewGRPCSocketHealthCheck(socketPath)
+	err := check(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "grpc health check failed")
+}

--- a/pkg/rpc/healthcheck_test.go
+++ b/pkg/rpc/healthcheck_test.go
@@ -49,35 +49,41 @@ func startTestHealthServer(t *testing.T, socketPath string, status healthpb.Heal
 	}
 }
 
-func TestNewGRPCSocketHealthCheck_Serving(t *testing.T) {
+func TestGRPCSocketHealthChecker_Serving(t *testing.T) {
 	socketPath := "/tmp/test-healthcheck-serving.sock"
 	_ = os.Remove(socketPath)
 	stop := startTestHealthServer(t, socketPath, healthpb.HealthCheckResponse_SERVING)
 	defer stop()
 
-	check := NewGRPCSocketHealthCheck(socketPath)
-	assert.NoError(t, check(nil))
+	checker, err := NewGRPCSocketHealthChecker(socketPath)
+	require.NoError(t, err)
+	defer checker.Close()
+	assert.NoError(t, checker.Check(nil))
 }
 
-func TestNewGRPCSocketHealthCheck_NotServing(t *testing.T) {
+func TestGRPCSocketHealthChecker_NotServing(t *testing.T) {
 	socketPath := "/tmp/test-healthcheck-notserving.sock"
 	_ = os.Remove(socketPath)
 	stop := startTestHealthServer(t, socketPath, healthpb.HealthCheckResponse_NOT_SERVING)
 	defer stop()
 
-	check := NewGRPCSocketHealthCheck(socketPath)
-	err := check(nil)
+	checker, err := NewGRPCSocketHealthChecker(socketPath)
+	require.NoError(t, err)
+	defer checker.Close()
+	err = checker.Check(nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "non-serving status")
 }
 
-func TestNewGRPCSocketHealthCheck_MissingSocket(t *testing.T) {
+func TestGRPCSocketHealthChecker_MissingSocket(t *testing.T) {
 	socketPath := "/tmp/test-healthcheck-missing.sock"
 	// Ensure nothing is listening at this path.
 	_ = os.Remove(socketPath)
 
-	check := NewGRPCSocketHealthCheck(socketPath)
-	err := check(nil)
+	checker, err := NewGRPCSocketHealthChecker(socketPath)
+	require.NoError(t, err)
+	defer checker.Close()
+	err = checker.Check(nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "grpc health check failed")
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Testing, 
Tested readiness probe by removing grpc socket. Sample logs when socket is removed.

```
{"level":"error","ts":"2026-05-05T14:36:43.331Z","caller":"healthz/healthz.go:59","msg":"grpc-socket check failed: grpc health check failed: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial unix /var/run/aws-node/npa.sock: connect: no such file or directory\""}
{"level":"info","ts":"2026-05-05T14:36:43.331Z","logger":"controller-runtime.healthz","caller":"healthz/healthz.go:128","msg":"healthz check failed","statuses":[{},{}]}
{"level":"error","ts":"2026-05-05T14:36:53.332Z","caller":"healthz/healthz.go:59","msg":"grpc-socket check failed: grpc health check failed: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial unix /var/run/aws-node/npa.sock: connect: no such file or directory\""}
{"level":"info","ts":"2026-05-05T14:36:53.332Z","logger":"controller-runtime.healthz","caller":"healthz/healthz.go:128","msg":"healthz check failed","statuses":[{},{}]}
```

```
Add a gRPC Unix-socket health check that performs a gRPC Health/Check RPC against the agent.
Add readiness checks for bpffs correctness (mounted + writable) and presence of required pinned BPF maps.
Register the new checks with the controller manager and add unit tests for the eBPF readiness checks.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
