### PR TITLE
fix: restore egress catch-all in cleanupPod for Ingress-only pods (#591)

### DIFF
--- a/controllers/policyendpoints_controller.go
+++ b/controllers/policyendpoints_controller.go
@@ -394,10 +394,18 @@ func (r *PolicyEndpointsReconciler) cleanupPod(ctx context.Context, targetPod np
 			// Update the Maps and move on
 			log().Infof("Active policies against this pod. Skip Detaching probes and Update Maps... ")
 			if noActiveIngressPolicies {
-				// No active ingress rules for this pod, but we only should land here
-				// if there are active egress rules. So, we need to add an allow-all entry to ingress rule set
+				// No active ingress rules for this pod (only egress rules remain).
+				// Add an allow-all entry to ingress rule set so non-egress traffic isn't dropped.
 				log().Info("No Ingress rules and no ingress isolation - Appending catch all entry")
 				r.addCatchAllEntry(&ingressRules)
+			}
+			if noActiveEgressPolicies {
+				// No active egress rules for this pod (only ingress rules remain).
+				// Add an allow-all entry to egress rule set so egress isn't dropped.
+				// Without this, egress_map ends up empty while egress_pod_state_map stays
+				// at POLICIES_APPLIED, and the eBPF dataplane drops all egress traffic.
+				log().Info("No Egress rules and no egress isolation - Appending catch all entry")
+				r.addCatchAllEntry(&egressRules)
 			}
 
 			err = r.updateeBPFMaps(podIdentifier, ingressRules, egressRules, ebpf.POLICIES_APPLIED)

--- a/controllers/policyendpoints_controller.go
+++ b/controllers/policyendpoints_controller.go
@@ -394,16 +394,16 @@ func (r *PolicyEndpointsReconciler) cleanupPod(ctx context.Context, targetPod np
 			// Update the Maps and move on
 			log().Infof("Active policies against this pod. Skip Detaching probes and Update Maps... ")
 			if noActiveIngressPolicies {
-				// No active ingress rules for this pod (only egress rules remain).
-				// Add an allow-all entry to ingress rule set so non-egress traffic isn't dropped.
+				// Add an allow-all entry to ingress rule set so ingress traffic
+				// isn't dropped by the eBPF dataplane.
 				log().Info("No Ingress rules and no ingress isolation - Appending catch all entry")
 				r.addCatchAllEntry(&ingressRules)
 			}
 			if noActiveEgressPolicies {
-				// No active egress rules for this pod (only ingress rules remain).
-				// Add an allow-all entry to egress rule set so egress isn't dropped.
-				// Without this, egress_map ends up empty while egress_pod_state_map stays
-				// at POLICIES_APPLIED, and the eBPF dataplane drops all egress traffic.
+				// Add an allow-all entry to egress rule set so egress traffic
+				// isn't dropped by the eBPF dataplane. Without this, egress_map
+				// ends up not having the catch all rule while pod_state_map stays
+				// at POLICIES_APPLIED and the eBPF dataplane drops all egress traffic.
 				log().Info("No Egress rules and no egress isolation - Appending catch all entry")
 				r.addCatchAllEntry(&egressRules)
 			}

--- a/controllers/policyendpoints_controller_test.go
+++ b/controllers/policyendpoints_controller_test.go
@@ -1437,3 +1437,121 @@ func TestCleanupPod_PreservesCatchAllOnRemainingPolicy(t *testing.T) {
 	assert.NotContains(t, mockBpf.LastIngressRules, catchAll)
 	assert.NotEmpty(t, mockBpf.LastIngressRules)
 }
+
+// Symmetric variant of TestCleanupPod_PreservesCatchAllOnRemainingPolicy:
+// after cleaning up one of N Egress-only NPs selecting a pod, the ingress rules
+// written to the bpf client must contain the 0.0.0.0/0 catch-all so that
+// ingress_map stays consistent with pod_state=POLICIES_APPLIED.
+func TestCleanupPod_EgressOnlyAddsIngressCatchAll(t *testing.T) {
+	protocolTCP := corev1.ProtocolTCP
+	var port80 int32 = 80
+
+	namespace := "my-namespace"
+	podIdentifier := "deployment1rs@my-namespace"
+	cleanedUpPE := "egress-1-abcd"
+	remainingPE := "egress-2-abcd"
+
+	remainingPolicy := policyendpoint.PolicyEndpoint{
+		ObjectMeta: metav1.ObjectMeta{Name: remainingPE, Namespace: namespace},
+		Spec: policyendpoint.PolicyEndpointSpec{
+			PodSelector: &metav1.LabelSelector{},
+			PolicyRef:   policyendpoint.PolicyReference{Name: "egress-2", Namespace: namespace},
+			Egress: []policyendpoint.EndpointInfo{
+				{
+					CIDR:  "10.0.0.0/24",
+					Ports: []policyendpoint.Port{{Port: &port80, Protocol: &protocolTCP}},
+				},
+			},
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := mock_client.NewMockClient(ctrl)
+	mockBpf := &ebpf.MockBpfClient{}
+	r := NewPolicyEndpointsReconciler(mockClient, "1.1.1.1", mockBpf, false)
+	r.podIdentifierToPolicyEndpointMap.Store(podIdentifier, []string{remainingPE})
+
+	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: remainingPE, Namespace: namespace}, gomock.Any()).DoAndReturn(
+		func(ctx context.Context, key types.NamespacedName, currentPE *policyendpoint.PolicyEndpoint, opts ...client.GetOption) error {
+			*currentPE = remainingPolicy
+			return nil
+		},
+	).AnyTimes()
+
+	targetPod := npatypes.Pod{
+		NamespacedName: types.NamespacedName{Name: "deployment1rs-1", Namespace: namespace},
+		PodIP:          "10.1.1.1",
+	}
+
+	err := r.cleanupPod(context.Background(), targetPod, cleanedUpPE, true)
+	assert.NoError(t, err)
+
+	catchAll := fwrp.EbpfFirewallRules{IPCidr: "0.0.0.0/0"}
+	assert.Contains(t, mockBpf.LastIngressRules, catchAll)
+	assert.NotContains(t, mockBpf.LastEgressRules, catchAll)
+	assert.NotEmpty(t, mockBpf.LastEgressRules)
+}
+
+// When the remaining PolicyEndpoint has BOTH ingress and egress rules,
+// neither side should get a 0.0.0.0/0 catch-all appended on cleanup —
+// the existing rule sets are non-empty so the dataplane will not drop traffic.
+func TestCleanupPod_BothDirectionsActiveNoCatchAll(t *testing.T) {
+	protocolTCP := corev1.ProtocolTCP
+	var port80 int32 = 80
+
+	namespace := "my-namespace"
+	podIdentifier := "deployment1rs@my-namespace"
+	cleanedUpPE := "ingress-1-abcd"
+	remainingPE := "mixed-2-abcd"
+
+	remainingPolicy := policyendpoint.PolicyEndpoint{
+		ObjectMeta: metav1.ObjectMeta{Name: remainingPE, Namespace: namespace},
+		Spec: policyendpoint.PolicyEndpointSpec{
+			PodSelector: &metav1.LabelSelector{},
+			PolicyRef:   policyendpoint.PolicyReference{Name: "mixed-2", Namespace: namespace},
+			Ingress: []policyendpoint.EndpointInfo{
+				{
+					CIDR:  "10.0.0.0/24",
+					Ports: []policyendpoint.Port{{Port: &port80, Protocol: &protocolTCP}},
+				},
+			},
+			Egress: []policyendpoint.EndpointInfo{
+				{
+					CIDR:  "10.0.1.0/24",
+					Ports: []policyendpoint.Port{{Port: &port80, Protocol: &protocolTCP}},
+				},
+			},
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := mock_client.NewMockClient(ctrl)
+	mockBpf := &ebpf.MockBpfClient{}
+	r := NewPolicyEndpointsReconciler(mockClient, "1.1.1.1", mockBpf, false)
+	r.podIdentifierToPolicyEndpointMap.Store(podIdentifier, []string{remainingPE})
+
+	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: remainingPE, Namespace: namespace}, gomock.Any()).DoAndReturn(
+		func(ctx context.Context, key types.NamespacedName, currentPE *policyendpoint.PolicyEndpoint, opts ...client.GetOption) error {
+			*currentPE = remainingPolicy
+			return nil
+		},
+	).AnyTimes()
+
+	targetPod := npatypes.Pod{
+		NamespacedName: types.NamespacedName{Name: "deployment1rs-1", Namespace: namespace},
+		PodIP:          "10.1.1.1",
+	}
+
+	err := r.cleanupPod(context.Background(), targetPod, cleanedUpPE, true)
+	assert.NoError(t, err)
+
+	catchAll := fwrp.EbpfFirewallRules{IPCidr: "0.0.0.0/0"}
+	assert.NotContains(t, mockBpf.LastIngressRules, catchAll)
+	assert.NotContains(t, mockBpf.LastEgressRules, catchAll)
+	assert.NotEmpty(t, mockBpf.LastIngressRules)
+	assert.NotEmpty(t, mockBpf.LastEgressRules)
+}

--- a/controllers/policyendpoints_controller_test.go
+++ b/controllers/policyendpoints_controller_test.go
@@ -1381,3 +1381,59 @@ func TestUpdateClusterPolicyBPFMaps_FailClosed(t *testing.T) {
 		return r.updateClusterPolicyBPFMaps("test-pod-id", nil, nil)
 	})
 }
+
+// Regression test for the asymmetric catch-all bug in cleanupPod (issue #591):
+// after cleaning up one of N Ingress-only NPs selecting a pod, the egress rules
+// written to the bpf client must still contain the 0.0.0.0/0 catch-all so that
+// egress_map stays consistent with pod_state=POLICIES_APPLIED.
+func TestCleanupPod_PreservesCatchAllOnRemainingPolicy(t *testing.T) {
+	protocolTCP := corev1.ProtocolTCP
+	var port80 int32 = 80
+
+	namespace := "my-namespace"
+	podIdentifier := "deployment1rs@my-namespace"
+	cleanedUpPE := "ingress-1-abcd"
+	remainingPE := "ingress-2-abcd"
+
+	remainingPolicy := policyendpoint.PolicyEndpoint{
+		ObjectMeta: metav1.ObjectMeta{Name: remainingPE, Namespace: namespace},
+		Spec: policyendpoint.PolicyEndpointSpec{
+			PodSelector: &metav1.LabelSelector{},
+			PolicyRef:   policyendpoint.PolicyReference{Name: "ingress-2", Namespace: namespace},
+			Ingress: []policyendpoint.EndpointInfo{
+				{
+					CIDR:  "10.0.0.0/24",
+					Ports: []policyendpoint.Port{{Port: &port80, Protocol: &protocolTCP}},
+				},
+			},
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := mock_client.NewMockClient(ctrl)
+	mockBpf := &ebpf.MockBpfClient{}
+	r := NewPolicyEndpointsReconciler(mockClient, "1.1.1.1", mockBpf, false)
+	r.podIdentifierToPolicyEndpointMap.Store(podIdentifier, []string{remainingPE})
+
+	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: remainingPE, Namespace: namespace}, gomock.Any()).DoAndReturn(
+		func(ctx context.Context, key types.NamespacedName, currentPE *policyendpoint.PolicyEndpoint, opts ...client.GetOption) error {
+			*currentPE = remainingPolicy
+			return nil
+		},
+	).AnyTimes()
+
+	targetPod := npatypes.Pod{
+		NamespacedName: types.NamespacedName{Name: "deployment1rs-1", Namespace: namespace},
+		PodIP:          "10.1.1.1",
+	}
+
+	err := r.cleanupPod(context.Background(), targetPod, cleanedUpPE, true)
+	assert.NoError(t, err)
+
+	catchAll := fwrp.EbpfFirewallRules{IPCidr: "0.0.0.0/0"}
+	assert.Contains(t, mockBpf.LastEgressRules, catchAll)
+	assert.NotContains(t, mockBpf.LastIngressRules, catchAll)
+	assert.NotEmpty(t, mockBpf.LastIngressRules)
+}

--- a/pkg/ebpf/bpf_client_mock.go
+++ b/pkg/ebpf/bpf_client_mock.go
@@ -32,6 +32,10 @@ type MockBpfClient struct {
 	UpdateClusterPolicyEbpfMapsErr        error
 	UpdatePodStateEbpfMapsErr             error
 	CreatePodStateEbpfEntryIfNotExistsErr error
+
+	// Captured args from the most recent UpdateEbpfMaps call.
+	LastIngressRules []fwrp.EbpfFirewallRules
+	LastEgressRules  []fwrp.EbpfFirewallRules
 }
 
 func (m *MockBpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier string, numInterfaces int) error {
@@ -46,6 +50,8 @@ func (m *MockBpfClient) DeleteBPFProbes(pod types.NamespacedName, podIdentifier 
 
 func (m *MockBpfClient) UpdateEbpfMaps(podIdentifier string, ingressFirewallRules []fwrp.EbpfFirewallRules, egressFirewallRules []fwrp.EbpfFirewallRules) error {
 	m.CallLog = append(m.CallLog, "UpdateEbpfMaps")
+	m.LastIngressRules = ingressFirewallRules
+	m.LastEgressRules = egressFirewallRules
 	return m.UpdateEbpfMapsErr
 }
 


### PR DESCRIPTION
## What

Restores the `0.0.0.0/0` egress catch-all entry in `cleanupPod` for pods that are still selected by other NetworkPolicies but have no active Egress policy.

## Why

The apply path (`reconcilePolicyEndpoint`, [L218–L227](https://github.com/aws/aws-network-policy-agent/blob/main/controllers/policyendpoints_controller.go#L218-L227)) is symmetric — it adds a catch-all to whichever rule set is empty *and* not isolated:

```go
if len(ingressRules) == 0 && !isIngressIsolated {
    r.addCatchAllEntry(&ingressRules)
}
if len(egressRules) == 0 && !isEgressIsolated {
    r.addCatchAllEntry(&egressRules)
}
```

The cleanup path (`cleanupPod`, [L391–L401](https://github.com/aws/aws-network-policy-agent/blob/main/controllers/policyendpoints_controller.go#L391-L401)) is asymmetric — it adds the catch-all to `ingressRules` only:

```go
} else {
    log().Infof("Active policies against this pod. Skip Detaching probes and Update Maps... ")
    if noActiveIngressPolicies {
        r.addCatchAllEntry(&ingressRules)
    }
    // missing: symmetric branch for noActiveEgressPolicies
    err = r.updateeBPFMaps(podIdentifier, ingressRules, egressRules, ebpf.POLICIES_APPLIED)
}
```

For a pod selected by N Ingress-only NetworkPolicies (`policyTypes: [Ingress]` only — the default and overwhelmingly common case), after deleting one of them:

- `deriveIngressAndEgressFirewallRules` returns `ingressRules=[N-1 rules]`, `egressRules=[]`, `isEgressIsolated=false`
- `noActiveIngressPolicies=false`, `noActiveEgressPolicies=true`
- Else branch entered; ingress catch-all not added (no-op since ingressRules is non-empty); **egress catch-all never written**
- `updateeBPFMaps(..., POLICIES_APPLIED)` writes the empty egress rule set → `egress_map` loses `0.0.0.0/0`
- `egress_pod_state_map` correctly stays at `POLICIES_APPLIED`

The eBPF program in [`pkg/ebpf/c/tc.v4egress.bpf.c::evaluateNamespacePolicyByLookUp`](https://github.com/aws/aws-network-policy-agent/blob/main/pkg/ebpf/c/tc.v4egress.bpf.c#L154-L165) then drops everything:

```c
struct lpm_trie_val *trie_val = bpf_map_lookup_elem(&egress_map, &trie_key);
if (trie_val == NULL) {
    if (pod_state != POLICIES_APPLIED) {
        return ACTION_PASS;
    }
    return ACTION_DENY;          // <-- hit: pod_state == POLICIES_APPLIED, egress_map empty
}
```

Net effect: silent egress black-hole on every pod the deleted Ingress NP selected, until the next NetworkPolicy write to that namespace triggers `reconcilePolicyEndpoint` (apply path, symmetric) which re-writes the catch-all.

GitOps controllers with `selfHeal: true` mask this in production because their re-apply loop heals the breakage within 1–3 seconds — long enough to drop in-flight egress connections (visible as transient DNS/connect failures correlated with NP churn), short enough to escape HTTP-level synthetic tests. Triggering the bug via `kubectl delete` on a cluster with selfHeal disabled produces persistent, deterministic egress drop until any subsequent NP write.

## Fix

Add the missing symmetric branch in `cleanupPod`:

```go
if noActiveEgressPolicies {
    log().Info("No Egress rules and no egress isolation - Appending catch all entry")
    r.addCatchAllEntry(&egressRules)
}
```

This mirrors the existing logic in `reconcilePolicyEndpoint` and re-establishes the invariant that `egress_map` and `egress_pod_state_map` agree on the pod's egress mode.

## Tests

New unit test `TestCleanupPod_PreservesCatchAllOnRemainingPolicy` exercises the exact bug:
- Pod selected by two Ingress-only NPs
- One is cleaned up; the other remains
- Asserts the egress rules written to the bpf client contain `0.0.0.0/0`
- Asserts ingress rules from the remaining NP are written unchanged

Verified the test **fails on `main`** and **passes with the fix**.

Also added `LastIngressRules` / `LastEgressRules` capture fields on `MockBpfClient` so future tests can assert against rule-map writes. Existing tests (`TestAddCatchAllEntry`, `TestPolicyEndpointReconcile`, `TestDeriveIngressAndEgressFirewallRules`, `TestUpdateeBPFMaps_FailClosed`, `TestUpdateClusterPolicyBPFMaps_FailClosed`, etc.) continue to pass — the capture fields default to nil and don't affect existing call-log assertions.

## Related

Closes #591. Verified in EKS 1.33 with agent `v1.3.1-eksbuild.1` and the workaround documented in the issue (explicit `allow-egress-all` NP) is no longer needed after this fix.

cc @jaydeokar — per your comment on the issue.
