### PR TITLE
Added NPA agent IT for upgrades and rollback

### DIFF
--- a/test/integration/upgrade/upgrade_suite_test.go
+++ b/test/integration/upgrade/upgrade_suite_test.go
@@ -1,0 +1,34 @@
+package upgrade
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-network-policy-agent/test/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	fw        *framework.Framework
+	ctx       context.Context
+	namespace = "upgrade-test"
+)
+
+func TestAgentUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Agent Upgrade Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	fw = framework.New(framework.GlobalOptions)
+	ctx = context.Background()
+
+	err := fw.NamespaceManager.CreateNamespace(ctx, namespace)
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	err := fw.NamespaceManager.DeleteAndWaitTillNamespaceDeleted(ctx, namespace)
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/test/integration/upgrade/upgrade_test.go
+++ b/test/integration/upgrade/upgrade_test.go
@@ -1,0 +1,454 @@
+package upgrade
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-network-policy-agent/test/framework/manifest"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	network "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+/*
+Utility test to test upgrades and rollback.
+
+Two scenarios:
+ 1. Binary unchanged (v1.3.2 -> v1.3.4): prog IDs, per-pod map IDs, and global map IDs all preserved.
+ 2. Binary changed (v1.2.7 -> v1.3.4): prog IDs change (new binary loaded). Global map IDs are also changed
+
+todo - can improve this test to run as part of automated pipeline by injecting image tags as env vars.
+*/
+const (
+	agentDaemonSet    = "aws-node"
+	agentNamespace    = "kube-system"
+	agentContainer    = "aws-eks-nodeagent"
+	baseImage         = "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent"
+	rolloutTimeout    = 5 * time.Minute
+	podReadyTimeout   = 2 * time.Minute
+	bpfSettleInterval = 10 * time.Second
+)
+
+type bpfState struct {
+	progIDs    map[string]int // pinPath basename -> prog ID
+	mapIDs     map[string]int // "podIdentifier/mapName" -> map ID
+	globalMaps map[string]int // global map name -> map ID (deduplicated)
+}
+
+// Scenario 1: Binary unchanged (v1.3.2 <-> v1.3.4)
+var _ = Describe("Agent Upgrade/Rollback - Binary Unchanged", Ordered, func() {
+	const (
+		fromTag = "v1.3.2"
+		toTag   = "v1.3.4"
+	)
+
+	var (
+		networkPolicy     *network.NetworkPolicy
+		workloadPod       *v1.Pod
+		nodeName          string
+		preUpgradeState   bpfState
+		postUpgradeState  bpfState
+		preRollbackState  bpfState
+		postRollbackState bpfState
+	)
+
+	It("should preserve all BPF state across upgrade", func() {
+		By("Setting agent image to old version: " + fromTag)
+		setAgentImage(baseImage + ":" + fromTag)
+		waitForDaemonSetRollout()
+
+		By("Deploying workload pod with network policy")
+		workloadPod = buildWorkloadPod("binary-unchanged")
+		var err error
+		workloadPod, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, workloadPod, podReadyTimeout)
+		Expect(err).ToNot(HaveOccurred())
+		nodeName = workloadPod.Spec.NodeName
+
+		networkPolicy = buildTestNetworkPolicy("binary-unchanged")
+		err = fw.NetworkPolicyManager.CreateNetworkPolicy(ctx, networkPolicy)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for BPF probes to be attached")
+		time.Sleep(bpfSettleInterval)
+
+		By("Capturing pre-upgrade BPF state")
+		preUpgradeState = captureBPFState(nodeName)
+		Expect(preUpgradeState.progIDs).ToNot(BeEmpty(), "should have BPF programs before upgrade")
+		Expect(preUpgradeState.globalMaps).ToNot(BeEmpty(), "should have global maps before upgrade")
+		GinkgoWriter.Printf("Pre-upgrade: progs=%v perPodMaps=%v globalMaps=%v\n",
+			preUpgradeState.progIDs, preUpgradeState.mapIDs, preUpgradeState.globalMaps)
+
+		By("Upgrading agent to: " + toTag)
+		setAgentImage(baseImage + ":" + toTag)
+		waitForDaemonSetRollout()
+		time.Sleep(bpfSettleInterval)
+
+		By("Capturing post-upgrade BPF state")
+		postUpgradeState = captureBPFState(nodeName)
+		Expect(postUpgradeState.progIDs).ToNot(BeEmpty(), "should have BPF programs after upgrade")
+		GinkgoWriter.Printf("Post-upgrade: progs=%v perPodMaps=%v globalMaps=%v\n",
+			postUpgradeState.progIDs, postUpgradeState.mapIDs, postUpgradeState.globalMaps)
+
+		By("Validating: all IDs preserved (binary unchanged)")
+		validateBPFState(preUpgradeState, postUpgradeState, false, "upgrade")
+	})
+
+	It("should preserve all BPF state across rollback", func() {
+		By("Capturing pre-rollback BPF state (agent on " + toTag + ")")
+		preRollbackState = captureBPFState(nodeName)
+		Expect(preRollbackState.progIDs).ToNot(BeEmpty())
+		GinkgoWriter.Printf("Pre-rollback: progs=%v perPodMaps=%v globalMaps=%v\n",
+			preRollbackState.progIDs, preRollbackState.mapIDs, preRollbackState.globalMaps)
+
+		By("Rolling back agent to: " + fromTag)
+		setAgentImage(baseImage + ":" + fromTag)
+		waitForDaemonSetRollout()
+		time.Sleep(bpfSettleInterval)
+
+		By("Capturing post-rollback BPF state")
+		postRollbackState = captureBPFState(nodeName)
+		Expect(postRollbackState.progIDs).ToNot(BeEmpty())
+		GinkgoWriter.Printf("Post-rollback: progs=%v perPodMaps=%v globalMaps=%v\n",
+			postRollbackState.progIDs, postRollbackState.mapIDs, postRollbackState.globalMaps)
+
+		By("Validating: all IDs preserved (binary unchanged)")
+		validateBPFState(preRollbackState, postRollbackState, false, "rollback")
+	})
+
+	AfterAll(func() {
+		if networkPolicy != nil {
+			fw.NetworkPolicyManager.DeleteNetworkPolicy(ctx, networkPolicy)
+		}
+		if workloadPod != nil {
+			fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, workloadPod)
+		}
+	})
+})
+
+// Scenario 2: Binary changed (v1.2.7 -> v1.3.4)
+var _ = Describe("Agent Upgrade/Rollback - Binary Changed", Ordered, func() {
+	const (
+		fromTag = "v1.2.7"
+		toTag   = "v1.3.4"
+	)
+
+	var (
+		networkPolicy     *network.NetworkPolicy
+		workloadPod       *v1.Pod
+		nodeName          string
+		preUpgradeState   bpfState
+		postUpgradeState  bpfState
+		preRollbackState  bpfState
+		postRollbackState bpfState
+	)
+
+	It("should reload all BPF state across upgrade", func() {
+		By("Setting agent image to old version: " + fromTag)
+		setAgentImage(baseImage + ":" + fromTag)
+		waitForDaemonSetRollout()
+
+		By("Deploying workload pod with network policy")
+		workloadPod = buildWorkloadPod("binary-changed")
+		var err error
+		workloadPod, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, workloadPod, podReadyTimeout)
+		Expect(err).ToNot(HaveOccurred())
+		nodeName = workloadPod.Spec.NodeName
+
+		networkPolicy = buildTestNetworkPolicy("binary-changed")
+		err = fw.NetworkPolicyManager.CreateNetworkPolicy(ctx, networkPolicy)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for BPF probes to be attached")
+		time.Sleep(bpfSettleInterval)
+
+		By("Capturing pre-upgrade BPF state")
+		preUpgradeState = captureBPFState(nodeName)
+		Expect(preUpgradeState.progIDs).ToNot(BeEmpty(), "should have BPF programs before upgrade")
+		Expect(preUpgradeState.globalMaps).ToNot(BeEmpty(), "should have global maps before upgrade")
+		GinkgoWriter.Printf("Pre-upgrade: progs=%v perPodMaps=%v globalMaps=%v\n",
+			preUpgradeState.progIDs, preUpgradeState.mapIDs, preUpgradeState.globalMaps)
+
+		By("Upgrading agent to: " + toTag)
+		setAgentImage(baseImage + ":" + toTag)
+		waitForDaemonSetRollout()
+		time.Sleep(bpfSettleInterval)
+
+		By("Capturing post-upgrade BPF state")
+		postUpgradeState = captureBPFState(nodeName)
+		Expect(postUpgradeState.progIDs).ToNot(BeEmpty(), "should have BPF programs after upgrade")
+		Expect(postUpgradeState.globalMaps).ToNot(BeEmpty(), "should have global maps after upgrade")
+		GinkgoWriter.Printf("Post-upgrade: progs=%v perPodMaps=%v globalMaps=%v\n",
+			postUpgradeState.progIDs, postUpgradeState.mapIDs, postUpgradeState.globalMaps)
+
+		By("Validating: all BPF state reloaded (binary changed)")
+		validateBPFState(preUpgradeState, postUpgradeState, true, "upgrade")
+	})
+
+	It("should reload all BPF state across rollback", func() {
+		By("Capturing pre-rollback BPF state (agent on " + toTag + ")")
+		preRollbackState = captureBPFState(nodeName)
+		Expect(preRollbackState.progIDs).ToNot(BeEmpty())
+		GinkgoWriter.Printf("Pre-rollback: progs=%v perPodMaps=%v globalMaps=%v\n",
+			preRollbackState.progIDs, preRollbackState.mapIDs, preRollbackState.globalMaps)
+
+		By("Rolling back agent to: " + fromTag)
+		setAgentImage(baseImage + ":" + fromTag)
+		waitForDaemonSetRollout()
+		time.Sleep(bpfSettleInterval)
+
+		By("Capturing post-rollback BPF state")
+		postRollbackState = captureBPFState(nodeName)
+		Expect(postRollbackState.progIDs).ToNot(BeEmpty())
+		Expect(postRollbackState.globalMaps).ToNot(BeEmpty())
+		GinkgoWriter.Printf("Post-rollback: progs=%v perPodMaps=%v globalMaps=%v\n",
+			postRollbackState.progIDs, postRollbackState.mapIDs, postRollbackState.globalMaps)
+
+		By("Validating: all BPF state reloaded (binary changed)")
+		validateBPFState(preRollbackState, postRollbackState, true, "rollback")
+	})
+
+	AfterAll(func() {
+		if networkPolicy != nil {
+			fw.NetworkPolicyManager.DeleteNetworkPolicy(ctx, networkPolicy)
+		}
+		if workloadPod != nil {
+			fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, workloadPod)
+		}
+	})
+})
+
+func validateBPFState(before, after bpfState, binaryChanged bool, operation string) {
+	if binaryChanged {
+		By("Binary changed: expecting all new IDs (programs, per-pod maps, global maps)")
+		for name, oldID := range before.progIDs {
+			newID, exists := after.progIDs[name]
+			Expect(exists).To(BeTrue(), "program %s should still exist after %s", name, operation)
+			Expect(newID).ToNot(Equal(oldID),
+				fmt.Sprintf("program %s should have new ID after binary change (old=%d new=%d)", name, oldID, newID))
+		}
+		for name, oldID := range before.globalMaps {
+			newID, exists := after.globalMaps[name]
+			Expect(exists).To(BeTrue(), "global map %s should still exist after %s", name, operation)
+			Expect(newID).ToNot(Equal(oldID),
+				fmt.Sprintf("global map %s should have new ID after binary change (old=%d new=%d)", name, oldID, newID))
+		}
+	} else {
+		By("Binary unchanged: expecting same program and map IDs")
+		for name, oldID := range before.progIDs {
+			newID, exists := after.progIDs[name]
+			Expect(exists).To(BeTrue(), "program %s should still exist after %s", name, operation)
+			Expect(newID).To(Equal(oldID),
+				fmt.Sprintf("program %s should keep same ID when binary unchanged (old=%d new=%d)", name, oldID, newID))
+		}
+		for key, oldID := range before.mapIDs {
+			newID, exists := after.mapIDs[key]
+			Expect(exists).To(BeTrue(), "per-pod map %s should still exist after %s", key, operation)
+			Expect(newID).To(Equal(oldID),
+				fmt.Sprintf("per-pod map %s should keep same ID when binary unchanged (old=%d new=%d)", key, oldID, newID))
+		}
+		for name, oldID := range before.globalMaps {
+			newID, exists := after.globalMaps[name]
+			Expect(exists).To(BeTrue(), "global map %s should still exist after %s", name, operation)
+			Expect(newID).To(Equal(oldID),
+				fmt.Sprintf("global map %s should keep same ID when binary unchanged (old=%d new=%d)", name, oldID, newID))
+		}
+	}
+}
+
+func setAgentImage(image string) {
+	ds := &appsv1.DaemonSet{}
+	err := fw.K8sClient.Get(ctx, client.ObjectKey{
+		Name:      agentDaemonSet,
+		Namespace: agentNamespace,
+	}, ds)
+	Expect(err).ToNot(HaveOccurred())
+
+	for i, c := range ds.Spec.Template.Spec.Containers {
+		if c.Name == agentContainer {
+			ds.Spec.Template.Spec.Containers[i].Image = image
+			break
+		}
+	}
+
+	err = fw.K8sClient.Update(ctx, ds)
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func waitForDaemonSetRollout() {
+	Eventually(func() bool {
+		ds := &appsv1.DaemonSet{}
+		err := fw.K8sClient.Get(ctx, client.ObjectKey{
+			Name:      agentDaemonSet,
+			Namespace: agentNamespace,
+		}, ds)
+		if err != nil {
+			return false
+		}
+		return ds.Status.UpdatedNumberScheduled == ds.Status.DesiredNumberScheduled &&
+			ds.Status.NumberReady == ds.Status.DesiredNumberScheduled &&
+			ds.Status.ObservedGeneration >= ds.Generation
+	}, rolloutTimeout, 5*time.Second).Should(BeTrue(), "DaemonSet rollout should complete")
+}
+
+func buildWorkloadPod(suffix string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "upgrade-test-pod-" + suffix,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": "upgrade-test-" + suffix},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:    "nginx",
+					Image:   "public.ecr.aws/nginx/nginx:latest",
+					Command: []string{"sleep", "3600"},
+				},
+			},
+		},
+	}
+}
+
+func buildTestNetworkPolicy(suffix string) *network.NetworkPolicy {
+	return manifest.NewNetworkPolicyBuilder().
+		Namespace(namespace).
+		Name("upgrade-test-policy-"+suffix).
+		PodSelector("app", "upgrade-test-"+suffix).
+		SetPolicyType(true, true).
+		Build()
+}
+
+func captureBPFState(nodeName string) bpfState {
+	checkPod := buildBPFCheckPod(nodeName)
+	var err error
+	checkPod, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, checkPod, podReadyTimeout)
+	Expect(err).ToNot(HaveOccurred())
+	defer fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, checkPod)
+
+	output, err := fw.PodManager.ExecInPod(namespace, checkPod.Name,
+		[]string{"chroot", "/host", "/opt/cni/bin/aws-eks-na-cli", "ebpf", "loaded-ebpfdata"})
+	Expect(err).ToNot(HaveOccurred())
+	GinkgoWriter.Printf("loaded-ebpfdata output:\n%s\n", output)
+
+	return parseLoadedEBPFData(output)
+}
+
+func buildBPFCheckPod(nodeName string) *v1.Pod {
+	privileged := true
+	hostPathDir := v1.HostPathDirectory
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("bpf-check-%d", time.Now().UnixNano()),
+			Namespace: namespace,
+		},
+		Spec: v1.PodSpec{
+			NodeName:      nodeName,
+			HostPID:       true,
+			HostNetwork:   true,
+			RestartPolicy: v1.RestartPolicyNever,
+			Containers: []v1.Container{
+				{
+					Name:    "check",
+					Image:   "public.ecr.aws/amazonlinux/amazonlinux:2023-minimal",
+					Command: []string{"sleep", "300"},
+					SecurityContext: &v1.SecurityContext{
+						Privileged: &privileged,
+					},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "host-root",
+							MountPath: "/host",
+						},
+					},
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "host-root",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Path: "/",
+							Type: &hostPathDir,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// parseLoadedEBPFData parses the output of `aws-eks-na-cli ebpf loaded-ebpfdata`.
+// Format:
+//
+//	PinPath:  /sys/fs/bpf/globals/aws/programs/podid_handle_ingress
+//	Pod Identifier : podid  Direction : ingress
+//	Prog ID:  1446
+//	Associated Maps ->
+//	Map Name:  ingress_map
+//	Map ID:  517
+//	Map Name:  aws_conntrack_map
+//	Map ID:  514
+//	===...===
+func parseLoadedEBPFData(output string) bpfState {
+	state := bpfState{
+		progIDs:    make(map[string]int),
+		mapIDs:     make(map[string]int),
+		globalMaps: make(map[string]int),
+	}
+
+	var currentPinName string
+	var currentPodID string
+	lines := strings.Split(output, "\n")
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+
+		if strings.HasPrefix(line, "PinPath:") {
+			pinPath := strings.TrimSpace(strings.TrimPrefix(line, "PinPath:"))
+			segments := strings.Split(pinPath, "/")
+			currentPinName = segments[len(segments)-1]
+		}
+
+		if strings.HasPrefix(line, "Pod Identifier :") {
+			parts := strings.Split(line, "Direction")
+			if len(parts) > 0 {
+				currentPodID = strings.TrimSpace(strings.TrimPrefix(parts[0], "Pod Identifier :"))
+			}
+		}
+
+		if strings.HasPrefix(line, "Prog ID:") {
+			idStr := strings.TrimSpace(strings.TrimPrefix(line, "Prog ID:"))
+			if id, err := strconv.Atoi(idStr); err == nil && currentPinName != "" {
+				state.progIDs[currentPinName] = id
+			}
+		}
+
+		if strings.HasPrefix(line, "Map Name:") {
+			mapName := strings.TrimSpace(strings.TrimPrefix(line, "Map Name:"))
+			if i+1 < len(lines) {
+				nextLine := strings.TrimSpace(lines[i+1])
+				if strings.HasPrefix(nextLine, "Map ID:") {
+					idStr := strings.TrimSpace(strings.TrimPrefix(nextLine, "Map ID:"))
+					if id, err := strconv.Atoi(idStr); err == nil {
+						if isGlobalMap(mapName) {
+							state.globalMaps[mapName] = id
+						} else if currentPodID != "" {
+							state.mapIDs[currentPodID+"/"+mapName] = id
+						}
+					}
+					i++
+				}
+			}
+		}
+	}
+	return state
+}
+
+func isGlobalMap(name string) bool {
+	return name == "aws_conntrack_map" || name == "policy_events"
+}


### PR DESCRIPTION
*Issue #, if available:*

Partially addresses https://github.com/aws/aws-network-policy-agent/issues/424

For now, hardcoded NPA versions, so dev can swap out versions with their test version and run this test to validate. For automated pipeline test, we can inject the new-dev version as env var and use that in test.

*Description of changes:*
IT for Agent upgrade and rollback

```
go test ./test/integration/upgrade/... -v --ginkgo.v -cluster-kubeconfig=/home/viveksbh/.kube/config -cluster-name=np-test -aws-region=us-west-2 -timeout 15m
=== RUN   TestAgentUpgrade
Running Suite: Agent Upgrade Test Suite - /home/viveksbh/OSS/temp-debug/aws-network-policy-agent/test/integration/upgrade
=========================================================================================================================
Random Seed: 1778006526

Will run 4 of 4 specs
------------------------------
[BeforeSuite]
/home/viveksbh/OSS/temp-debug/aws-network-policy-agent/test/integration/upgrade/upgrade_suite_test.go:23
[BeforeSuite] PASSED [0.064 seconds]
------------------------------
Agent Upgrade/Rollback - Binary Unchanged should preserve all BPF state across upgrade
/home/viveksbh/OSS/temp-debug/aws-network-policy-agent/test/integration/upgrade/upgrade_test.go:61
  STEP: Setting agent image to old version: v1.3.2 @ 05/05/26 18:42:06.704
  STEP: Deploying workload pod with network policy @ 05/05/26 18:42:16.748
  STEP: Waiting for BPF probes to be attached @ 05/05/26 18:42:20.79
  STEP: Capturing pre-upgrade BPF state @ 05/05/26 18:42:30.793
  loaded-ebpfdata output:
  PinPath:  /sys/fs/bpf/globals/aws/programs/upgrade-test-pod-binary-upgrade-test_handle_egress
  Pod Identifier : upgrade-test-pod-binary-upgrade-test  Direction : egress
  Prog ID:  2858
  Associated Maps ->
  Map Name:  aws_conntrack_map
  Map ID:  968
  Map Name:  cp_egress_map
  Map ID:  973
  Map Name:  egress_map
  Map ID:  974
  Map Name:  egress_pod_state_map
  Map ID:  975
  Map Name:  policy_events
  Map ID:  969
  ========================================================================================
  PinPath:  /sys/fs/bpf/globals/aws/programs/upgrade-test-pod-binary-upgrade-test_handle_ingress
  Pod Identifier : upgrade-test-pod-binary-upgrade-test  Direction : ingress
  Prog ID:  2857
  Associated Maps ->
  Map Name:  ingress_pod_state_map
  Map ID:  972
  Map Name:  policy_events
  Map ID:  969
  Map Name:  aws_conntrack_map
  Map ID:  968
  Map Name:  cp_ingress_map
  Map ID:  970
  Map Name:  ingress_map
  Map ID:  971
  ========================================================================================
  Pre-upgrade: progs=map[upgrade-test-pod-binary-upgrade-test_handle_egress:2858 upgrade-test-pod-binary-upgrade-test_handle_ingress:2857] perPodMaps=map[upgrade-test-pod-binary-upgrade-test/cp_egress_map:973 upgrade-test-pod-binary-upgrade-test/cp_ingress_map:970 upgrade-test-pod-binary-upgrade-test/egress_map:974 upgrade-test-pod-binary-upgrade-test/egress_pod_state_map:975 upgrade-test-pod-binary-upgrade-test/ingress_map:971 upgrade-test-pod-binary-upgrade-test/ingress_pod_state_map:972] globalMaps=map[aws_conntrack_map:968 policy_events:969]
  STEP: Upgrading agent to: v1.3.4 @ 05/05/26 18:42:34.925
  STEP: Capturing post-upgrade BPF state @ 05/05/26 18:42:54.978
  loaded-ebpfdata output:
  PinPath:  /sys/fs/bpf/globals/aws/programs/upgrade-test-pod-binary-upgrade-test_handle_ingress
  Pod Identifier : upgrade-test-pod-binary-upgrade-test  Direction : ingress
  Prog ID:  2857
  Associated Maps ->                                                                                                                               Map Name:  policy_events                                                                                                                         Map ID:  969                                                                                                                                     Map Name:  aws_conntrack_map
  Map ID:  968
  Map Name:  cp_ingress_map
  Map ID:  970
  Map Name:  ingress_map
  Map ID:  971
  Map Name:  ingress_pod_state_map
  Map ID:  972
  ========================================================================================
  PinPath:  /sys/fs/bpf/globals/aws/programs/upgrade-test-pod-binary-upgrade-test_handle_egress
  Pod Identifier : upgrade-test-pod-binary-upgrade-test  Direction : egress
  Prog ID:  2858
  Associated Maps ->
  Map Name:  egress_pod_state_map
  Map ID:  975
  Map Name:  policy_events
  Map ID:  969
  Map Name:  aws_conntrack_map
  Map ID:  968
  Map Name:  cp_egress_map
  Map ID:  973
  Map Name:  egress_map
  Map ID:  974
  ========================================================================================
  Post-upgrade: progs=map[upgrade-test-pod-binary-upgrade-test_handle_egress:2858 upgrade-test-pod-binary-upgrade-test_handle_ingress:2857] perPodMaps=map[upgrade-test-pod-binary-upgrade-test/cp_egress_map:973 upgrade-test-pod-binary-upgrade-test/cp_ingress_map:970 upgrade-test-pod-binary-upgrade-test/egress_map:974 upgrade-test-pod-binary-upgrade-test/egress_pod_state_map:975 upgrade-test-pod-binary-upgrade-test/ingress_map:971 upgrade-test-pod-binary-upgrade-test/ingress_pod_state_map:972] globalMaps=map[aws_conntrack_map:968 policy_events:969]
  STEP: Validating: all IDs preserved (binary unchanged) @ 05/05/26 18:42:59.124
  STEP: Binary unchanged: expecting same program and map IDs @ 05/05/26 18:42:59.124
• [52.420 seconds]
------------------------------
Agent Upgrade/Rollback - Binary Unchanged should preserve all BPF state across rollback
/home/viveksbh/OSS/temp-debug/aws-network-policy-agent/test/integration/upgrade/upgrade_test.go:102
  STEP: Capturing pre-rollback BPF state (agent on v1.3.4) @ 05/05/26 18:42:59.124                                                                 loaded-ebpfdata output:                                                                                                                          PinPath:  /sys/fs/bpf/globals/aws/programs/upgrade-test-pod-binary-upgrade-test_handle_ingress                                                   Pod Identifier : upgrade-test-pod-binary-upgrade-test  Direction : ingress
  Prog ID:  2857
  Associated Maps ->
  Map Name:  ingress_pod_state_map
  Map ID:  972
  Map Name:  policy_events
  Map ID:  969
  Map Name:  aws_conntrack_map
  Map ID:  968
  Map Name:  cp_ingress_map
  Map ID:  970
  Map Name:  ingress_map
  Map ID:  971
  ========================================================================================
  PinPath:  /sys/fs/bpf/globals/aws/programs/upgrade-test-pod-binary-upgrade-test_handle_egress
  Pod Identifier : upgrade-test-pod-binary-upgrade-test  Direction : egress
  Prog ID:  2858
  Associated Maps ->
  Map Name:  egress_pod_state_map
  Map ID:  975
  Map Name:  policy_events
  Map ID:  969
  Map Name:  aws_conntrack_map
  Map ID:  968
  Map Name:  cp_egress_map
  Map ID:  973
  Map Name:  egress_map
  Map ID:  974
  ========================================================================================
  Pre-rollback: progs=map[upgrade-test-pod-binary-upgrade-test_handle_egress:2858 upgrade-test-pod-binary-upgrade-test_handle_ingress:2857] perPodMaps=map[upgrade-test-pod-binary-upgrade-test/cp_egress_map:973 upgrade-test-pod-binary-upgrade-test/cp_ingress_map:970 upgrade-test-pod-binary-upgrade-test/egress_map:974 upgrade-test-pod-binary-upgrade-test/egress_pod_state_map:975 upgrade-test-pod-binary-upgrade-test/ingress_map:971 upgrade-test-pod-binary-upgrade-test/ingress_pod_state_map:972] globalMaps=map[aws_conntrack_map:968 policy_events:969]
  STEP: Rolling back agent to: v1.3.2 @ 05/05/26 18:43:03.297
  STEP: Capturing post-rollback BPF state @ 05/05/26 18:43:23.343
  loaded-ebpfdata output:
  PinPath:  /sys/fs/bpf/globals/aws/programs/upgrade-test-pod-binary-upgrade-test_handle_egress
  Pod Identifier : upgrade-test-pod-binary-upgrade-test  Direction : egress
  Prog ID:  2858                                                                                                                                   Associated Maps ->                                                                                                                               Map Name:  cp_egress_map                                                                                                                         Map ID:  973
  Map Name:  egress_map
  Map ID:  974
  Map Name:  egress_pod_state_map
  Map ID:  975
  Map Name:  policy_events
  Map ID:  969
  Map Name:  aws_conntrack_map
  Map ID:  968
  ========================================================================================
  PinPath:  /sys/fs/bpf/globals/aws/programs/upgrade-test-pod-binary-upgrade-test_handle_ingress
  Pod Identifier : upgrade-test-pod-binary-upgrade-test  Direction : ingress
  Prog ID:  2857
  Associated Maps ->
  Map Name:  aws_conntrack_map
  Map ID:  968
  Map Name:  cp_ingress_map
  Map ID:  970
  Map Name:  ingress_map
  Map ID:  971
  Map Name:  ingress_pod_state_map
  Map ID:  972
  Map Name:  policy_events
  Map ID:  969
  ========================================================================================
  Post-rollback: progs=map[upgrade-test-pod-binary-upgrade-test_handle_egress:2858 upgrade-test-pod-binary-upgrade-test_handle_ingress:2857] perPodMaps=map[upgrade-test-pod-binary-upgrade-test/cp_egress_map:973 upgrade-test-pod-binary-upgrade-test/cp_ingress_map:970 upgrade-test-pod-binary-upgrade-test/egress_map:974 upgrade-test-pod-binary-upgrade-test/egress_pod_state_map:975 upgrade-test-pod-binary-upgrade-test/ingress_map:971 upgrade-test-pod-binary-upgrade-test/ingress_pod_state_map:972] globalMaps=map[aws_conntrack_map:968 policy_events:969]
  STEP: Validating: all IDs preserved (binary unchanged) @ 05/05/26 18:43:27.488
  STEP: Binary unchanged: expecting same program and map IDs @ 05/05/26 18:43:27.488
• [62.394 seconds]
------------------------------
Agent Upgrade/Rollback - Binary Changed should reload all BPF state across upgrade
/home/viveksbh/OSS/temp-debug/aws-network-policy-agent/test/integration/upgrade/upgrade_test.go:151                                                STEP: Setting agent image to old version: v1.2.7 @ 05/05/26 18:44:01.519                                                                         STEP: Deploying workload pod with network policy @ 05/05/26 18:44:11.559                                                                         STEP: Waiting for BPF probes to be attached @ 05/05/26 18:44:13.586
  STEP: Capturing pre-upgrade BPF state @ 05/05/26 18:44:23.595
  loaded-ebpfdata output:
  PinPath:  /sys/fs/bpf/globals/aws/programs/upgrade-test-pod-binary-upgrade-test_handle_egress
  Pod Identifier : upgrade-test-pod-binary-upgrade-test  Direction : egress
  Prog ID:  2968
  Associated Maps ->
  Map Name:  egress_pod_state_map
  Map ID:  1003
  Map Name:  policy_events
  Map ID:  999
  Map Name:  aws_conntrack_map
  Map ID:  998
  Map Name:  egress_map
  Map ID:  1002
  ========================================================================================
  PinPath:  /sys/fs/bpf/globals/aws/programs/upgrade-test-pod-binary-upgrade-test_handle_ingress
  Pod Identifier : upgrade-test-pod-binary-upgrade-test  Direction : ingress
  Prog ID:  2967
  Associated Maps ->
  Map Name:  ingress_pod_state_map
  Map ID:  1001
  Map Name:  policy_events
  Map ID:  999
  Map Name:  aws_conntrack_map
  Map ID:  998
  Map Name:  ingress_map
  Map ID:  1000
  ========================================================================================
  Pre-upgrade: progs=map[upgrade-test-pod-binary-upgrade-test_handle_egress:2968 upgrade-test-pod-binary-upgrade-test_handle_ingress:2967] perPodMaps=map[upgrade-test-pod-binary-upgrade-test/egress_map:1002 upgrade-test-pod-binary-upgrade-test/egress_pod_state_map:1003 upgrade-test-pod-binary-upgrade-test/ingress_map:1000 upgrade-test-pod-binary-upgrade-test/ingress_pod_state_map:1001] globalMaps=map[aws_conntrack_map:998 policy_events:999]
  STEP: Upgrading agent to: v1.3.4 @ 05/05/26 18:44:27.743
  STEP: Capturing post-upgrade BPF state @ 05/05/26 18:44:47.788
  loaded-ebpfdata output:
  PinPath:  /sys/fs/bpf/globals/aws/programs/upgrade-test-pod-binary-upgrade-test_handle_egress
  Pod Identifier : upgrade-test-pod-binary-upgrade-test  Direction : egress
  Prog ID:  3004
  Associated Maps ->
  Map Name:  egress_pod_state_map
  Map ID:  1019                                                                                                                                    Map Name:  policy_events                                                                                                                         Map ID:  1013                                                                                                                                    Map Name:  aws_conntrack_map
  Map ID:  1012
  Map Name:  cp_egress_map
  Map ID:  1017
  Map Name:  egress_map
  Map ID:  1018
  ========================================================================================
  PinPath:  /sys/fs/bpf/globals/aws/programs/upgrade-test-pod-binary-upgrade-test_handle_ingress
  Pod Identifier : upgrade-test-pod-binary-upgrade-test  Direction : ingress
  Prog ID:  3003
  Associated Maps ->
  Map Name:  ingress_pod_state_map
  Map ID:  1016
  Map Name:  policy_events
  Map ID:  1013
  Map Name:  aws_conntrack_map
  Map ID:  1012
  Map Name:  cp_ingress_map
  Map ID:  1014
  Map Name:  ingress_map
  Map ID:  1015
  ========================================================================================
  Post-upgrade: progs=map[upgrade-test-pod-binary-upgrade-test_handle_egress:3004 upgrade-test-pod-binary-upgrade-test_handle_ingress:3003] perPodMaps=map[upgrade-test-pod-binary-upgrade-test/cp_egress_map:1017 upgrade-test-pod-binary-upgrade-test/cp_ingress_map:1014 upgrade-test-pod-binary-upgrade-test/egress_map:1018 upgrade-test-pod-binary-upgrade-test/egress_pod_state_map:1019 upgrade-test-pod-binary-upgrade-test/ingress_map:1015 upgrade-test-pod-binary-upgrade-test/ingress_pod_state_map:1016] globalMaps=map[aws_conntrack_map:1012 policy_events:1013]
  STEP: Validating: all BPF state reloaded (binary changed) @ 05/05/26 18:44:51.945
  STEP: Binary changed: expecting all new IDs (programs, per-pod maps, global maps) @ 05/05/26 18:44:51.945
• [50.427 seconds]
------------------------------
Agent Upgrade/Rollback - Binary Changed should reload all BPF state across rollback
/home/viveksbh/OSS/temp-debug/aws-network-policy-agent/test/integration/upgrade/upgrade_test.go:193
  STEP: Capturing pre-rollback BPF state (agent on v1.3.4) @ 05/05/26 18:44:51.945
  loaded-ebpfdata output:
  PinPath:  /sys/fs/bpf/globals/aws/programs/upgrade-test-pod-binary-upgrade-test_handle_egress                                                    Pod Identifier : upgrade-test-pod-binary-upgrade-test  Direction : egress                                                                        Prog ID:  3004                                                                                                                                   Associated Maps ->
  Map Name:  egress_pod_state_map
  Map ID:  1019
  Map Name:  policy_events
  Map ID:  1013
  Map Name:  aws_conntrack_map
  Map ID:  1012
  Map Name:  cp_egress_map
  Map ID:  1017
  Map Name:  egress_map
  Map ID:  1018
  ========================================================================================
  PinPath:  /sys/fs/bpf/globals/aws/programs/upgrade-test-pod-binary-upgrade-test_handle_ingress
  Pod Identifier : upgrade-test-pod-binary-upgrade-test  Direction : ingress
  Prog ID:  3003
  Associated Maps ->
  Map Name:  cp_ingress_map
  Map ID:  1014
  Map Name:  ingress_map
  Map ID:  1015
  Map Name:  ingress_pod_state_map
  Map ID:  1016
  Map Name:  policy_events
  Map ID:  1013
  Map Name:  aws_conntrack_map
  Map ID:  1012
  ========================================================================================
  Pre-rollback: progs=map[upgrade-test-pod-binary-upgrade-test_handle_egress:3004 upgrade-test-pod-binary-upgrade-test_handle_ingress:3003] perPodMaps=map[upgrade-test-pod-binary-upgrade-test/cp_egress_map:1017 upgrade-test-pod-binary-upgrade-test/cp_ingress_map:1014 upgrade-test-pod-binary-upgrade-test/egress_map:1018 upgrade-test-pod-binary-upgrade-test/egress_pod_state_map:1019 upgrade-test-pod-binary-upgrade-test/ingress_map:1015 upgrade-test-pod-binary-upgrade-test/ingress_pod_state_map:1016] globalMaps=map[aws_conntrack_map:1012 policy_events:1013]
  STEP: Rolling back agent to: v1.2.7 @ 05/05/26 18:44:56.075
  STEP: Capturing post-rollback BPF state @ 05/05/26 18:45:16.123
  loaded-ebpfdata output:
  PinPath:  /sys/fs/bpf/globals/aws/programs/upgrade-test-pod-binary-upgrade-test_handle_egress
  Pod Identifier : upgrade-test-pod-binary-upgrade-test  Direction : egress
  Prog ID:  3038
  Associated Maps ->
  Map Name:  aws_conntrack_map
  Map ID:  1028
  Map Name:  egress_map
  Map ID:  1032
  Map Name:  egress_pod_state_map
  Map ID:  1033
  Map Name:  policy_events
  Map ID:  1029
  ========================================================================================
  PinPath:  /sys/fs/bpf/globals/aws/programs/upgrade-test-pod-binary-upgrade-test_handle_ingress
  Pod Identifier : upgrade-test-pod-binary-upgrade-test  Direction : ingress
  Prog ID:  3037
  Associated Maps ->
  Map Name:  ingress_pod_state_map
  Map ID:  1031
  Map Name:  policy_events
  Map ID:  1029
  Map Name:  aws_conntrack_map
  Map ID:  1028
  Map Name:  ingress_map
  Map ID:  1030
  ========================================================================================
  Post-rollback: progs=map[upgrade-test-pod-binary-upgrade-test_handle_egress:3038 upgrade-test-pod-binary-upgrade-test_handle_ingress:3037] perPodMaps=map[upgrade-test-pod-binary-upgrade-test/egress_map:1032 upgrade-test-pod-binary-upgrade-test/egress_pod_state_map:1033 upgrade-test-pod-binary-upgrade-test/ingress_map:1030 upgrade-test-pod-binary-upgrade-test/ingress_pod_state_map:1031] globalMaps=map[aws_conntrack_map:1028 policy_events:1029]
  STEP: Validating: all BPF state reloaded (binary changed) @ 05/05/26 18:45:22.308
  STEP: Binary changed: expecting all new IDs (programs, per-pod maps, global maps) @ 05/05/26 18:45:22.308
• [64.420 seconds]
------------------------------
[AfterSuite]
/home/viveksbh/OSS/temp-debug/aws-network-policy-agent/test/integration/upgrade/upgrade_suite_test.go:31
[AfterSuite] PASSED [6.014 seconds]
------------------------------

Ran 4 of 4 Specs in 235.740 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestAgentUpgrade (235.74s)
PASS
ok      github.com/aws/aws-network-policy-agent/test/integration/upgrade        235.756s
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
