### PR TITLE
fix(utils): retry GetHostVethName on transient LinkNotFoundError

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -15,9 +15,11 @@ import (
 	"github.com/aws/aws-network-policy-agent/api/v1alpha1"
 	"github.com/aws/aws-network-policy-agent/pkg/logger"
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/vishvananda/netlink"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 var (
@@ -230,14 +232,46 @@ func getHostLinkByName(name string) (netlink.Link, error) {
 // short bounded retry budget eliminates the transient failure without
 // extending the CNI ADD path materially for the happy case.
 //
-// Defaults: ~50 ms, 100 ms, 200 ms, 400 ms, 500 ms (capped), 500 ms, 500 ms, 500 ms
-// with +/-10% jitter -> ~2.65s worst case across 8 attempts.
+// Defaults: ~50 ms, 100 ms, 200 ms, 400 ms, 800 ms, 1 s (capped), 1 s, 1 s
+// with +/-10% jitter -> ~5 s worst case across 8 attempts. This is well under
+// kubelet's pod-sandbox retry interval (~10 s) and gives plenty of headroom
+// for the high-concurrency case (e.g. Karpenter scale-up bursts).
 var GetHostVethNameBackoff = wait.Backoff{
 	Duration: 50 * time.Millisecond,
 	Factor:   2.0,
 	Jitter:   0.1,
 	Steps:    8,
-	Cap:      500 * time.Millisecond,
+	Cap:      1 * time.Second,
+}
+
+var (
+	// vethLookupRetries counts terminal outcomes of GetHostVethName when the
+	// retry path was exercised (i.e. attempt > 1, or the call exhausted the
+	// retry budget). The single-attempt happy path is intentionally not
+	// counted; use vethLookupAttempts for the full distribution.
+	vethLookupRetries = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "awsnodeagent_veth_lookup_retries_total",
+			Help: "Terminal outcomes of host-veth lookups that exercised the retry path. " +
+				"result=success: link resolved on a retry; result=exhausted: retry budget exhausted with LinkNotFoundError.",
+		},
+		[]string{"result"},
+	)
+
+	// vethLookupAttempts is observed on every GetHostVethName call (success
+	// or failure) and records the number of probe attempts taken. Buckets
+	// align with the default Steps in GetHostVethNameBackoff.
+	vethLookupAttempts = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "awsnodeagent_veth_lookup_attempts",
+			Help:    "Number of probe attempts taken by GetHostVethName per call.",
+			Buckets: prometheus.LinearBuckets(1, 1, 8),
+		},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(vethLookupRetries, vethLookupAttempts)
 }
 
 // isLinkNotFoundError reports whether err (or anything wrapped by it) is a
@@ -268,7 +302,12 @@ var GetHostVethName = func(podName, podNamespace string, interfaceIndex int, int
 		interfaceName string
 		lastErr       error
 		attempt       int
+		exhausted     bool
 	)
+
+	defer func() {
+		vethLookupAttempts.Observe(float64(attempt))
+	}()
 
 	backoff := GetHostVethNameBackoff
 	// wait.ExponentialBackoff treats Steps as the total number of attempts
@@ -301,13 +340,20 @@ var GetHostVethName = func(podName, podNamespace string, interfaceIndex int, int
 		if !allNotFound {
 			return false, attemptErr
 		}
+		exhausted = true
 		log().Debugf("Host veth not yet visible for pod %s/%s (hash %s), attempt %d/%d",
 			podNamespace, podName, hashSuffix, attempt, backoff.Steps)
 		return false, nil
 	})
 
 	if err == nil {
+		if attempt > 1 {
+			vethLookupRetries.WithLabelValues("success").Inc()
+		}
 		return interfaceName, nil
+	}
+	if exhausted {
+		vethLookupRetries.WithLabelValues("exhausted").Inc()
 	}
 	// err is either wait.ErrWaitTimeout (retry budget exhausted) or the
 	// non-retryable error we returned from the condition. In both cases we

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,10 +4,12 @@ import (
 	"crypto/sha1"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
 	"strings"
+	"time"
 	"unsafe"
 
 	"github.com/aws/aws-network-policy-agent/api/v1alpha1"
@@ -15,6 +17,7 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/vishvananda/netlink"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 var (
@@ -219,28 +222,102 @@ func getHostLinkByName(name string) (netlink.Link, error) {
 	return getLinkByNameFunc(name)
 }
 
-var GetHostVethName = func(podName, podNamespace string, interfaceIndex int, interfacePrefixes []string) (string, error) {
-	var interfaceName string
-	var errors error
+// GetHostVethNameBackoff controls the retry schedule used by GetHostVethName.
+// During CNI ADD there is a small race window in which the VPC CNI plugin has
+// requested NPA to enforce policy on a newly created pod but the host-side
+// veth (eni<hash> or vlan<hash>) is not yet visible to netlink on this thread.
+// The interface is consistently present within tens of milliseconds, so a
+// short bounded retry budget eliminates the transient failure without
+// extending the CNI ADD path materially for the happy case.
+//
+// Defaults: ~50 ms, 100 ms, 200 ms, 400 ms, 500 ms (capped), 500 ms, 500 ms, 500 ms
+// with +/-10% jitter -> ~2.65s worst case across 8 attempts.
+var GetHostVethNameBackoff = wait.Backoff{
+	Duration: 50 * time.Millisecond,
+	Factor:   2.0,
+	Jitter:   0.1,
+	Steps:    8,
+	Cap:      500 * time.Millisecond,
+}
 
+// isLinkNotFoundError reports whether err (or anything wrapped by it) is a
+// netlink.LinkNotFoundError. Only this specific error indicates the transient
+// "veth not yet visible" condition that is safe to retry.
+//
+// Exposed as a var so tests can substitute a matcher (the embedded error in
+// netlink.LinkNotFoundError is unexported, which makes it hard to construct
+// the concrete type from another package for table-driven tests).
+var isLinkNotFoundError = func(err error) bool {
+	if err == nil {
+		return false
+	}
+	var lnf netlink.LinkNotFoundError
+	return errors.As(err, &lnf)
+}
+
+var GetHostVethName = func(podName, podNamespace string, interfaceIndex int, interfacePrefixes []string) (string, error) {
 	if interfaceIndex > 0 {
 		podName = fmt.Sprintf("%s.%s", podName, strconv.Itoa(interfaceIndex))
 	}
 
 	h := sha1.New()
 	h.Write([]byte(fmt.Sprintf("%s.%s", podNamespace, podName)))
+	hashSuffix := hex.EncodeToString(h.Sum(nil))[:11]
 
-	for _, prefix := range interfacePrefixes {
-		interfaceName = fmt.Sprintf("%s%s", prefix, hex.EncodeToString(h.Sum(nil))[:11])
-		if _, err := getHostLinkByName(interfaceName); err == nil {
-			return interfaceName, nil
-		} else {
-			errors = multierror.Append(errors, fmt.Errorf("failed to find link %s: %w", interfaceName, err))
+	var (
+		interfaceName string
+		lastErr       error
+		attempt       int
+	)
+
+	backoff := GetHostVethNameBackoff
+	// wait.ExponentialBackoff treats Steps as the total number of attempts
+	// (each iteration consumes one step). It returns ErrWaitTimeout when the
+	// budget is exhausted without the condition becoming true.
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		attempt++
+		var attemptErr error
+		allNotFound := true
+		for _, prefix := range interfacePrefixes {
+			name := fmt.Sprintf("%s%s", prefix, hashSuffix)
+			if _, lookupErr := getHostLinkByName(name); lookupErr == nil {
+				interfaceName = name
+				if attempt > 1 {
+					log().Infof("Resolved host veth %s for pod %s/%s on attempt %d",
+						name, podNamespace, podName, attempt)
+				}
+				return true, nil
+			} else {
+				attemptErr = multierror.Append(attemptErr, fmt.Errorf("failed to find link %s: %w", name, lookupErr))
+				if !isLinkNotFoundError(lookupErr) {
+					allNotFound = false
+				}
+			}
 		}
-	}
+		lastErr = attemptErr
+		// Only the transient "link not found" case is worth retrying; any
+		// other netlink error (e.g. permission, socket failure) won't be
+		// resolved by waiting.
+		if !allNotFound {
+			return false, attemptErr
+		}
+		log().Debugf("Host veth not yet visible for pod %s/%s (hash %s), attempt %d/%d",
+			podNamespace, podName, hashSuffix, attempt, backoff.Steps)
+		return false, nil
+	})
 
-	log().Errorf("Not found any interface starting with prefixes and the hash. Prefixes searched %v hash %v error %v", interfacePrefixes, hex.EncodeToString(h.Sum(nil))[:11], errors)
-	return "", errors
+	if err == nil {
+		return interfaceName, nil
+	}
+	// err is either wait.ErrWaitTimeout (retry budget exhausted) or the
+	// non-retryable error we returned from the condition. In both cases we
+	// already captured the underlying per-attempt details in lastErr.
+	if lastErr == nil {
+		lastErr = err
+	}
+	log().Errorf("Not found any interface starting with prefixes and the hash. Prefixes searched %v hash %v error %v",
+		interfacePrefixes, hashSuffix, lastErr)
+	return "", lastErr
 }
 
 func ComputeTrieKey(n net.IPNet, isIPv6Enabled bool) []byte {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -302,7 +302,6 @@ var GetHostVethName = func(podName, podNamespace string, interfaceIndex int, int
 		interfaceName string
 		lastErr       error
 		attempt       int
-		exhausted     bool
 	)
 
 	defer func() {
@@ -340,7 +339,6 @@ var GetHostVethName = func(podName, podNamespace string, interfaceIndex int, int
 		if !allNotFound {
 			return false, attemptErr
 		}
-		exhausted = true
 		log().Debugf("Host veth not yet visible for pod %s/%s (hash %s), attempt %d/%d",
 			podNamespace, podName, hashSuffix, attempt, backoff.Steps)
 		return false, nil
@@ -352,7 +350,12 @@ var GetHostVethName = func(podName, podNamespace string, interfaceIndex int, int
 		}
 		return interfaceName, nil
 	}
-	if exhausted {
+	// Only count "exhausted" when the retry budget actually ran out (i.e.
+	// wait.ExponentialBackoff returned because Steps was reached, not
+	// because the condition surfaced a non-retryable error). Otherwise we
+	// would conflate "budget consumed" with "permission denied" in the
+	// metric, which is the signal operators tune the backoff against.
+	if wait.Interrupted(err) {
 		vethLookupRetries.WithLabelValues("exhausted").Inc()
 	}
 	// err is either wait.ErrWaitTimeout (retry budget exhausted) or the

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -321,7 +321,13 @@ var GetHostVethName = func(podName, podNamespace string, interfaceIndex int, int
 			if _, lookupErr := getHostLinkByName(name); lookupErr == nil {
 				interfaceName = name
 				if attempt > 1 {
-					log().Infof("Resolved host veth %s for pod %s/%s on attempt %d",
+					// Debug-level: during scale-up bursts every recovered
+					// pod would emit one of these. Operators should rely
+					// on the awsnodeagent_veth_lookup_retries_total and
+					// awsnodeagent_veth_lookup_attempts metrics for the
+					// hot-path observability signal; this log line is for
+					// per-pod debugging when needed.
+					log().Debugf("Resolved host veth %s for pod %s/%s on attempt %d",
 						name, podNamespace, podName, attempt)
 				}
 				return true, nil

--- a/pkg/utils/utils_linux_test.go
+++ b/pkg/utils/utils_linux_test.go
@@ -4,6 +4,9 @@
 package utils
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
 	"sync/atomic"
 	"testing"
 
@@ -31,6 +34,26 @@ func TestGetHostVethName_RealNetlink_TriggersRetries(t *testing.T) {
 		}
 	}
 
+	const (
+		podName      = "no-such-pod"
+		podNamespace = "no-such-ns"
+	)
+	// Belt-and-suspenders: on a busy test host (e.g. a real EKS node) an
+	// interface named eni<hash> or vlan<hash> for our chosen pod/ns could
+	// in theory exist. Probability is astronomically low, but the test
+	// asserts an exact lookup count so any collision turns into a hard
+	// failure. Skip if either computed name resolves to a real link.
+	h := sha1.New()
+	h.Write([]byte(fmt.Sprintf("%s.%s", podNamespace, podName)))
+	hashSuffix := hex.EncodeToString(h.Sum(nil))[:11]
+	for _, prefix := range []string{"eni", "vlan"} {
+		name := prefix + hashSuffix
+		if _, err := netlink.LinkByName(name); err == nil {
+			t.Skipf("computed test interface %q already exists on this host; "+
+				"would collide with the retry-count assertion, skipping", name)
+		}
+	}
+
 	originalFunc := getLinkByNameFunc
 	originalBackoff := GetHostVethNameBackoff
 	t.Cleanup(func() {
@@ -48,10 +71,7 @@ func TestGetHostVethName_RealNetlink_TriggersRetries(t *testing.T) {
 		return netlink.LinkByName(name)
 	}
 
-	// "no-such-pod"/"no-such-ns" hashes to a deterministic 11-char suffix
-	// that is astronomically unlikely to collide with any real interface
-	// name on the test host.
-	got, err := GetHostVethName("no-such-pod", "no-such-ns", 0, []string{"eni", "vlan"})
+	got, err := GetHostVethName(podName, podNamespace, 0, []string{"eni", "vlan"})
 	assert.Empty(t, got)
 	assert.Error(t, err)
 	// 3 attempts x 2 prefixes = 6 lookups. If the production

--- a/pkg/utils/utils_linux_test.go
+++ b/pkg/utils/utils_linux_test.go
@@ -1,0 +1,63 @@
+//go:build linux
+// +build linux
+
+package utils
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
+)
+
+// TestGetHostVethName_RealNetlink_TriggersRetries is the strongest end-to-end
+// guard for the retry path: it exercises GetHostVethName against the actual
+// netlink.LinkByName syscall (not a sentinel, not a fake, not an override of
+// isLinkNotFoundError). If a future netlink version changes the concrete
+// type returned for a missing link, this test catches it; all
+// matcher-override-based tests would silently still pass.
+//
+// Linux-only because netlink.LinkByName is a no-op stub on other platforms.
+func TestGetHostVethName_RealNetlink_TriggersRetries(t *testing.T) {
+	// Probe netlink first; if the test environment cannot open an
+	// AF_NETLINK socket (rare, but possible in heavily sandboxed CI),
+	// skip rather than fail on infrastructure noise. We only want to fail
+	// when the retry/matcher contract itself regresses.
+	if _, err := netlink.LinkByName("definitely-not-a-real-link-aws-npa-test"); err != nil {
+		if _, ok := err.(netlink.LinkNotFoundError); !ok {
+			t.Skipf("netlink not usable in this environment, skipping: %v", err)
+		}
+	}
+
+	originalFunc := getLinkByNameFunc
+	originalBackoff := GetHostVethNameBackoff
+	t.Cleanup(func() {
+		getLinkByNameFunc = originalFunc
+		GetHostVethNameBackoff = originalBackoff
+	})
+
+	GetHostVethNameBackoff = fastBackoff(3)
+
+	exhaustedBefore := testutil.ToFloat64(vethLookupRetries.WithLabelValues("exhausted"))
+
+	var calls int32
+	getLinkByNameFunc = func(name string) (netlink.Link, error) {
+		atomic.AddInt32(&calls, 1)
+		return netlink.LinkByName(name)
+	}
+
+	// "no-such-pod"/"no-such-ns" hashes to a deterministic 11-char suffix
+	// that is astronomically unlikely to collide with any real interface
+	// name on the test host.
+	got, err := GetHostVethName("no-such-pod", "no-such-ns", 0, []string{"eni", "vlan"})
+	assert.Empty(t, got)
+	assert.Error(t, err)
+	// 3 attempts x 2 prefixes = 6 lookups. If the production
+	// isLinkNotFoundError matcher fails to recognize whatever concrete
+	// error type netlink actually returned, we would see exactly 2.
+	assert.Equal(t, int32(6), atomic.LoadInt32(&calls),
+		"production matcher must recognize the real netlink miss type and drive retries")
+	assert.Equal(t, exhaustedBefore+1, testutil.ToFloat64(vethLookupRetries.WithLabelValues("exhausted")))
+}

--- a/pkg/utils/utils_linux_test.go
+++ b/pkg/utils/utils_linux_test.go
@@ -6,6 +6,7 @@ package utils
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -27,9 +28,12 @@ func TestGetHostVethName_RealNetlink_TriggersRetries(t *testing.T) {
 	// Probe netlink first; if the test environment cannot open an
 	// AF_NETLINK socket (rare, but possible in heavily sandboxed CI),
 	// skip rather than fail on infrastructure noise. We only want to fail
-	// when the retry/matcher contract itself regresses.
+	// when the retry/matcher contract itself regresses. Use errors.As so
+	// a wrapped LinkNotFoundError is still recognized as a "netlink works"
+	// signal rather than incorrectly skipping.
 	if _, err := netlink.LinkByName("definitely-not-a-real-link-aws-npa-test"); err != nil {
-		if _, ok := err.(netlink.LinkNotFoundError); !ok {
+		var lnf netlink.LinkNotFoundError
+		if !errors.As(err, &lnf) {
 			t.Skipf("netlink not usable in this environment, skipping: %v", err)
 		}
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-network-policy-agent/api/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/vishvananda/netlink"
 	corev1 "k8s.io/api/core/v1"
@@ -794,6 +795,8 @@ func TestGetHostVethName_RetriesOnTransientLinkNotFound(t *testing.T) {
 		return errors.Is(err, sentinelLinkNotFound)
 	}
 
+	successBefore := testutil.ToFloat64(vethLookupRetries.WithLabelValues("success"))
+
 	var calls int32
 	// Return Link-not-found for the first 4 calls (covers both prefixes on
 	// attempts 1 and 2), then succeed for the "eni" prefix.
@@ -810,6 +813,8 @@ func TestGetHostVethName_RetriesOnTransientLinkNotFound(t *testing.T) {
 	assert.Equal(t, "eni9cfdfc6963c", got)
 	assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(5),
 		"should have probed at least 5 times across multiple attempts")
+	assert.Equal(t, successBefore+1, testutil.ToFloat64(vethLookupRetries.WithLabelValues("success")),
+		"retries_total{result=success} should increment when success follows a retry")
 }
 
 // TestGetHostVethName_ExhaustsRetries verifies the bounded retry budget:
@@ -830,6 +835,8 @@ func TestGetHostVethName_ExhaustsRetries(t *testing.T) {
 		return errors.Is(err, sentinelLinkNotFound)
 	}
 
+	exhaustedBefore := testutil.ToFloat64(vethLookupRetries.WithLabelValues("exhausted"))
+
 	var calls int32
 	getLinkByNameFunc = func(name string) (netlink.Link, error) {
 		atomic.AddInt32(&calls, 1)
@@ -842,6 +849,8 @@ func TestGetHostVethName_ExhaustsRetries(t *testing.T) {
 	// 3 attempts x 2 prefixes = 6 netlink lookups.
 	assert.Equal(t, int32(6), atomic.LoadInt32(&calls))
 	assert.Contains(t, err.Error(), "failed to find link")
+	assert.Equal(t, exhaustedBefore+1, testutil.ToFloat64(vethLookupRetries.WithLabelValues("exhausted")),
+		"retries_total{result=exhausted} should increment when retries are exhausted")
 }
 
 // TestGetHostVethName_NoRetryOnNonNotFound verifies that errors other than

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,14 +1,35 @@
 package utils
 
 import (
+	"errors"
 	"net"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-network-policy-agent/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/vishvananda/netlink"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
+
+// sentinelLinkNotFound is a test-only error used by the GetHostVethName retry
+// tests to mimic netlink.LinkNotFoundError. We do not construct the netlink
+// type directly because its embedded error field is unexported.
+var sentinelLinkNotFound = errors.New("Link not found")
+
+// fastBackoff returns a Backoff with the given number of steps and zero delay
+// so retry tests do not actually sleep.
+func fastBackoff(steps int) wait.Backoff {
+	return wait.Backoff{
+		Duration: time.Nanosecond,
+		Factor:   1.0,
+		Jitter:   0,
+		Steps:    steps,
+		Cap:      time.Nanosecond,
+	}
+}
 
 func TestComputeTrieKey(t *testing.T) {
 
@@ -682,8 +703,13 @@ func TestGetHostVethName(t *testing.T) {
 		mockNetlink     bool
 	}
 
-	originalFunc := getLinkByNameFunc                   // Save original function
-	defer func() { getLinkByNameFunc = originalFunc }() // Restore after test
+	originalFunc := getLinkByNameFunc
+	originalBackoff := GetHostVethNameBackoff
+	defer func() {
+		getLinkByNameFunc = originalFunc
+		GetHostVethNameBackoff = originalBackoff
+	}()
+	GetHostVethNameBackoff = fastBackoff(1)
 
 	tests := []struct {
 		name    string
@@ -730,6 +756,10 @@ func TestGetHostVethName(t *testing.T) {
 			getLinkByNameFunc = func(name string) (netlink.Link, error) {
 				return &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: name}}, nil
 			}
+		} else {
+			getLinkByNameFunc = func(name string) (netlink.Link, error) {
+				return nil, errors.New("Link not found")
+			}
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
@@ -742,6 +772,107 @@ func TestGetHostVethName(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGetHostVethName_RetriesOnTransientLinkNotFound verifies that
+// GetHostVethName transparently retries when netlink first reports
+// LinkNotFoundError and the interface becomes visible on a later attempt.
+// This is the failure mode reported in
+// https://github.com/aws/aws-network-policy-agent/issues/569 .
+func TestGetHostVethName_RetriesOnTransientLinkNotFound(t *testing.T) {
+	originalFunc := getLinkByNameFunc
+	originalMatcher := isLinkNotFoundError
+	originalBackoff := GetHostVethNameBackoff
+	defer func() {
+		getLinkByNameFunc = originalFunc
+		isLinkNotFoundError = originalMatcher
+		GetHostVethNameBackoff = originalBackoff
+	}()
+
+	GetHostVethNameBackoff = fastBackoff(5)
+	isLinkNotFoundError = func(err error) bool {
+		return errors.Is(err, sentinelLinkNotFound)
+	}
+
+	var calls int32
+	// Return Link-not-found for the first 4 calls (covers both prefixes on
+	// attempts 1 and 2), then succeed for the "eni" prefix.
+	getLinkByNameFunc = func(name string) (netlink.Link, error) {
+		c := atomic.AddInt32(&calls, 1)
+		if c <= 4 {
+			return nil, sentinelLinkNotFound
+		}
+		return &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: name}}, nil
+	}
+
+	got, err := GetHostVethName("foo", "bar", 0, []string{"eni", "vlan"})
+	assert.NoError(t, err)
+	assert.Equal(t, "eni9cfdfc6963c", got)
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(5),
+		"should have probed at least 5 times across multiple attempts")
+}
+
+// TestGetHostVethName_ExhaustsRetries verifies the bounded retry budget:
+// after the configured Steps, GetHostVethName returns the accumulated
+// multierror.
+func TestGetHostVethName_ExhaustsRetries(t *testing.T) {
+	originalFunc := getLinkByNameFunc
+	originalMatcher := isLinkNotFoundError
+	originalBackoff := GetHostVethNameBackoff
+	defer func() {
+		getLinkByNameFunc = originalFunc
+		isLinkNotFoundError = originalMatcher
+		GetHostVethNameBackoff = originalBackoff
+	}()
+
+	GetHostVethNameBackoff = fastBackoff(3)
+	isLinkNotFoundError = func(err error) bool {
+		return errors.Is(err, sentinelLinkNotFound)
+	}
+
+	var calls int32
+	getLinkByNameFunc = func(name string) (netlink.Link, error) {
+		atomic.AddInt32(&calls, 1)
+		return nil, sentinelLinkNotFound
+	}
+
+	got, err := GetHostVethName("foo", "bar", 0, []string{"eni", "vlan"})
+	assert.Empty(t, got)
+	assert.Error(t, err)
+	// 3 attempts x 2 prefixes = 6 netlink lookups.
+	assert.Equal(t, int32(6), atomic.LoadInt32(&calls))
+	assert.Contains(t, err.Error(), "failed to find link")
+}
+
+// TestGetHostVethName_NoRetryOnNonNotFound verifies that errors other than
+// LinkNotFoundError short-circuit (no retry). Permission errors, netlink
+// socket failures, etc. are not transient and retrying just adds latency.
+func TestGetHostVethName_NoRetryOnNonNotFound(t *testing.T) {
+	originalFunc := getLinkByNameFunc
+	originalMatcher := isLinkNotFoundError
+	originalBackoff := GetHostVethNameBackoff
+	defer func() {
+		getLinkByNameFunc = originalFunc
+		isLinkNotFoundError = originalMatcher
+		GetHostVethNameBackoff = originalBackoff
+	}()
+
+	GetHostVethNameBackoff = fastBackoff(5)
+	isLinkNotFoundError = func(err error) bool {
+		return errors.Is(err, sentinelLinkNotFound)
+	}
+
+	var calls int32
+	getLinkByNameFunc = func(name string) (netlink.Link, error) {
+		atomic.AddInt32(&calls, 1)
+		return nil, errors.New("permission denied")
+	}
+
+	got, err := GetHostVethName("foo", "bar", 0, []string{"eni", "vlan"})
+	assert.Empty(t, got)
+	assert.Error(t, err)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls),
+		"should probe each prefix once then bail without retry on non-retryable error")
 }
 
 func TestIsFileExistsError(t *testing.T) {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"sync/atomic"
 	"testing"
@@ -851,6 +852,100 @@ func TestGetHostVethName_ExhaustsRetries(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to find link")
 	assert.Equal(t, exhaustedBefore+1, testutil.ToFloat64(vethLookupRetries.WithLabelValues("exhausted")),
 		"retries_total{result=exhausted} should increment when retries are exhausted")
+}
+
+// TestIsLinkNotFoundError_MatchesRealType validates the production
+// isLinkNotFoundError matcher against the real netlink.LinkNotFoundError
+// type with no override. The retry path's entire gate is the errors.As
+// check this matcher performs; if netlink ever changes its returned type
+// or someone wraps the error upstream, this test catches the regression
+// where the matcher silently stops firing.
+func TestIsLinkNotFoundError_MatchesRealType(t *testing.T) {
+	realErr := netlink.LinkNotFoundError{}
+	wrappedReal := fmt.Errorf("netlink lookup failed: %w", netlink.LinkNotFoundError{})
+	doubleWrapped := fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", netlink.LinkNotFoundError{}))
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "real netlink.LinkNotFoundError", err: realErr, want: true},
+		{name: "wrapped real netlink.LinkNotFoundError", err: wrappedReal, want: true},
+		{name: "double-wrapped real netlink.LinkNotFoundError", err: doubleWrapped, want: true},
+		// Negative cases: string-equal but wrong type must not match. The
+		// matcher MUST gate on type identity, never on the error string.
+		{name: "plain errors.New with same text", err: errors.New("Link not found"), want: false},
+		{name: "plain errors.New unrelated", err: errors.New("permission denied"), want: false},
+		{name: "nil", err: nil, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isLinkNotFoundError(tt.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestGetHostVethName_RealLinkNotFoundError_DrivesRetry exercises the full
+// GetHostVethName retry path using the real netlink.LinkNotFoundError type
+// without overriding the production isLinkNotFoundError matcher. This is the
+// end-to-end check that the errors.As gate inside the retry condition
+// recognizes the actual concrete type returned by netlink.
+func TestGetHostVethName_RealLinkNotFoundError_DrivesRetry(t *testing.T) {
+	originalFunc := getLinkByNameFunc
+	originalBackoff := GetHostVethNameBackoff
+	t.Cleanup(func() {
+		getLinkByNameFunc = originalFunc
+		GetHostVethNameBackoff = originalBackoff
+	})
+
+	GetHostVethNameBackoff = fastBackoff(5)
+
+	exhaustedBefore := testutil.ToFloat64(vethLookupRetries.WithLabelValues("exhausted"))
+
+	var calls int32
+	getLinkByNameFunc = func(name string) (netlink.Link, error) {
+		atomic.AddInt32(&calls, 1)
+		return nil, netlink.LinkNotFoundError{}
+	}
+
+	got, err := GetHostVethName("foo", "bar", 0, []string{"eni", "vlan"})
+	assert.Empty(t, got)
+	assert.Error(t, err)
+	// 5 attempts x 2 prefixes = 10 probes. If the production matcher fails
+	// to recognize netlink.LinkNotFoundError as retryable, we would see
+	// exactly 2 probes (one per prefix, then bail).
+	assert.Equal(t, int32(10), atomic.LoadInt32(&calls),
+		"production isLinkNotFoundError matcher must recognize real netlink.LinkNotFoundError and drive retries")
+	assert.Equal(t, exhaustedBefore+1, testutil.ToFloat64(vethLookupRetries.WithLabelValues("exhausted")))
+}
+
+// TestGetHostVethName_RealLinkNotFoundError_WrappedDrivesRetry covers the
+// case where an upstream caller wraps the netlink error before returning it
+// (e.g. fmt.Errorf("...: %w", lnf)). The production matcher uses errors.As
+// so wrapping must not defeat the retry decision.
+func TestGetHostVethName_RealLinkNotFoundError_WrappedDrivesRetry(t *testing.T) {
+	originalFunc := getLinkByNameFunc
+	originalBackoff := GetHostVethNameBackoff
+	t.Cleanup(func() {
+		getLinkByNameFunc = originalFunc
+		GetHostVethNameBackoff = originalBackoff
+	})
+
+	GetHostVethNameBackoff = fastBackoff(3)
+
+	var calls int32
+	getLinkByNameFunc = func(name string) (netlink.Link, error) {
+		atomic.AddInt32(&calls, 1)
+		return nil, fmt.Errorf("netlink lookup for %s: %w", name, netlink.LinkNotFoundError{})
+	}
+
+	got, err := GetHostVethName("foo", "bar", 0, []string{"eni", "vlan"})
+	assert.Empty(t, got)
+	assert.Error(t, err)
+	assert.Equal(t, int32(6), atomic.LoadInt32(&calls),
+		"wrapped netlink.LinkNotFoundError must still satisfy errors.As and drive retries")
 }
 
 // TestGetHostVethName_NoRetryOnNonNotFound verifies that errors other than

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -951,6 +951,8 @@ func TestGetHostVethName_RealLinkNotFoundError_WrappedDrivesRetry(t *testing.T) 
 // TestGetHostVethName_NoRetryOnNonNotFound verifies that errors other than
 // LinkNotFoundError short-circuit (no retry). Permission errors, netlink
 // socket failures, etc. are not transient and retrying just adds latency.
+// It also pins down the contract that the exhausted counter is reserved for
+// "retry budget actually ran out" and never fires on a non-retryable error.
 func TestGetHostVethName_NoRetryOnNonNotFound(t *testing.T) {
 	originalFunc := getLinkByNameFunc
 	originalMatcher := isLinkNotFoundError
@@ -966,6 +968,8 @@ func TestGetHostVethName_NoRetryOnNonNotFound(t *testing.T) {
 		return errors.Is(err, sentinelLinkNotFound)
 	}
 
+	exhaustedBefore := testutil.ToFloat64(vethLookupRetries.WithLabelValues("exhausted"))
+
 	var calls int32
 	getLinkByNameFunc = func(name string) (netlink.Link, error) {
 		atomic.AddInt32(&calls, 1)
@@ -977,6 +981,51 @@ func TestGetHostVethName_NoRetryOnNonNotFound(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, int32(2), atomic.LoadInt32(&calls),
 		"should probe each prefix once then bail without retry on non-retryable error")
+	assert.Equal(t, exhaustedBefore, testutil.ToFloat64(vethLookupRetries.WithLabelValues("exhausted")),
+		"non-retryable error must not increment retries_total{result=exhausted}")
+}
+
+// TestGetHostVethName_NoExhaustedOnLateNonRetryable guards the specific
+// failure mode where a retryable LinkNotFound on attempt 1 is followed by a
+// non-retryable error (e.g. permission denied) on attempt 2. The retry
+// budget was not exhausted in that scenario, so retries_total{result=
+// exhausted} must stay flat even though the function did exercise the
+// retry path.
+func TestGetHostVethName_NoExhaustedOnLateNonRetryable(t *testing.T) {
+	originalFunc := getLinkByNameFunc
+	originalMatcher := isLinkNotFoundError
+	originalBackoff := GetHostVethNameBackoff
+	defer func() {
+		getLinkByNameFunc = originalFunc
+		isLinkNotFoundError = originalMatcher
+		GetHostVethNameBackoff = originalBackoff
+	}()
+
+	GetHostVethNameBackoff = fastBackoff(5)
+	isLinkNotFoundError = func(err error) bool {
+		return errors.Is(err, sentinelLinkNotFound)
+	}
+
+	exhaustedBefore := testutil.ToFloat64(vethLookupRetries.WithLabelValues("exhausted"))
+
+	var calls int32
+	getLinkByNameFunc = func(name string) (netlink.Link, error) {
+		c := atomic.AddInt32(&calls, 1)
+		// Attempt 1 (calls 1,2): both prefixes return retryable LinkNotFound.
+		// Attempt 2 (calls 3,4): permission denied -> non-retryable.
+		if c <= 2 {
+			return nil, sentinelLinkNotFound
+		}
+		return nil, errors.New("permission denied")
+	}
+
+	got, err := GetHostVethName("foo", "bar", 0, []string{"eni", "vlan"})
+	assert.Empty(t, got)
+	assert.Error(t, err)
+	assert.Equal(t, int32(4), atomic.LoadInt32(&calls),
+		"should retry past attempt 1 (all LinkNotFound) and bail on attempt 2 (non-retryable)")
+	assert.Equal(t, exhaustedBefore, testutil.ToFloat64(vethLookupRetries.WithLabelValues("exhausted")),
+		"non-retryable error after a retryable attempt must not be counted as exhausted")
 }
 
 func TestIsFileExistsError(t *testing.T) {

--- a/test/integration/vethrace/vethrace_suite_test.go
+++ b/test/integration/vethrace/vethrace_suite_test.go
@@ -1,0 +1,34 @@
+package vethrace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-network-policy-agent/test/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	fw        *framework.Framework
+	ctx       context.Context
+	namespace = "vethrace-test"
+)
+
+func TestVethRaceUnderPodChurn(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Veth Race Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	fw = framework.New(framework.GlobalOptions)
+	ctx = context.Background()
+
+	err := fw.NamespaceManager.CreateNamespace(ctx, namespace)
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	err := fw.NamespaceManager.DeleteAndWaitTillNamespaceDeleted(ctx, namespace)
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/test/integration/vethrace/vethrace_test.go
+++ b/test/integration/vethrace/vethrace_test.go
@@ -1,0 +1,246 @@
+package vethrace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-network-policy-agent/test/framework/manifest"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	network "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// The race fires under concurrent CNI ADD. parallelism controls the
+	// concurrency of each "wave", completions controls total samples.
+	// 50 x 1000 = 20 waves, runtime ~10-13 min, expected ~10 hits on a
+	// known-buggy build at the issue's ~1% steady-state failure rate.
+	completions  = 1000
+	parallelism  = 50
+	podSleep     = 5 * time.Second
+	churnTimeout = 15 * time.Minute
+	pollInterval = 5 * time.Second
+	jobName      = "vethrace-churn"
+
+	// Substring of the kubelet FailedCreatePodSandBox event message that
+	// only appears when the CNI plugin's call to NPA fails. The full
+	// kubelet event surface is:
+	//   Failed to create pod sandbox: rpc error: code = Unknown desc =
+	//   failed to setup network for sandbox "<id>": plugin type="aws-cni"
+	//   name="aws-cni" failed (add): add cmd: failed to setup network policy
+	// (see aws/aws-network-policy-agent#569).
+	cniNetworkPolicyFailMsg = "failed to setup network policy"
+)
+
+var _ = Describe("Veth Race Under Pod Churn", Ordered, func() {
+	var (
+		networkPolicy     *network.NetworkPolicy
+		defaultDenyPolicy *network.NetworkPolicy
+		job               *batchv1.Job
+		workerNodes       []v1.Node
+	)
+
+	// This test reproduces aws/aws-network-policy-agent#569 (NPA returns
+	// transient "Link not found" during pod CNI ADD). The network policies
+	// force every churn pod through NPA's GetHostVethName path; the Job
+	// bursts enough concurrent creates to hit the race window. The fix in
+	// this PR retries the netlink lookup inside NPA, so on a fixed build
+	// no churn pod should produce a "failed to setup network policy"
+	// sandbox event. On an unfixed build the same workload reproduces it.
+	It("should not produce CNI network-policy failures during high pod churn", func() {
+		By("Getting worker nodes and labeling them for churn scheduling")
+		var err error
+		workerNodes, err = getWorkerNodes()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(workerNodes)).To(BeNumerically(">=", 1))
+		lo.ForEach(workerNodes, func(node v1.Node, _ int) {
+			node.Labels["test-node"] = "true"
+			err = fw.K8sClient.Update(ctx, &node)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("Creating a default deny network policy")
+		defaultDenyPolicy = buildDefaultDenyNetworkPolicy()
+		Expect(fw.NetworkPolicyManager.CreateNetworkPolicy(ctx, defaultDenyPolicy)).ToNot(HaveOccurred())
+
+		By("Creating a network policy targeting churn pods")
+		networkPolicy = buildChurnNetworkPolicy()
+		Expect(fw.NetworkPolicyManager.CreateNetworkPolicy(ctx, networkPolicy)).ToNot(HaveOccurred())
+
+		By("Recording the event baseline before churn starts")
+		startTime := metav1.Now()
+
+		By(fmt.Sprintf("Creating a Job that bursts %d concurrent short-lived pods, %d total",
+			parallelism, completions))
+		job = buildChurnJob()
+		Expect(fw.K8sClient.Create(ctx, job)).ToNot(HaveOccurred())
+
+		By(fmt.Sprintf("Waiting up to %v for the Job to complete %d pods", churnTimeout, completions))
+		waitForJobCompletion()
+
+		By("Asserting no churn pod hit the NPA veth race")
+		failures := findCniNetworkPolicyFailures(startTime)
+		Expect(failures).To(BeEmpty(),
+			"detected FailedCreatePodSandBox events with NPA veth race signature; "+
+				"this PR's retry path should absorb them")
+	})
+
+	AfterAll(func() {
+		// Foreground propagation: the API server blocks the Job delete
+		// until all dependent pods are gone. Without this the test can
+		// exit before the garbage collector drains the (up to completions)
+		// finished pods, leaving them in the test namespace.
+		if job != nil {
+			propagation := metav1.DeletePropagationForeground
+			Expect(fw.K8sClient.Delete(ctx, job, &client.DeleteOptions{
+				PropagationPolicy: &propagation,
+			})).To(Or(Succeed(), MatchError(ContainSubstring("not found"))))
+			// Belt-and-suspenders: any pods orphaned by an interrupted
+			// delete still get reaped here. List + delete is namespaced
+			// and label-scoped, so no risk to anything outside the test.
+			pods := &v1.PodList{}
+			if err := fw.K8sClient.List(ctx, pods,
+				client.InNamespace(namespace),
+				client.MatchingLabels{"app": "churn-pod"}); err == nil {
+				for i := range pods.Items {
+					fw.K8sClient.Delete(ctx, &pods.Items[i])
+				}
+			}
+		}
+		if networkPolicy != nil {
+			fw.NetworkPolicyManager.DeleteNetworkPolicy(ctx, networkPolicy)
+		}
+		if defaultDenyPolicy != nil {
+			fw.NetworkPolicyManager.DeleteNetworkPolicy(ctx, defaultDenyPolicy)
+		}
+		lo.ForEach(workerNodes, func(node v1.Node, _ int) {
+			delete(node.Labels, "test-node")
+			fw.K8sClient.Update(ctx, &node)
+		})
+	})
+})
+
+func buildDefaultDenyNetworkPolicy() *network.NetworkPolicy {
+	return manifest.NewNetworkPolicyBuilder().
+		Namespace(namespace).
+		Name("default-deny-all").
+		SetPolicyType(true, true).
+		Build()
+}
+
+func buildChurnNetworkPolicy() *network.NetworkPolicy {
+	// Targeted policy on the churn label forces NPA into every CNI ADD
+	// path for these pods, which is what makes the race reproducible.
+	return manifest.NewNetworkPolicyBuilder().
+		Namespace(namespace).
+		Name("churn-pod-policy").
+		PodSelector("app", "churn-pod").
+		SetPolicyType(true, true).
+		Build()
+}
+
+func buildChurnJob() *batchv1.Job {
+	par := int32(parallelism)
+	comp := int32(completions)
+	backoffLimit := int32(0)
+	ttl := int32(30)
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: namespace,
+		},
+		Spec: batchv1.JobSpec{
+			Parallelism:             &par,
+			Completions:             &comp,
+			BackoffLimit:            &backoffLimit,
+			TTLSecondsAfterFinished: &ttl,
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "churn-pod"},
+				},
+				Spec: v1.PodSpec{
+					NodeSelector: map[string]string{
+						"test-node": "true",
+					},
+					RestartPolicy: v1.RestartPolicyNever,
+					Containers: []v1.Container{
+						{
+							Name:    "churn",
+							Image:   "public.ecr.aws/amazonlinux/amazonlinux:2023-minimal",
+							Command: []string{"sleep", fmt.Sprintf("%d", int(podSleep.Seconds()))},
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1m"),
+									v1.ResourceMemory: resource.MustParse("4Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getWorkerNodes() ([]v1.Node, error) {
+	nodeList := &v1.NodeList{}
+	err := fw.K8sClient.List(ctx, nodeList, client.MatchingLabels{
+		"kubernetes.io/os": "linux",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return lo.Filter(nodeList.Items, func(node v1.Node, index int) bool {
+		return strings.Contains(node.Status.NodeInfo.OSImage, "Amazon Linux 2023")
+	}), nil
+}
+
+// findCniNetworkPolicyFailures returns a slice of human-readable lines
+// describing each FailedCreatePodSandBox event in the test namespace that
+// was emitted at or after startTime and carries the NPA veth race
+// signature. Empty slice means the workload completed cleanly.
+func findCniNetworkPolicyFailures(startTime metav1.Time) []string {
+	events := &v1.EventList{}
+	Expect(fw.K8sClient.List(ctx, events, client.InNamespace(namespace))).ToNot(HaveOccurred())
+
+	var hits []string
+	for _, e := range events.Items {
+		if e.Reason != "FailedCreatePodSandBox" {
+			continue
+		}
+		if e.LastTimestamp.Before(&startTime) {
+			continue
+		}
+		if !strings.Contains(e.Message, cniNetworkPolicyFailMsg) {
+			continue
+		}
+		hits = append(hits, fmt.Sprintf("pod=%s reason=%s msg=%s",
+			e.InvolvedObject.Name, e.Reason, e.Message))
+	}
+	return hits
+}
+
+// waitForJobCompletion polls the churn Job until either the desired number
+// of completions is reached or the timeout is hit. Polling is sized so the
+// race window between batches stays exercised continuously.
+func waitForJobCompletion() {
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, churnTimeout, true, func(context.Context) (bool, error) {
+		j := &batchv1.Job{}
+		if err := fw.K8sClient.Get(ctx, client.ObjectKey{Name: jobName, Namespace: namespace}, j); err != nil {
+			return false, err
+		}
+		return j.Status.Succeeded >= int32(completions), nil
+	})
+	Expect(err).ToNot(HaveOccurred(),
+		fmt.Sprintf("churn Job did not reach %d successful pods within %v", completions, churnTimeout))
+}

--- a/test/integration/vethrace/vethrace_test.go
+++ b/test/integration/vethrace/vethrace_test.go
@@ -218,7 +218,12 @@ func findCniNetworkPolicyFailures(startTime metav1.Time) []string {
 		if e.Reason != "FailedCreatePodSandBox" {
 			continue
 		}
-		if e.LastTimestamp.Before(&startTime) {
+		// Filter by event time. Use the most recent of EventTime,
+		// LastTimestamp, CreationTimestamp; CreationTimestamp is always
+		// set by the API server even when the legacy LastTimestamp is
+		// zero (depends on event source).
+		et := eventTime(&e)
+		if et.Before(&startTime) {
 			continue
 		}
 		if !strings.Contains(e.Message, cniNetworkPolicyFailMsg) {
@@ -230,13 +235,27 @@ func findCniNetworkPolicyFailures(startTime metav1.Time) []string {
 	return hits
 }
 
+// eventTime returns the most recent timestamp available on the event,
+// preferring EventTime (microsecond precision, set by newer event
+// recorders), falling back to LastTimestamp (legacy) and finally to
+// CreationTimestamp (always set by the API server).
+func eventTime(e *v1.Event) metav1.Time {
+	if !e.EventTime.IsZero() {
+		return metav1.NewTime(e.EventTime.Time)
+	}
+	if !e.LastTimestamp.IsZero() {
+		return e.LastTimestamp
+	}
+	return e.CreationTimestamp
+}
+
 // waitForJobCompletion polls the churn Job until either the desired number
 // of completions is reached or the timeout is hit. Polling is sized so the
 // race window between batches stays exercised continuously.
 func waitForJobCompletion() {
-	err := wait.PollUntilContextTimeout(ctx, pollInterval, churnTimeout, true, func(context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, churnTimeout, true, func(pollCtx context.Context) (bool, error) {
 		j := &batchv1.Job{}
-		if err := fw.K8sClient.Get(ctx, client.ObjectKey{Name: jobName, Namespace: namespace}, j); err != nil {
+		if err := fw.K8sClient.Get(pollCtx, client.ObjectKey{Name: jobName, Namespace: namespace}, j); err != nil {
 			return false, err
 		}
 		return j.Status.Succeeded >= int32(completions), nil


### PR DESCRIPTION
Fixes #569.

## Summary

During CNI ADD there is a small race window in which the VPC CNI plugin has requested NPA to enforce policy on a newly created pod but the host-side veth (`eni<hash>` or `vlan<hash>`) is not yet visible to netlink on the goroutine handling the request. A single `netlink.LinkByName` miss currently fails the gRPC request, the CNI plugin fails the ADD, and kubelet retries the pod sandbox ~10s later, adding ~14s of latency per affected pod (~1% steady state, ~11% during Karpenter scale-up per the report in #569).

## Change

Wrap the prefix probe in `wait.ExponentialBackoff` (already a dep used in `pkg/ebpf/bpf_client.go`) with a bounded budget and jitter:

- 8 attempts, 50 ms initial, factor 2, capped at 1 s, +/-10% jitter. Worst case across all 8 attempts is ~5s, comfortably under kubelet's pod-sandbox retry interval (~10s).
- Only retry when every probed prefix returned `netlink.LinkNotFoundError`. Other netlink errors (permission, socket failure, etc.) are non-transient and surface immediately.
- Tunable via the exported `utils.GetHostVethNameBackoff` package var.

No call-site changes. `AttacheBPFProbes` and the gRPC handler are untouched.

## Observability

Two metrics registered against the controller-runtime metrics registry:

- `awsnodeagent_veth_lookup_retries_total{result="success"|"exhausted"}` counter. `success` increments when the link resolves on a retry; `exhausted` increments only when `wait.ExponentialBackoff` returned because the retry budget was reached (gated on `wait.Interrupted(err)`), so non-retryable errors that happen after a retryable attempt are not conflated with budget exhaustion.
- `awsnodeagent_veth_lookup_attempts` histogram (linear buckets 1..8) observed on every call so operators can see the attempt-count distribution and confirm the budget is right-sized.

## Tests

`pkg/utils/utils_test.go` and `pkg/utils/utils_linux_test.go` cover:

- `TestGetHostVethName_RetriesOnTransientLinkNotFound`: succeeds after several transient misses; asserts `retries_total{result="success"}` increments.
- `TestGetHostVethName_ExhaustsRetries`: verifies exactly `Steps x len(prefixes)` netlink lookups when the link never appears; asserts `retries_total{result="exhausted"}` increments.
- `TestGetHostVethName_NoRetryOnNonNotFound`: non-retryable errors short-circuit (no retry, no sleep); asserts `retries_total{result="exhausted"}` does NOT move.
- `TestGetHostVethName_NoExhaustedOnLateNonRetryable`: retryable miss followed by a non-retryable error does NOT count as exhausted.
- `TestIsLinkNotFoundError_MatchesRealType`: pins the production `isLinkNotFoundError` matcher against the real `netlink.LinkNotFoundError` type (bare, wrapped, double-wrapped).
- `TestGetHostVethName_RealLinkNotFoundError_DrivesRetry` / `_WrappedDrivesRetry`: drive the full retry path with the real netlink type (no sentinel, no matcher override).
- `TestGetHostVethName_RealNetlink_TriggersRetries` (Linux-only): end-to-end against the real `netlink.LinkByName` syscall on a guaranteed-missing link.

Existing `TestGetHostVethName` table-driven tests still pass.

## Risk

Low. The retry path is gated on `LinkNotFoundError` and bounded in time. The happy path is unchanged other than the histogram observation and an `attempt > 1` counter increment.
