### PR TITLE
Fix/podidentifier reverse migration

### DIFF
--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -182,6 +182,18 @@ func NewBpfClient(ctx context.Context, nodeIP string, enablePolicyEventLogs, ena
 	}
 	log().Info("Copied eBPF binaries to the host directory")
 
+	// Reverse migration: rename "@" separator pin files back to the legacy
+	// "-" format to prepare for downgrade to a pre-fix NPA version. Only
+	// runs if the forward migration marker (.npa_format_v2) is present.
+	if err := migrateReversePinsFromCNIState(
+		utils.BPF_PROGRAMS_PIN_PATH_DIRECTORY,
+		utils.BPF_MAPS_PIN_PATH_DIRECTORY,
+		cniIpamStatePath,
+		formatV2MarkerPath,
+	); err != nil {
+		log().Errorf("reverse pin migration failed (non-fatal): %v", err)
+	}
+
 	var interfaceNametoIngressPinPath map[string]string
 	var interfaceNametoEgressPinPath map[string]string
 	eventBufferFD := 0

--- a/pkg/ebpf/reverse_pin_migration.go
+++ b/pkg/ebpf/reverse_pin_migration.go
@@ -1,0 +1,175 @@
+package ebpf
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-network-policy-agent/pkg/utils"
+)
+
+const cniIpamStatePath = "/var/run/aws-node/ipam.json"
+const formatV2MarkerPath = "/var/run/aws-node/.npa_format_v2"
+
+type ipamAllocation struct {
+	Metadata struct {
+		K8sPodName      string `json:"k8sPodName"`
+		K8sPodNamespace string `json:"k8sPodNamespace"`
+	} `json:"metadata"`
+}
+
+type ipamStateFile struct {
+	Version     string           `json:"version"`
+	Allocations []ipamAllocation `json:"allocations"`
+}
+
+// v2GetPodIdentifier computes the "@"-format identifier that the forward
+// migration (PR #576) produces. Self-contained so this branch has no
+// dependency on the forward-fix branch.
+func v2GetPodIdentifier(podName, podNamespace string) string {
+	if strings.Contains(podName, ".") {
+		podName = strings.Replace(podName, ".", "-", -1)
+	}
+	podIdentifierPrefix := podName
+	if strings.Contains(podName, "-") {
+		tmpName := strings.Split(podName, "-")
+		podIdentifierPrefix = strings.Join(tmpName[:len(tmpName)-1], "-")
+	}
+	return podIdentifierPrefix + "@" + podNamespace
+}
+
+// legacyGetPodIdentifier computes the legacy "-"-format identifier (same as
+// the current GetPodIdentifier on main). Self-contained so the reverse
+// migration logic doesn't depend on the public function's signature.
+func legacyGetPodIdentifier(podName, podNamespace string) string {
+	if strings.Contains(podName, ".") {
+		podName = strings.Replace(podName, ".", "_", -1)
+	}
+	podIdentifierPrefix := podName
+	if strings.Contains(podName, "-") {
+		tmpName := strings.Split(podName, "-")
+		podIdentifierPrefix = strings.Join(tmpName[:len(tmpName)-1], "-")
+	}
+	return podIdentifierPrefix + "-" + podNamespace
+}
+
+// migrateReversePinsFromCNIState renames per-pod bpffs pin files from the
+// new "@" separator format back to the legacy "-" format. This enables a
+// clean downgrade to a pre-fix NPA version without workload restart.
+//
+// Only runs if the forward migration marker (.npa_format_v2) is present.
+// The v2 marker is the sole idempotency guard: once removed at the end,
+// subsequent calls are no-ops.
+func migrateReversePinsFromCNIState(progsDir, mapsDir, ipamPath, v2MarkerPath string) error {
+	if _, err := os.Stat(v2MarkerPath); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("checking v2 marker %s: %w", v2MarkerPath, err)
+	}
+
+	raw, err := os.ReadFile(ipamPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read CNI ipam state %s: %w", ipamPath, err)
+	}
+
+	var state ipamStateFile
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return fmt.Errorf("parse CNI ipam state %s: %w", ipamPath, err)
+	}
+
+	type migration struct {
+		newID    string
+		legacyID string
+		ns       string
+		name     string
+	}
+	seen := map[string]bool{}
+	var migrations []migration
+	for _, a := range state.Allocations {
+		if a.Metadata.K8sPodName == "" || a.Metadata.K8sPodNamespace == "" {
+			continue
+		}
+		v2ID := v2GetPodIdentifier(a.Metadata.K8sPodName, a.Metadata.K8sPodNamespace)
+		if seen[v2ID] {
+			continue
+		}
+		seen[v2ID] = true
+		legacyID := legacyGetPodIdentifier(a.Metadata.K8sPodName, a.Metadata.K8sPodNamespace)
+		if v2ID == legacyID {
+			continue
+		}
+		migrations = append(migrations, migration{
+			newID:    v2ID,
+			legacyID: legacyID,
+			ns:       a.Metadata.K8sPodNamespace,
+			name:     a.Metadata.K8sPodName,
+		})
+	}
+
+	for _, m := range migrations {
+		if cleaned := reverseRenamePinFamily(progsDir, mapsDir, m.newID, m.legacyID); cleaned > 0 {
+			log().Infof("reverse-migrated %d bpffs pin file(s) for %s/%s: %s -> %s",
+				cleaned, m.ns, m.name, m.newID, m.legacyID)
+		}
+	}
+
+	if err := os.Remove(v2MarkerPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log().Warnf("reverse migration: failed to remove v2 marker %s: %v", v2MarkerPath, err)
+	}
+	log().Infof("reverse pin migration complete; v2 marker removed at %s", v2MarkerPath)
+	return nil
+}
+
+func reverseRenamePinFamily(progsDir, mapsDir, srcID, dstID string) int {
+	cleaned := 0
+	for _, dir := range []string{"ingress", "egress"} {
+		progName := utils.TC_INGRESS_PROG
+		if dir == "egress" {
+			progName = utils.TC_EGRESS_PROG
+		}
+		if reverseRenamePinIfExists(progsDir+srcID+"_"+progName, progsDir+dstID+"_"+progName) {
+			cleaned++
+		}
+	}
+	for _, mapName := range []string{
+		utils.TC_INGRESS_MAP,
+		utils.TC_EGRESS_MAP,
+		utils.TC_CLUSTER_POLICY_INGRESS_MAP,
+		utils.TC_CLUSTER_POLICY_EGRESS_MAP,
+		utils.TC_INGRESS_POD_STATE_MAP,
+		utils.TC_EGRESS_POD_STATE_MAP,
+	} {
+		if reverseRenamePinIfExists(mapsDir+srcID+"_"+mapName, mapsDir+dstID+"_"+mapName) {
+			cleaned++
+		}
+	}
+	return cleaned
+}
+
+// reverseRenamePinIfExists renames src → dst, but if dst already exists
+// (the pre-fix agent created it with current rules), it removes the orphan
+// src instead to avoid overwriting active state.
+func reverseRenamePinIfExists(src, dst string) bool {
+	if _, err := os.Stat(src); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			log().Warnf("reverse pin migration: stat %s: %v", src, err)
+		}
+		return false
+	}
+	if _, err := os.Stat(dst); err == nil {
+		if err := os.Remove(src); err != nil {
+			log().Warnf("reverse pin migration: remove orphan %s: %v", src, err)
+		}
+		return true
+	}
+	if err := os.Rename(src, dst); err != nil {
+		log().Warnf("reverse pin migration: rename %s -> %s: %v", src, dst, err)
+		return false
+	}
+	return true
+}

--- a/pkg/ebpf/reverse_pin_migration_test.go
+++ b/pkg/ebpf/reverse_pin_migration_test.go
@@ -1,0 +1,154 @@
+package ebpf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/aws-network-policy-agent/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func writeIpam(t *testing.T, dir string, pods [][2]string) string {
+	t.Helper()
+	allocs := ""
+	for i, p := range pods {
+		if i > 0 {
+			allocs += ","
+		}
+		allocs += `{"metadata":{"k8sPodName":"` + p[0] + `","k8sPodNamespace":"` + p[1] + `"}}`
+	}
+	path := filepath.Join(dir, "ipam.json")
+	body := `{"version":"vpc-cni-ipam/1","allocations":[` + allocs + `]}`
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("write ipam: %v", err)
+	}
+	return path
+}
+
+func TestMigrateReversePins_HappyPath(t *testing.T) {
+	progsDir := t.TempDir() + "/"
+	mapsDir := t.TempDir() + "/"
+	markerDir := t.TempDir()
+	v2Marker := filepath.Join(markerDir, ".npa_format_v2")
+
+	ipamPath := writeIpam(t, t.TempDir(), [][2]string{
+		{"deny-me-0", "ns1"},
+		{"web-frontend-0", "my-namespace"},
+		{"aws-node-xyz", "kube-system"},
+	})
+
+	assert.NoError(t, os.WriteFile(v2Marker, []byte("v2\n"), 0644))
+
+	atFiles := []struct{ dir, name string }{
+		{progsDir, "deny-me@ns1_" + utils.TC_INGRESS_PROG},
+		{progsDir, "deny-me@ns1_" + utils.TC_EGRESS_PROG},
+		{mapsDir, "deny-me@ns1_" + utils.TC_INGRESS_MAP},
+		{mapsDir, "deny-me@ns1_" + utils.TC_EGRESS_POD_STATE_MAP},
+		{progsDir, "web-frontend@my-namespace_" + utils.TC_INGRESS_PROG},
+		{mapsDir, "web-frontend@my-namespace_" + utils.TC_CLUSTER_POLICY_INGRESS_MAP},
+		{progsDir, "aws-node@kube-system_" + utils.TC_INGRESS_PROG},
+		{mapsDir, "aws-node@kube-system_" + utils.TC_INGRESS_MAP},
+	}
+	for _, f := range atFiles {
+		assert.NoError(t, os.WriteFile(f.dir+f.name, []byte("x"), 0644))
+	}
+
+	err := migrateReversePinsFromCNIState(progsDir, mapsDir, ipamPath, v2Marker)
+	assert.NoError(t, err)
+
+	expectations := map[string]bool{
+		progsDir + "deny-me@ns1_" + utils.TC_INGRESS_PROG:                            false,
+		progsDir + "deny-me-ns1_" + utils.TC_INGRESS_PROG:                            true,
+		progsDir + "deny-me-ns1_" + utils.TC_EGRESS_PROG:                             true,
+		mapsDir + "deny-me-ns1_" + utils.TC_INGRESS_MAP:                              true,
+		mapsDir + "deny-me-ns1_" + utils.TC_EGRESS_POD_STATE_MAP:                     true,
+		progsDir + "web-frontend@my-namespace_" + utils.TC_INGRESS_PROG:              false,
+		progsDir + "web-frontend-my-namespace_" + utils.TC_INGRESS_PROG:              true,
+		mapsDir + "web-frontend@my-namespace_" + utils.TC_CLUSTER_POLICY_INGRESS_MAP: false,
+		mapsDir + "web-frontend-my-namespace_" + utils.TC_CLUSTER_POLICY_INGRESS_MAP: true,
+		progsDir + "aws-node@kube-system_" + utils.TC_INGRESS_PROG:                   false,
+		progsDir + "aws-node-kube-system_" + utils.TC_INGRESS_PROG:                   true,
+		mapsDir + "aws-node@kube-system_" + utils.TC_INGRESS_MAP:                     false,
+		mapsDir + "aws-node-kube-system_" + utils.TC_INGRESS_MAP:                     true,
+	}
+	for path, shouldExist := range expectations {
+		_, err := os.Stat(path)
+		if shouldExist {
+			assert.NoError(t, err, "expected %s to exist", path)
+		} else {
+			assert.True(t, os.IsNotExist(err), "expected %s to be gone", path)
+		}
+	}
+
+	_, err = os.Stat(v2Marker)
+	assert.True(t, os.IsNotExist(err), "v2 marker must be removed after reverse migration")
+}
+
+func TestMigrateReversePins_NoV2MarkerIsNoOp(t *testing.T) {
+	progsDir := t.TempDir() + "/"
+	mapsDir := t.TempDir() + "/"
+	markerDir := t.TempDir()
+	v2Marker := filepath.Join(markerDir, ".npa_format_v2")
+	ipamPath := writeIpam(t, t.TempDir(), [][2]string{{"deny-me-0", "ns1"}})
+
+	keep := progsDir + "deny-me@ns1_" + utils.TC_INGRESS_PROG
+	assert.NoError(t, os.WriteFile(keep, []byte("x"), 0644))
+
+	err := migrateReversePinsFromCNIState(progsDir, mapsDir, ipamPath, v2Marker)
+	assert.NoError(t, err)
+
+	_, err = os.Stat(keep)
+	assert.NoError(t, err, "pin file must be untouched when no v2 marker exists")
+}
+
+func TestMigrateReversePins_IdempotentAfterV2MarkerRemoved(t *testing.T) {
+	progsDir := t.TempDir() + "/"
+	mapsDir := t.TempDir() + "/"
+	markerDir := t.TempDir()
+	v2Marker := filepath.Join(markerDir, ".npa_format_v2")
+	ipamPath := writeIpam(t, t.TempDir(), [][2]string{{"deny-me-0", "ns1"}})
+
+	assert.NoError(t, os.WriteFile(v2Marker, []byte("v2\n"), 0644))
+
+	pin := progsDir + "deny-me@ns1_" + utils.TC_INGRESS_PROG
+	assert.NoError(t, os.WriteFile(pin, []byte("x"), 0644))
+
+	assert.NoError(t, migrateReversePinsFromCNIState(progsDir, mapsDir, ipamPath, v2Marker))
+	_, err := os.Stat(progsDir + "deny-me-ns1_" + utils.TC_INGRESS_PROG)
+	assert.NoError(t, err, "first run must reverse the pin")
+	_, err = os.Stat(v2Marker)
+	assert.True(t, os.IsNotExist(err), "v2 marker must be gone after first run")
+
+	fresh := progsDir + "another@ns1_" + utils.TC_INGRESS_PROG
+	assert.NoError(t, os.WriteFile(fresh, []byte("x"), 0644))
+
+	assert.NoError(t, migrateReversePinsFromCNIState(progsDir, mapsDir, ipamPath, v2Marker))
+	_, err = os.Stat(fresh)
+	assert.NoError(t, err, "second run must not process pins since v2 marker is absent")
+}
+
+func TestMigrateReversePins_DoesNotOverwriteExistingLegacyPins(t *testing.T) {
+	progsDir := t.TempDir() + "/"
+	mapsDir := t.TempDir() + "/"
+	markerDir := t.TempDir()
+	v2Marker := filepath.Join(markerDir, ".npa_format_v2")
+	ipamPath := writeIpam(t, t.TempDir(), [][2]string{{"deny-me-0", "ns1"}})
+
+	assert.NoError(t, os.WriteFile(v2Marker, []byte("v2\n"), 0644))
+
+	orphan := progsDir + "deny-me@ns1_" + utils.TC_INGRESS_PROG
+	assert.NoError(t, os.WriteFile(orphan, []byte("stale-data"), 0644))
+
+	active := progsDir + "deny-me-ns1_" + utils.TC_INGRESS_PROG
+	assert.NoError(t, os.WriteFile(active, []byte("current-rules"), 0644))
+
+	assert.NoError(t, migrateReversePinsFromCNIState(progsDir, mapsDir, ipamPath, v2Marker))
+
+	_, err := os.Stat(orphan)
+	assert.True(t, os.IsNotExist(err), "orphan @ pin must be removed")
+
+	content, err := os.ReadFile(active)
+	assert.NoError(t, err)
+	assert.Equal(t, "current-rules", string(content), "active - pin must not be overwritten")
+}


### PR DESCRIPTION
fix(ebpf): add reverse pin migration for safe downgrade from @-separator fix

Adds migrateReversePinsFromCNIState which renames per-pod bpffs pin files
from the "@" format (produced by PR #576) back to the legacy "-" format.
This enables a clean downgrade to pre-fix NPA versions without workload
restart or enforcement loss.

Trigger: presence of /var/run/aws-node/.npa_format_v2 marker (written by
the forward migration). After renaming, the marker is removed — making
subsequent restarts no-ops.

This image also reverts GetPodIdentifier to the legacy "-" separator so
any new pods created while it runs get "-"-format pins, consistent with
the downgraded agent.

Usage: deploy this image as a transition step between the fix image and
the pre-fix image. Enforcement is preserved throughout.