### PR TITLE
feat: embed version and build metadata in NPA binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,20 @@ GO_ENV_EBPF += GOARCH=$(GO_ARCH)
 GO_ENV_EBPF += CGO_CFLAGS=$(CUSTOM_CGO_CFLAGS)
 GO_ENV_EBPF += CGO_LDFLAGS=$(CUSTOM_CGO_LDFLAGS)
 
+# Version metadata injection
+GIT_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "unknown")
+BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
+EBPF_SDK_VERSION ?= $(shell go list -m -f '{{.Version}}' github.com/aws/aws-ebpf-sdk-go 2>/dev/null || echo "unknown")
+# Freeze values so all binaries built in this make invocation get identical metadata
+GIT_VERSION := $(GIT_VERSION)
+BUILD_DATE := $(BUILD_DATE)
+EBPF_SDK_VERSION := $(EBPF_SDK_VERSION)
+VERSION_PKG := github.com/aws/aws-network-policy-agent/pkg/version
+VERSION_LDFLAGS := -X $(VERSION_PKG).GitVersion=$(GIT_VERSION) -X $(VERSION_PKG).BuildDate=$(BUILD_DATE) -X $(VERSION_PKG).EbpfSDKVersion=$(EBPF_SDK_VERSION)
+
 # Build using the host's Go toolchain.
 BUILD_MODE ?= -buildmode=pie
-build-linux: BUILD_FLAGS = $(BUILD_MODE) -ldflags '-s -w $(LDFLAGS) -extldflags "-static"'
+build-linux: BUILD_FLAGS = $(BUILD_MODE) -ldflags '-s -w $(LDFLAGS) $(VERSION_LDFLAGS) -extldflags "-static"'
 build-linux: ## Build the controllerusing the host's Go toolchain.
 	$(GO_ENV_EBPF) go build $(VENDOR_OVERRIDE_FLAG) $(BUILD_FLAGS) -tags netgo,ebpf,core -a -o controller main.go
 	go build $(VENDOR_OVERRIDE_FLAG) $(BUILD_FLAGS) -o aws-eks-na-cli ./cmd/cli

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/aws-network-policy-agent/pkg/rpcclient"
 	"github.com/aws/aws-network-policy-agent/pkg/utils"
 	"github.com/aws/aws-network-policy-agent/pkg/utils/imds"
+	"github.com/aws/aws-network-policy-agent/pkg/version"
 	"github.com/samber/lo"
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -74,7 +75,7 @@ func main() {
 		os.Exit(1)
 	}
 	log := logger.New(ctrlConfig.LogLevel, ctrlConfig.LogFile, ctrlConfig.LogFileMaxSize, ctrlConfig.LogFileMaxBackups)
-	log.Infof("Starting network policy agent with log level: %s", ctrlConfig.LogLevel)
+	log.Infof("Starting network policy agent: %s, log level: %s", version.String(), ctrlConfig.LogLevel)
 
 	ctrl.SetLogger(logger.GetControllerRuntimeLogger())
 	if ctrlConfig.EnableProfiling {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,13 @@
 package version
 
+import "fmt"
+
 var (
-	GitVersion string
-	GitCommit  string
-	BuildDate  string
+	GitVersion     = "unknown"
+	BuildDate      = "unknown"
+	EbpfSDKVersion = "unknown"
 )
+
+func String() string {
+	return fmt.Sprintf("%s (built: %s, ebpf-sdk: %s)", GitVersion, BuildDate, EbpfSDKVersion)
+}


### PR DESCRIPTION
## Summary
Stamp version and build metadata into the NPA binary via ldflags so it is logged at startup for runtime diagnosis.
  
Changes:
  - pkg/version/version.go: New file with GitVersion, BuildDate, EbpfSdkVersion variables (defaulting to "unknown") and a String() helper
  - main.go: Startup log now includes version.String() output
  - Makefile: Added VERSION_LDFLAGS that injects git version, build date, and ebpf SDK version at compile time

At build time, the Makefile resolves:
  | Variable | Source |
  |----------|--------|
  | `GIT_VERSION` | `git describe --tags --always --dirty` |
  | `BUILD_DATE` | `date -u +%Y-%m-%dT%H:%M:%SZ` |
  | `EBPF_SDK_VERSION` | `go list -m -f '{{.Version}}' github.com/aws/aws-ebpf-sdk-go` |
  
  These are injected into the binary via ldflags (`-X pkg/version.GitVersion=...`).
  
  If any command fails (e.g., no .git directory), the value defaults to "unknown".

  ## Testing 
  - Built locally with Go 1.26.4, confirmed startup log shows all metadata fields
  - Deployed test image to dev cluster, verified log output in /var/log/aws-routed-eni/network-policy-agent.log
  - Unstamped binary (no ldflags) correctly shows unknown (built: unknown, ebpf-sdk: unknown)
 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
