### PR TITLE
Support addon-distribution pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build the manager binary
 ARG golang_image
+ARG base_image
 
 FROM $golang_image as builder
 
@@ -45,7 +46,7 @@ COPY --from=vmlinuxbuilder /vmlinuxbuilder/pkg/ebpf/c/vmlinux.h ./pkg/ebpf/c/
 RUN make build-bpf
 
 # Container base image
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest-al23
+FROM ${base_image}
 
 WORKDIR /
 COPY --from=builder /workspace/controller .

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ VERSION ?= $(shell git describe --tags --always --dirty || echo "unknown")
 IMAGE_NAME ?= $(IMAGE)$(IMAGE_ARCH_SUFFIX):$(VERSION)
 GOLANG_VERSION ?= $(shell cat .go-version)
 GOLANG_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/golang:$(GOLANG_VERSION)-gcc-al23
+# BASE_IMAGE is the base layer image for the aws-network-policy-agent container.
+BASE_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:latest-al23
 # TEST_IMAGE is the testing environment container image.
 TEST_IMAGE = aws-network-policy-agent-test
 TEST_IMAGE_NAME = $(TEST_IMAGE)$(IMAGE_ARCH_SUFFIX):$(VERSION)
@@ -159,7 +161,7 @@ build-bpf: ## Build BPF.
 #docker-build: test ## Build docker image with the manager.
 #	docker build -t ${IMAGE_NAME} .
 docker-build: setup-ebpf-sdk-override## Build docker image with the manager.
-	docker build -t ${IMAGE_NAME} --build-arg golang_image="$(GOLANG_IMAGE)" .
+	docker build -t ${IMAGE_NAME} --build-arg golang_image="$(GOLANG_IMAGE)" --build-arg base_image="$(BASE_IMAGE)" .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -200,6 +202,7 @@ docker-buildx: setup-ebpf-sdk-override ## Build and push docker image for the ma
 		--cache-from=type=gha \
 		--cache-to=type=gha,mode=max \
 		--build-arg golang_image="$(GOLANG_IMAGE)" \
+		--build-arg base_image="$(BASE_IMAGE)" \
 		.
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
@@ -215,6 +218,7 @@ multi-arch-build-and-push: setup-ebpf-sdk-override ## Build and push docker imag
 		--cache-to=type=gha,mode=max \
 		-t $(IMAGE):$(VERSION) \
 		--build-arg golang_image="$(GOLANG_IMAGE)" \
+		--build-arg base_image="$(BASE_IMAGE)" \
 		--push \
 		.
 


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## Which issue does this PR fix

N/A — enables a new downstream integration (Amazon EKS internal addon-distribution pipeline).

## What will this PR do?

Parameterize the base image so external callers (Amazon EKS internal addon-distribution pipeline) can pin the CVE-patched base image at build time without maintaining a downstream Dockerfile patch.

Follows the same pattern used in [`aws/amazon-vpc-cni-k8s`](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/Makefile):

- **Dockerfile**: `ARG base_image` (no default). Final stage: `FROM ${base_image}`.
- **Makefile**: `BASE_IMAGE ?= <current hardcoded value>` (Makefile owns the default). All three docker targets (`docker-build`, `docker-buildx`, `multi-arch-build-and-push`) pass `--build-arg base_image="$(BASE_IMAGE)"` unconditionally.

External callers override via `make docker-build BASE_IMAGE=<image>`.

## Will this PR introduce any new dependencies?

No.

## Will this break upgrades or downgrades. Has updating a running cluster been tested?

No behavior change for existing callers:

| Callsite | Effect |
|---|---|
| `make docker-build` (no envs) | `BASE_IMAGE ?=` default kicks in → same final image as today |
| `make docker-buildx` (no envs) | Same |
| `make multi-arch-build-and-push` (release flow) | Same |
| `.github/actions/build-and-push-image` (PR CI) | Same |
| `make build-bpf`, `make vmlinuxh` (local dev) | Unchanged |

## Does this PR introduce any user-facing change?

```release-note
Base image is now parameterized via `BASE_IMAGE` env var (or `--build-arg base_image=<image>`). Default preserves current behavior.
```

## Testing

Verified locally on x86 host:

- [x] `make docker-build` with no `BASE_IMAGE` env → exit 0. Final image size 99.9 MB. `docker history` shows base = `eks-distro-minimal-base-glibc` layers (`COPY /newroot /`). All artifacts present in `/`: `controller`, `aws-eks-na-cli`, `aws-eks-na-cli-v6`, `tc.v4ingress.bpf.o`, `tc.v4egress.bpf.o`, `tc.v6ingress.bpf.o`, `tc.v6egress.bpf.o`, `v4events.bpf.o`, `v6events.bpf.o`.
- [x] `make docker-build BASE_IMAGE=public.ecr.aws/amazonlinux/amazonlinux:2023` → exit 0. Final image 229 MB. `docker history` shows base = `al2023-container-raw-*.tar.xz` (150 MB) — override flowed through. Same artifacts present.

Pending (upstream CI covers):
- [ ] `make docker-buildx PLATFORMS=linux/arm64` (cross-platform buildx).
- [ ] `.github/workflows/pr-tests.yaml` `docker-build` job.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
