### PR TITLE
Connect to IPAMD via Unix socket and add timeout to ipamd conn

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"time"
 
 	cnirpc "github.com/aws/amazon-vpc-cni-k8s/rpc"
 	"github.com/aws/aws-network-policy-agent/pkg/ebpf"
@@ -54,7 +55,7 @@ import (
 
 var (
 	scheme              = runtime.NewScheme()
-	LOCAL_IPAMD_ADDRESS = "127.0.0.1:50051"
+	LOCAL_IPAMD_ADDRESS = "unix:///var/run/aws-node/ipamd.sock"
 	npaSocketPath       = "/var/run/aws-node/npa.sock"
 )
 
@@ -115,7 +116,7 @@ func main() {
 			nodeIP = lo.Must1(imds.GetMetaData("ipv6"))
 		}
 
-		npMode, isMultiNICEnabled := lo.Must2(getNetworkPolicyConfigsFromIpamd(log))
+		npMode, isMultiNICEnabled := lo.Must2(getNetworkPolicyConfigsFromIpamd(ctx, log))
 
 		ebpfClient := lo.Must1(ebpf.NewBpfClient(ctx, nodeIP, ctrlConfig.EnablePolicyEventLogs, ctrlConfig.EnableCloudWatchLogs,
 			ctrlConfig.EnableIPv6, ctrlConfig.ConntrackCacheCleanupPeriod, ctrlConfig.ConntrackCacheTableSize, npMode, isMultiNICEnabled, ctrlConfig.LogLevel))
@@ -184,14 +185,13 @@ func loadControllerConfig() (config.ControllerConfig, error) {
 	return controllerConfig, nil
 }
 
-func getNetworkPolicyConfigsFromIpamd(log logger.Logger) (string, bool, error) {
-	ctx := context.Background()
-
-	// grpc connection waits till the ipmad is up and running
-	log.Info("Trying to establish GRPC connection to ipamd")
+func getNetworkPolicyConfigsFromIpamd(ctx context.Context, log logger.Logger) (string, bool, error) {
+	log.Infof("Trying to establish GRPC connection to ipamd at %s", LOCAL_IPAMD_ADDRESS)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 	grpcConn, err := rpcclient.New().Dial(ctx, LOCAL_IPAMD_ADDRESS, rpcclient.GetDefaultServiceRetryConfig(), rpcclient.GetInsecureConnectionType())
 	if err != nil {
-		log.Errorf("Failed to connect to ipamd %v", err)
+		log.Errorf("Failed to connect to ipamd at %s: %v", LOCAL_IPAMD_ADDRESS, err)
 		return "", false, err
 	}
 	defer grpcConn.Close()
@@ -202,7 +202,7 @@ func getNetworkPolicyConfigsFromIpamd(log logger.Logger) (string, bool, error) {
 		log.Errorf("Failed to get network policy configs %v", err)
 		return "", false, err
 	}
-	log.Infof("Connected to ipamd grpc endpoint. NetworkPolicyMode: %s MultiNICEnabled: %v", resp.NetworkPolicyMode, resp.MultiNICEnabled)
+	log.Infof("Connected to ipamd at %s. NetworkPolicyMode: %s MultiNICEnabled: %v", LOCAL_IPAMD_ADDRESS, resp.NetworkPolicyMode, resp.MultiNICEnabled)
 	if !utils.IsValidNetworkPolicyEnforcingMode(resp.NetworkPolicyMode) {
 		err = errors.New("Invalid Network Policy Mode")
 		log.Errorf("Invalid Network Policy Mode from ipamd %s error: %v", resp.NetworkPolicyMode, err)


### PR DESCRIPTION
Switch LOCAL_IPAMD_ADDRESS from TCP 127.0.0.1:50051 to unix:///var/run/aws-node/ipamd.sock to match the VPC CNI change that removes the TCP gRPC listener from IPAMD.

Add a 30-second timeout to the IPAMD gRPC connection attempt. Previously context.Background() with waitForReady caused NPA to hang indefinitely and aws-node shows 2/2 ready. With the timeout, NPA crashes on failure, making the issue visible via restart counts and logs.

The timeout context inherits from the signal handler context so it is also cancelled on SIGTERM for clean shutdown.

*Issue #, if available:*

*Description of changes:*
follow up on the IPAMD change: https://github.com/aws/amazon-vpc-cni-k8s/pull/3739

Tested in dev cluster.

Before the fix, with VPC CNI change, NPA hanged indefinitely to connect IPAMD
```
{"level":"info","ts":"2026-07-07T18:04:52.600Z","caller":"runtime/proc.go:290","msg":"Starting network policy agent with log level: debug"}
  {"level":"info","ts":"2026-07-07T18:04:52.601Z","caller":"runtime/proc.go:290","msg":"Network Policy is enabled, checking CRDs..."}
  {"level":"info","ts":"2026-07-07T18:04:52.626Z","caller":"runtime/proc.go:290","msg":"CRD found in the required GVK resource clusterpolicyendpoints"}
  {"level":"info","ts":"2026-07-07T18:04:52.628Z","caller":"workspace/main.go:142","msg":"Trying to establish GRPC connection to ipamd"}
```
After the fix, IPAMD conn established via unix socket path
```
  {"level":"info","ts":"2026-07-07T18:06:58.758Z","caller":"workspace/main.go:118","msg":"Trying to establish GRPC connection to ipamd"}
  {"level":"info","ts":"2026-07-07T18:06:59.760Z","caller":"workspace/main.go:118","msg":"Connected to ipamd grpc endpoint. NetworkPolicyMode: standard MultiNICEnabled: false"}
```
Negative test, npa timeout at 30s if no ipamd conn established
```
  {"level":"info","ts":"2026-07-07T21:09:08.285Z","caller":"workspace/main.go:119","msg":"Trying to establish GRPC connection to ipamd at unix:///var/run/aws-node/ipamd.sock"}
  {"level":"error","ts":"2026-07-07T21:09:38.285Z","caller":"workspace/main.go:119","msg":"Failed to get network policy configs rpc error: code = DeadlineExceeded desc = latest balancer error: connection error: desc = \"transport: Error while dialing: dial unix /var/run/aws-node/ipamd.sock: connect: no such file or directory\""}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
