### PR TITLE
fix(deps): bump Go minimum version to 1.26.4 to resolve stdlib vulnerabilities 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/aws-network-policy-agent
 
-go 1.26.1
+go 1.26.4
 
 require (
 	github.com/aws/amazon-vpc-cni-k8s v1.20.0


### PR DESCRIPTION
bump Go minimum version to 1.26.4 to resolve stdlib vulnerabilities 
Addresses GO-2026-5039 (net/textproto), GO-2026-5038 (mime), and GO-2026-5037 (crypto/x509) by raising the go directive in go.mod from 1.26.1 to 1.26.4.

