### PR TITLE
fix(utils): make GetPodIdentifier injective to prevent cross-namespac…

### DIFF
--- a/controllers/policyendpoints_controller_test.go
+++ b/controllers/policyendpoints_controller_test.go
@@ -79,9 +79,9 @@ func TestPolicyEndpointReconcile(t *testing.T) {
 		assert.Nil(t, err)
 		val, ok := policyEndpointReconciler.networkPolicyToPodIdentifierMap.Load("allow-all-egress")
 		assert.True(t, ok)
-		assert.True(t, lo.Contains(val.([]string), "deployment1rs-my-namespace"))
+		assert.True(t, lo.Contains(val.([]string), "deployment1rs@my-namespace"))
 
-		val, ok = policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Load("deployment1rs-my-namespace")
+		val, ok = policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Load("deployment1rs@my-namespace")
 		assert.True(t, ok)
 		assert.True(t, lo.Contains(val.([]string), "allow-all-egress-abcd"))
 
@@ -125,9 +125,9 @@ func TestPolicyEndpointReconcile(t *testing.T) {
 		assert.Nil(t, err)
 		val, ok := policyEndpointReconciler.networkPolicyToPodIdentifierMap.Load("allow-all-egress")
 		assert.True(t, ok)
-		assert.True(t, lo.Contains(val.([]string), "deployment1rs-my-namespace"))
+		assert.True(t, lo.Contains(val.([]string), "deployment1rs@my-namespace"))
 
-		val, ok = policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Load("deployment1rs-my-namespace")
+		val, ok = policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Load("deployment1rs@my-namespace")
 		assert.True(t, ok)
 		assert.True(t, lo.Contains(val.([]string), "allow-all-egress-abcd"))
 

--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -392,6 +392,18 @@ func (l *bpfClient) recoverBPFState(bpfTCClient tc.BpfTc, eBPFSDKClient goelf.Bp
 	var interfaceNametoIngressPinPath = make(map[string]string)
 	var interfaceNametoEgressPinPath = make(map[string]string)
 
+	// Rename legacy "-" separator pin files to the new "_" format using
+	// VPC CNI's local pod inventory. Runs once per node, guarded by
+	// formatV2MarkerPath.
+	if err := migrateLegacyPinsFromCNIState(
+		utils.BPF_PROGRAMS_PIN_PATH_DIRECTORY,
+		utils.BPF_MAPS_PIN_PATH_DIRECTORY,
+		cniIpamStatePath,
+		formatV2MarkerPath,
+	); err != nil {
+		log().Errorf("legacy pin migration failed (non-fatal): %v", err)
+	}
+
 	// Recover global maps (Conntrack and Events) if there is no need to update
 	// events binary
 	if !updateEventsProbe {
@@ -789,7 +801,15 @@ func (l *bpfClient) attachIngressBPFProbe(hostVethName string, podIdentifier str
 
 	log().Infof("Attempting to do an Ingress Attach with progFD: %d", progFD)
 	err = l.bpfTCClient.TCEgressAttach(hostVethName, progFD, utils.TC_INGRESS_PROG)
-	if err != nil && !utils.IsFileExistsError(err.Error()) {
+	if err != nil && utils.IsFileExistsError(err.Error()) {
+		log().Warnf("Stale ingress TC filter on %s; detaching before re-attach", hostVethName)
+		if detachErr := l.bpfTCClient.TCEgressDetach(hostVethName); detachErr != nil {
+			log().Errorf("Ingress TC detach failed on %s: %v", hostVethName, detachErr)
+			return 0, detachErr
+		}
+		err = l.bpfTCClient.TCEgressAttach(hostVethName, progFD, utils.TC_INGRESS_PROG)
+	}
+	if err != nil {
 		log().Errorf("Ingress Attach failed %v", err)
 		return 0, err
 	}
@@ -826,7 +846,15 @@ func (l *bpfClient) attachEgressBPFProbe(hostVethName string, podIdentifier stri
 
 	log().Infof("Attempting to do an Egress Attach with progFD: %d", progFD)
 	err = l.bpfTCClient.TCIngressAttach(hostVethName, progFD, utils.TC_EGRESS_PROG)
-	if err != nil && !utils.IsFileExistsError(err.Error()) {
+	if err != nil && utils.IsFileExistsError(err.Error()) {
+		log().Warnf("Stale egress TC filter on %s; detaching before re-attach", hostVethName)
+		if detachErr := l.bpfTCClient.TCIngressDetach(hostVethName); detachErr != nil {
+			log().Errorf("Egress TC detach failed on %s: %v", hostVethName, detachErr)
+			return 0, detachErr
+		}
+		err = l.bpfTCClient.TCIngressAttach(hostVethName, progFD, utils.TC_EGRESS_PROG)
+	}
+	if err != nil {
 		log().Errorf("Egress Attach failed %v", err)
 		return 0, err
 	}

--- a/pkg/ebpf/c/tc.v4egress.bpf.c
+++ b/pkg/ebpf/c/tc.v4egress.bpf.c
@@ -482,4 +482,5 @@ int handle_egress(struct __sk_buff *skb)
 	return BPF_OK;
 }
 
+const volatile __u32 NPA_FILE_VERSION = 2;
 char _license[] SEC("license") = "GPL";

--- a/pkg/ebpf/c/tc.v4ingress.bpf.c
+++ b/pkg/ebpf/c/tc.v4ingress.bpf.c
@@ -465,4 +465,5 @@ int handle_ingress(struct __sk_buff *skb)
 	return BPF_OK;
 }
 
+const volatile __u32 NPA_FILE_VERSION = 2;
 char _license[] SEC("license") = "GPL";

--- a/pkg/ebpf/c/tc.v6egress.bpf.c
+++ b/pkg/ebpf/c/tc.v6egress.bpf.c
@@ -472,4 +472,5 @@ int handle_egress(struct __sk_buff *skb)
 	return BPF_OK;
 }
 
+const volatile __u32 NPA_FILE_VERSION = 2;
 char _license[] SEC("license") = "GPL";

--- a/pkg/ebpf/c/tc.v6ingress.bpf.c
+++ b/pkg/ebpf/c/tc.v6ingress.bpf.c
@@ -463,4 +463,5 @@ int handle_ingress(struct __sk_buff *skb)
 	return BPF_OK;
 }
 
+const volatile __u32 NPA_FILE_VERSION = 2;
 char _license[] SEC("license") = "GPL";

--- a/pkg/ebpf/legacy_pin_migration.go
+++ b/pkg/ebpf/legacy_pin_migration.go
@@ -1,0 +1,158 @@
+package ebpf
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/aws/aws-network-policy-agent/pkg/utils"
+)
+
+// cniIpamStatePath is VPC CNI's per-pod allocation checkpoint; already on a
+// path the NPA container mounts.
+const cniIpamStatePath = "/var/run/aws-node/ipam.json"
+
+// formatV2MarkerPath is the sentinel file written after a successful one-shot
+// legacy-format migration. Its presence makes the migration a no-op on every
+// subsequent agent restart.
+const formatV2MarkerPath = "/var/run/aws-node/.npa_format_v2"
+
+type ipamAllocation struct {
+	Metadata struct {
+		K8sPodName      string `json:"k8sPodName"`
+		K8sPodNamespace string `json:"k8sPodNamespace"`
+	} `json:"metadata"`
+}
+
+type ipamStateFile struct {
+	Version     string           `json:"version"`
+	Allocations []ipamAllocation `json:"allocations"`
+}
+
+// migrateLegacyPinsFromCNIState renames per-pod bpffs pin files from the
+// legacy "-" separator format to the new "_" format. Runs once per node;
+// the markerPath sentinel makes it a no-op on subsequent restarts.
+func migrateLegacyPinsFromCNIState(progsDir, mapsDir, ipamPath, markerPath string) error {
+	if _, err := os.Stat(markerPath); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("checking migration marker %s: %w", markerPath, err)
+	}
+
+	raw, err := os.ReadFile(ipamPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read CNI ipam state %s: %w", ipamPath, err)
+	}
+
+	var state ipamStateFile
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return fmt.Errorf("parse CNI ipam state %s: %w", ipamPath, err)
+	}
+
+	byLegacyID := map[string][]ipamAllocation{}
+	for _, a := range state.Allocations {
+		if a.Metadata.K8sPodName == "" || a.Metadata.K8sPodNamespace == "" {
+			continue
+		}
+		legacyID := utils.LegacyGetPodIdentifier(a.Metadata.K8sPodName, a.Metadata.K8sPodNamespace)
+		byLegacyID[legacyID] = append(byLegacyID[legacyID], a)
+	}
+
+	var totalFailed int
+	for legacyID, pods := range byLegacyID {
+		// Sort by pod name so the choice of inheriting pod is deterministic.
+		// For multi-replica workloads all pods produce the same new ID, so
+		// order is irrelevant. For true cross-namespace collisions the first
+		// pod's pin gets renamed; the other pods will get fresh per-pod pins
+		// via the reconcile loop's normal attach path.
+		sort.Slice(pods, func(i, j int) bool {
+			return pods[i].Metadata.K8sPodName < pods[j].Metadata.K8sPodName
+		})
+		p := pods[0]
+		newID := utils.GetPodIdentifier(p.Metadata.K8sPodName, p.Metadata.K8sPodNamespace)
+
+		if len(pods) > 1 {
+			log().Infof("legacy pin %s shared by %d local pods; inheriting to first pod %s/%s (%s); other pods get fresh pins via reconcile",
+				legacyID, len(pods), p.Metadata.K8sPodNamespace, p.Metadata.K8sPodName, newID)
+		}
+		renamed, failed := renamePinFamily(progsDir, mapsDir, legacyID, newID)
+		totalFailed += failed
+		if renamed > 0 {
+			log().Infof("migrated %d bpffs pin file(s) for %s/%s: %s -> %s",
+				renamed, p.Metadata.K8sPodNamespace, p.Metadata.K8sPodName, legacyID, newID)
+		}
+	}
+
+	if totalFailed > 0 {
+		return fmt.Errorf("legacy pin migration incomplete: %d rename(s) failed; will retry on next restart", totalFailed)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(markerPath), 0755); err != nil {
+		return fmt.Errorf("ensure marker dir for %s: %w", markerPath, err)
+	}
+	if err := os.WriteFile(markerPath, []byte("v2\n"), 0644); err != nil {
+		return fmt.Errorf("write migration marker %s: %w", markerPath, err)
+	}
+	log().Infof("legacy pin migration complete; marker written at %s", markerPath)
+	return nil
+}
+
+func renamePinFamily(progsDir, mapsDir, legacyID, newID string) (renamed int, failed int) {
+	for _, dir := range []string{"ingress", "egress"} {
+		progName := utils.TC_INGRESS_PROG
+		if dir == "egress" {
+			progName = utils.TC_EGRESS_PROG
+		}
+		switch renamePinIfExists(progsDir+legacyID+"_"+progName, progsDir+newID+"_"+progName) {
+		case renameOK:
+			renamed++
+		case renameFailed:
+			failed++
+		}
+	}
+	for _, mapName := range []string{
+		utils.TC_INGRESS_MAP,
+		utils.TC_EGRESS_MAP,
+		utils.TC_CLUSTER_POLICY_INGRESS_MAP,
+		utils.TC_CLUSTER_POLICY_EGRESS_MAP,
+		utils.TC_INGRESS_POD_STATE_MAP,
+		utils.TC_EGRESS_POD_STATE_MAP,
+	} {
+		switch renamePinIfExists(mapsDir+legacyID+"_"+mapName, mapsDir+newID+"_"+mapName) {
+		case renameOK:
+			renamed++
+		case renameFailed:
+			failed++
+		}
+	}
+	return renamed, failed
+}
+
+type renameResult int
+
+const (
+	renameSkipped renameResult = iota // source does not exist
+	renameOK                          // rename succeeded
+	renameFailed                      // source exists but rename failed
+)
+
+func renamePinIfExists(src, dst string) renameResult {
+	if _, err := os.Stat(src); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			log().Warnf("legacy pin migration: stat %s: %v", src, err)
+			return renameFailed
+		}
+		return renameSkipped
+	}
+	if err := os.Rename(src, dst); err != nil {
+		log().Warnf("legacy pin migration: rename %s -> %s: %v", src, dst, err)
+		return renameFailed
+	}
+	return renameOK
+}

--- a/pkg/ebpf/legacy_pin_migration_test.go
+++ b/pkg/ebpf/legacy_pin_migration_test.go
@@ -1,0 +1,220 @@
+package ebpf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/aws-network-policy-agent/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+// writeIpam writes a minimal ipam.json with the given (podName, podNamespace) pairs.
+func writeIpam(t *testing.T, dir string, pods [][2]string) string {
+	t.Helper()
+	allocs := ""
+	for i, p := range pods {
+		if i > 0 {
+			allocs += ","
+		}
+		allocs += `{"metadata":{"k8sPodName":"` + p[0] + `","k8sPodNamespace":"` + p[1] + `"}}`
+	}
+	path := filepath.Join(dir, "ipam.json")
+	body := `{"version":"vpc-cni-ipam/1","allocations":[` + allocs + `]}`
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("write ipam: %v", err)
+	}
+	return path
+}
+
+func TestMigrateLegacyPinsFromCNIState_HappyPath(t *testing.T) {
+	progsDir := t.TempDir() + "/"
+	mapsDir := t.TempDir() + "/"
+	ipamPath := writeIpam(t, t.TempDir(), [][2]string{
+		{"deny-me-0", "ns1"},
+		{"web-frontend-0", "my-namespace"},
+		// Namespace containing "-" — boundary must be the prefix/ns join,
+		// the "-" inside the namespace must be PRESERVED.
+		{"aws-node-xyz", "kube-system"},
+	})
+
+	legacyFiles := []struct{ dir, name string }{
+		{progsDir, "deny-me-ns1_" + utils.TC_INGRESS_PROG},
+		{progsDir, "deny-me-ns1_" + utils.TC_EGRESS_PROG},
+		{mapsDir, "deny-me-ns1_" + utils.TC_INGRESS_MAP},
+		{mapsDir, "deny-me-ns1_" + utils.TC_EGRESS_POD_STATE_MAP},
+		{progsDir, "web-frontend-my-namespace_" + utils.TC_INGRESS_PROG},
+		{mapsDir, "web-frontend-my-namespace_" + utils.TC_CLUSTER_POLICY_INGRESS_MAP},
+		{progsDir, "aws-node-kube-system_" + utils.TC_INGRESS_PROG},
+		{mapsDir, "aws-node-kube-system_" + utils.TC_INGRESS_MAP},
+	}
+	for _, f := range legacyFiles {
+		assert.NoError(t, os.WriteFile(f.dir+f.name, []byte("x"), 0644))
+	}
+
+	if err := migrateLegacyPinsFromCNIState(progsDir, mapsDir, ipamPath, filepath.Join(t.TempDir(), ".npa_format_v2")); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	expectations := map[string]bool{
+		// deny-me/ns1
+		progsDir + "deny-me-ns1_" + utils.TC_INGRESS_PROG:        false,
+		progsDir + "deny-me@ns1_" + utils.TC_INGRESS_PROG:        true,
+		progsDir + "deny-me@ns1_" + utils.TC_EGRESS_PROG:         true,
+		mapsDir + "deny-me@ns1_" + utils.TC_INGRESS_MAP:          true,
+		mapsDir + "deny-me@ns1_" + utils.TC_EGRESS_POD_STATE_MAP: true,
+		// web-frontend/my-namespace
+		progsDir + "web-frontend@my-namespace_" + utils.TC_INGRESS_PROG:              true,
+		mapsDir + "web-frontend@my-namespace_" + utils.TC_CLUSTER_POLICY_INGRESS_MAP: true,
+		progsDir + "web-frontend-my-namespace_" + utils.TC_INGRESS_PROG:              false,
+		// aws-node/kube-system — boundary must become "@" but "kube-system" stays intact
+		progsDir + "aws-node-kube-system_" + utils.TC_INGRESS_PROG: false,
+		progsDir + "aws-node@kube-system_" + utils.TC_INGRESS_PROG: true,
+		mapsDir + "aws-node@kube-system_" + utils.TC_INGRESS_MAP:   true,
+		// Anti-assertion: must NOT corrupt "kube-system" by changing its internal "-"
+		progsDir + "aws-node@kube_system_" + utils.TC_INGRESS_PROG: false,
+		mapsDir + "aws-node@kube_system_" + utils.TC_INGRESS_MAP:   false,
+	}
+	for path, shouldExist := range expectations {
+		_, err := os.Stat(path)
+		if shouldExist {
+			assert.NoError(t, err, "expected %s to exist", path)
+		} else {
+			assert.True(t, os.IsNotExist(err), "expected %s to be gone", path)
+		}
+	}
+}
+
+// When two pods share a legacy identifier (the cross-namespace bypass case),
+// the legacy pin is renamed to the first pod's new identifier (sorted by name).
+// The other pod will get a fresh per-pod pin via the reconcile loop.
+func TestMigrateLegacyPinsFromCNIState_CollisionRenamesToFirstPod(t *testing.T) {
+	progsDir := t.TempDir() + "/"
+	mapsDir := t.TempDir() + "/"
+	ipamPath := writeIpam(t, t.TempDir(), [][2]string{
+		{"deny-me-x", "ns1"}, // legacy: deny-me-ns1, new: deny-me@ns1
+		{"deny-x", "me-ns1"}, // legacy: deny-me-ns1, new: deny@me-ns1
+	})
+
+	legacyPin := progsDir + "deny-me-ns1_" + utils.TC_INGRESS_PROG
+	assert.NoError(t, os.WriteFile(legacyPin, []byte("x"), 0644))
+
+	if err := migrateLegacyPinsFromCNIState(progsDir, mapsDir, ipamPath, filepath.Join(t.TempDir(), ".npa_format_v2")); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// Legacy pin no longer exists — it was renamed.
+	_, err := os.Stat(legacyPin)
+	assert.True(t, os.IsNotExist(err), "legacy pin must be renamed away")
+	// First pod by name is "deny-me-x" → new id "deny-me@ns1" inherits the pin.
+	_, err = os.Stat(progsDir + "deny-me@ns1_" + utils.TC_INGRESS_PROG)
+	assert.NoError(t, err, "first pod's new pin must exist after rename")
+	// Second pod's new pin must NOT have been created by the migration; the
+	// reconcile loop is responsible for creating it.
+	_, err = os.Stat(progsDir + "deny@me-ns1_" + utils.TC_INGRESS_PROG)
+	assert.True(t, os.IsNotExist(err), "non-inheriting pod's new pin must not be created by migration")
+}
+
+func TestMigrateLegacyPinsFromCNIState_MissingIpamIsNoOp(t *testing.T) {
+	progsDir := t.TempDir() + "/"
+	mapsDir := t.TempDir() + "/"
+	ipamPath := filepath.Join(t.TempDir(), "does-not-exist.json")
+
+	keep := progsDir + "untouched-ns_" + utils.TC_INGRESS_PROG
+	assert.NoError(t, os.WriteFile(keep, []byte("x"), 0644))
+
+	if err := migrateLegacyPinsFromCNIState(progsDir, mapsDir, ipamPath, filepath.Join(t.TempDir(), ".npa_format_v2")); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	_, err := os.Stat(keep)
+	assert.NoError(t, err)
+}
+
+func TestMigrateLegacyPinsFromCNIState_OrphanLeftAlone(t *testing.T) {
+	progsDir := t.TempDir() + "/"
+	mapsDir := t.TempDir() + "/"
+	ipamPath := writeIpam(t, t.TempDir(), [][2]string{
+		{"alive-pod-0", "ns1"},
+	})
+	orphan := progsDir + "ghost-ns1_" + utils.TC_INGRESS_PROG
+	assert.NoError(t, os.WriteFile(orphan, []byte("x"), 0644))
+
+	if err := migrateLegacyPinsFromCNIState(progsDir, mapsDir, ipamPath, filepath.Join(t.TempDir(), ".npa_format_v2")); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	_, err := os.Stat(orphan)
+	assert.NoError(t, err, "orphan pin not owned by any local pod must be preserved")
+}
+
+// Second call must be a no-op once the marker file exists.
+func TestMigrateLegacyPinsFromCNIState_RunsOnlyOnce(t *testing.T) {
+	progsDir := t.TempDir() + "/"
+	mapsDir := t.TempDir() + "/"
+	markerDir := t.TempDir()
+	markerPath := filepath.Join(markerDir, ".npa_format_v2")
+	ipamPath := writeIpam(t, t.TempDir(), [][2]string{{"deny-me-0", "ns1"}})
+
+	legacyPin := progsDir + "deny-me-ns1_" + utils.TC_INGRESS_PROG
+	assert.NoError(t, os.WriteFile(legacyPin, []byte("x"), 0644))
+
+	// First run: migration happens, marker is written
+	assert.NoError(t, migrateLegacyPinsFromCNIState(progsDir, mapsDir, ipamPath, markerPath))
+	_, err := os.Stat(markerPath)
+	assert.NoError(t, err, "marker must be written after first run")
+	_, err = os.Stat(progsDir + "deny-me@ns1_" + utils.TC_INGRESS_PROG)
+	assert.NoError(t, err, "first run must rename the pin")
+
+	// Seed a fresh legacy pin to prove the second run does NOT touch it
+	stale := progsDir + "another-ns1_" + utils.TC_INGRESS_PROG
+	assert.NoError(t, os.WriteFile(stale, []byte("x"), 0644))
+
+	assert.NoError(t, migrateLegacyPinsFromCNIState(progsDir, mapsDir, ipamPath, markerPath))
+	_, err = os.Stat(stale)
+	assert.NoError(t, err, "second run must skip migration once marker is present")
+}
+
+// If a rename fails, the marker must NOT be written so the next restart retries.
+// All pins are still attempted (no short-circuit on first failure).
+func TestMigrateLegacyPinsFromCNIState_NoMarkerOnRenameFail(t *testing.T) {
+	progsDir := t.TempDir() + "/"
+	mapsDir := t.TempDir() + "/"
+	markerDir := t.TempDir()
+	markerPath := filepath.Join(markerDir, ".npa_format_v2")
+	ipamPath := writeIpam(t, t.TempDir(), [][2]string{{"deny-me-0", "ns1"}})
+
+	legacyPin := progsDir + "deny-me-ns1_" + utils.TC_INGRESS_PROG
+	assert.NoError(t, os.WriteFile(legacyPin, []byte("x"), 0644))
+
+	// Block rename by making the destination a non-empty directory
+	// (os.Rename cannot overwrite a non-empty directory).
+	destBlocker := progsDir + "deny-me@ns1_" + utils.TC_INGRESS_PROG
+	assert.NoError(t, os.MkdirAll(destBlocker+"/subdir", 0755))
+
+	err := migrateLegacyPinsFromCNIState(progsDir, mapsDir, ipamPath, markerPath)
+	assert.Error(t, err, "migration must report failure when renames fail")
+	assert.Contains(t, err.Error(), "incomplete")
+
+	_, statErr := os.Stat(markerPath)
+	assert.True(t, os.IsNotExist(statErr), "marker must NOT be written when renames fail")
+
+	// Legacy pin must still be present (was not successfully renamed)
+	_, statErr = os.Stat(legacyPin)
+	assert.NoError(t, statErr, "legacy pin must be preserved on failed rename")
+}
+
+func TestLegacyGetPodIdentifier(t *testing.T) {
+	cases := []struct {
+		name, ns, want string
+	}{
+		{"deny-me-0", "ns1", "deny-me-ns1"},
+		{"deny-0", "me-ns1", "deny-me-ns1"},
+		{"web-frontend-0", "my-namespace", "web-frontend-my-namespace"},
+		{"aws-node-xyz", "kube-system", "aws-node-kube-system"},
+		{"my.pod-x", "ns1", "my_pod-ns1"},
+		{"foo", "bar", "foo-bar"},
+	}
+	for _, c := range cases {
+		got := utils.LegacyGetPodIdentifier(c.name, c.ns)
+		assert.Equal(t, c.want, got, "%s / %s", c.name, c.ns)
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -169,13 +169,34 @@ func GetPodNamespacedName(podName, podNamespace string) string {
 	return podName + "_" + podNamespace
 }
 
+// Separator is "@" because it is illegal in DNS-1123 pod names and namespaces,
+// making the identifier injective on (podName-prefix, podNamespace). "@" also
+// keeps pin filenames parseable by aws-ebpf-sdk-go, which splits on the first
+// "_" to find the suffix boundary; using "_" here would shadow that split.
 func GetPodIdentifier(podName, podNamespace string) string {
 	if strings.Contains(podName, ".") {
 		log().Debug("Replacing '.' character with '_' for pod pin path.")
 		podName = strings.Replace(podName, ".", "_", -1)
 	}
 	podIdentifierPrefix := podName
-	if strings.Contains(string(podName), "-") {
+	if strings.Contains(podName, "-") {
+		tmpName := strings.Split(podName, "-")
+		podIdentifierPrefix = strings.Join(tmpName[:len(tmpName)-1], "-")
+	}
+	return podIdentifierPrefix + "@" + podNamespace
+}
+
+// LegacyGetPodIdentifier replicates the pre-fix GetPodIdentifier algorithm
+// with the "-" separator. Used only by the legacy bpffs pin migration to
+// compute what a previously-running agent would have produced for a given
+// (podName, podNamespace) pair.
+// TODO: remove after the migration window closes.
+func LegacyGetPodIdentifier(podName, podNamespace string) string {
+	if strings.Contains(podName, ".") {
+		podName = strings.Replace(podName, ".", "_", -1)
+	}
+	podIdentifierPrefix := podName
+	if strings.Contains(podName, "-") {
 		tmpName := strings.Split(podName, "-")
 		podIdentifierPrefix = strings.Join(tmpName[:len(tmpName)-1], "-")
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -409,7 +409,7 @@ func TestGetPodIdentifier(t *testing.T) {
 				podName:      "hello-udp-748dc8d996-fb8b2",
 				podNamespace: "default",
 			},
-			want: "hello-udp-748dc8d996-default",
+			want: "hello-udp-748dc8d996@default",
 		},
 	}
 	for _, tt := range tests {
@@ -417,6 +417,24 @@ func TestGetPodIdentifier(t *testing.T) {
 			got := GetPodIdentifier(tt.args.podName, tt.args.podNamespace)
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+// Distinct (podName, podNamespace) pairs that aliased to the same podIdentifier
+// under the previous "-" separator must produce different identifiers now.
+func TestGetPodIdentifier_NoCrossNamespaceCollision(t *testing.T) {
+	pairs := [][2][2]string{
+		{{"deny-me-x", "ns1"}, {"deny", "me-ns1"}},
+		{{"a-b-c", "d"}, {"a", "b-c-d"}},
+		{{"deploy-app-x", "ns1"}, {"deploy", "app-x-ns1"}},
+		{{"deploy-app-abc-xyz", "kube-system"}, {"deploy", "app-abc-xyz-kube-system"}},
+		{{"my.pod-x", "ns"}, {"my_pod", "x-ns"}},
+		{{"my.pod-x", "ns"}, {"my-pod-x", "ns"}},
+	}
+	for _, p := range pairs {
+		left := GetPodIdentifier(p[0][0], p[0][1])
+		right := GetPodIdentifier(p[1][0], p[1][1])
+		assert.NotEqual(t, left, right, "distinct pods must not collide: %v vs %v", p[0], p[1])
 	}
 }
 
@@ -437,7 +455,7 @@ func TestGetDotPodIdentifier(t *testing.T) {
 				podName:      "my.pod.name-udp-748dc8d996-fb8b2",
 				podNamespace: "default",
 			},
-			want: "my_pod_name-udp-748dc8d996-default",
+			want: "my_pod_name-udp-748dc8d996@default",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
…e collisions

fix(utils): make GetPodIdentifier injective to prevent cross-namespace collisions

The per-pod BPF pin path key was "<stripped-pod-name>-<namespace>". Since
"-" is legal in both DNS-1123 pod names and namespaces, the boundary was
ambiguous: "deny-me-x"/"ns1" and "deny"/"me-ns1" both produced "deny-me-ns1",
so distinct pods shared programs and maps on a node. Switch the separator
to "@" (illegal in DNS-1123, accepted by bpffs, transparent to the SDK's
"_"-split pin parser).

On first startup, migrateLegacyPinsFromCNIState reads VPC CNI's
/var/run/aws-node/ipam.json and renames pin families <legacy>_* -> <new>_*
for each local pod. A marker at /var/run/aws-node/.npa_format_v2 makes the
migration a no-op on subsequent restarts.

Tests:
- Upgrade v1.3.1 → patched build: migration renamed all 16 legacy - pin families to @ format, marker written, agent log shows clean migration
- Cross-namespace identifier injectivity: GetPodIdentifier("deny-me-x", "ns1") and GetPodIdentifier("deny", "me-ns1") now produce distinct strings (deny-me@ns1 vs deny@me-ns1)
- unit tests 

