### PR TITLE
fix: cloudwatch log-level filtering

### DIFF
--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func main() {
 		npMode, isMultiNICEnabled := lo.Must2(getNetworkPolicyConfigsFromIpamd(log))
 
 		ebpfClient := lo.Must1(ebpf.NewBpfClient(ctx, nodeIP, ctrlConfig.EnablePolicyEventLogs, ctrlConfig.EnableCloudWatchLogs,
-			ctrlConfig.EnableIPv6, ctrlConfig.ConntrackCacheCleanupPeriod, ctrlConfig.ConntrackCacheTableSize, npMode, isMultiNICEnabled))
+			ctrlConfig.EnableIPv6, ctrlConfig.ConntrackCacheCleanupPeriod, ctrlConfig.ConntrackCacheTableSize, npMode, isMultiNICEnabled, ctrlConfig.LogLevel))
 		ebpfClient.ReAttachEbpfProbes()
 
 		policyEndpointController = controllers.NewPolicyEndpointsReconciler(mgr.GetClient(), nodeIP, ebpfClient, ctrlConfig.EnableIPv6)

--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -119,7 +119,7 @@ type BPFContext struct {
 }
 
 func NewBpfClient(ctx context.Context, nodeIP string, enablePolicyEventLogs, enableCloudWatchLogs bool,
-	enableIPv6 bool, conntrackTTL int, conntrackTableSize int, networkPolicyMode string, isMultiNICEnabled bool) (*bpfClient, error) {
+	enableIPv6 bool, conntrackTTL int, conntrackTableSize int, networkPolicyMode string, isMultiNICEnabled bool, logLevel string) (*bpfClient, error) {
 	var conntrackMap goebpfmaps.BpfMap
 
 	ebpfClient := &bpfClient{
@@ -249,7 +249,7 @@ func NewBpfClient(ctx context.Context, nodeIP string, enablePolicyEventLogs, ena
 	log().Info("Initialized Conntrack client")
 
 	if enablePolicyEventLogs {
-		err = events.ConfigurePolicyEventsLogging(enableCloudWatchLogs, eventBufferFD, enableIPv6)
+		err = events.ConfigurePolicyEventsLogging(enableCloudWatchLogs, eventBufferFD, enableIPv6, logLevel)
 		if err != nil {
 			log().Errorf("unable to initialize event buffer for Policy event exiting..error: %v", err)
 			sdkAPIErr.WithLabelValues("ConfigurePolicyEventsLogging").Inc()

--- a/pkg/ebpf/events/events.go
+++ b/pkg/ebpf/events/events.go
@@ -88,7 +88,7 @@ type ringBufferDataV6_t struct {
 	Tier       uint8
 }
 
-func ConfigurePolicyEventsLogging(enableCloudWatchLogs bool, mapFD int, enableIPv6 bool) error {
+func ConfigurePolicyEventsLogging(enableCloudWatchLogs bool, mapFD int, enableIPv6 bool, logLevel string) error {
 	// Enable logging and setup ring buffer
 	ctx := context.Background()
 	if mapFD <= 0 {
@@ -113,7 +113,7 @@ func ConfigurePolicyEventsLogging(enableCloudWatchLogs bool, mapFD int, enableIP
 			}
 		}
 		log().Debug("Configure Event loop ... ")
-		capturePolicyEvents(ctx, eventChanList[mapFD], enableCloudWatchLogs, enableIPv6)
+		capturePolicyEvents(ctx, eventChanList[mapFD], enableCloudWatchLogs, enableIPv6, logLevel)
 	}
 	return nil
 }
@@ -207,7 +207,7 @@ func publishDataToCloudwatch(ctx context.Context, logQueue []types.InputLogEvent
 	return true
 }
 
-func capturePolicyEvents(ctx context.Context, ringbufferdata <-chan []byte, enableCloudWatchLogs bool, enableIPv6 bool) {
+func capturePolicyEvents(ctx context.Context, ringbufferdata <-chan []byte, enableCloudWatchLogs bool, enableIPv6 bool, logLevel string) {
 	nodeName := os.Getenv("MY_NODE_NAME")
 	// Read from ringbuffer channel, perf buffer support is not there and 5.10 kernel is needed.
 	go func(ringbufferdata <-chan []byte) {
@@ -215,6 +215,7 @@ func capturePolicyEvents(ctx context.Context, ringbufferdata <-chan []byte, enab
 		for record := range ringbufferdata {
 			var logQueue []types.InputLogEvent
 			var message string
+			var isDenyVerdict bool
 			direction := "egress"
 			if enableIPv6 {
 				var rb ringBufferDataV6_t
@@ -232,6 +233,7 @@ func capturePolicyEvents(ctx context.Context, ringbufferdata <-chan []byte, enab
 				}
 
 				tier := getTier(int(rb.Tier))
+				isDenyVerdict = rb.Verdict == VerdictDeny
 
 				if rb.Verdict == VerdictDeny {
 					dropCountTotal.WithLabelValues(direction).Add(float64(1))
@@ -260,6 +262,7 @@ func capturePolicyEvents(ctx context.Context, ringbufferdata <-chan []byte, enab
 				}
 
 				tier := getTier(int(rb.Tier))
+				isDenyVerdict = rb.Verdict == VerdictDeny
 
 				if rb.Verdict == VerdictDeny {
 					dropCountTotal.WithLabelValues(direction).Add(float64(1))
@@ -274,9 +277,13 @@ func capturePolicyEvents(ctx context.Context, ringbufferdata <-chan []byte, enab
 			}
 
 			if enableCloudWatchLogs {
-				done = publishDataToCloudwatch(ctx, logQueue, message)
-				if done {
-					break
+				// Apply same filtering as local logging:
+				// DENY always published, ACCEPT only at debug level
+				if isDenyVerdict || logLevel == "debug" {
+					done = publishDataToCloudwatch(ctx, logQueue, message)
+					if done {
+						break
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #578

## Problem

When `--enable-cloudwatch-logs=true` is configured, ALL flow events (ACCEPT + DENY) are sent to CloudWatch regardless of `--log-level`. Local file logging correctly filters ACCEPT events (only emitted at debug level via Zap), but the CloudWatch path in `publishDataToCloudwatch()` has no equivalent filtering.

## Root Cause

In `pkg/ebpf/events/events.go`, `capturePolicyEvents()` builds the CloudWatch message unconditionally for every event and calls `publishDataToCloudwatch()` without checking the verdict or log level.

## Fix

Pass `logLevel` through `NewBpfClient` → `ConfigurePolicyEventsLogging` → `capturePolicyEvents`, and gate CloudWatch publishing:
- DENY events: always published (matches Info-level local logging)
- ACCEPT/EXPIRED_DELETED: only published when `logLevel == "debug"` (matches Debug-level local logging)

## Test

UT - Pass

E2E Test - Pass
**Config:** `--enable-cloudwatch-logs=true --enable-policy-event-logs=true --log-level=info`

**Setup:** NetworkPolicy allowing only `app=allowed` → `server:80`. Generated ACCEPT (allowed-client) and DENY (denied-client) traffic.

Before Fix:
Verified only local logs show DENY but not cloudwatch 

After fix:
Verified both local logs and CloudWatch show only DENY