### PR TITLE
fix: clean up non-local pod identifiers from the PolicyEndpoint and ClusterPolicyEndpoint pod identifier maps

### DIFF
--- a/controllers/clusterpolicyendpoints_controller.go
+++ b/controllers/clusterpolicyendpoints_controller.go
@@ -348,6 +348,7 @@ func (r *ClusterPolicyEndpointsReconciler) deriveTargetPodsForParentCNP(ctx cont
 	var newTargetPods, podsToBeCleanedUp, currentPods []npatypes.Pod
 	var targetPodIdentifiers []string
 	podIdentifiers := make(map[string]bool)
+	allPodIdentifiers := make(map[string]bool)
 
 	// Get current pods selected by the PE objects for this CNP
 	existingPods, podsPresent := r.ClusterPolicyEndpointSelectorMap.Load(resourceName)
@@ -360,11 +361,12 @@ func (r *ClusterPolicyEndpointsReconciler) deriveTargetPodsForParentCNP(ctx cont
 	parentCPEObjects := r.getClusterPolicyEndpointsOfParentCNP(ctx, parentCNP)
 	log().Infof("Parent Cluster Network Policy resource Name: %s Total Cluster Policy Endpoints for Parent CNP: Count: %d", parentCNP, len(parentCPEObjects))
 
+	// No early return when there are no CPEs left: stale pod identifier detection
+	// and map cleanup below must still run on a full CNP delete.
 	if len(parentCPEObjects) == 0 {
 		podsToBeCleanedUp = append(podsToBeCleanedUp, currentPods...)
 		r.ClusterPolicyEndpointSelectorMap.Delete(resourceName)
 		log().Infof("No CPEs left: number of pods to cleanup - %d", len(podsToBeCleanedUp))
-		return newTargetPods, podIdentifiers, podsToBeCleanedUp
 	}
 
 	// Extract names for later use
@@ -375,11 +377,19 @@ func (r *ClusterPolicyEndpointsReconciler) deriveTargetPodsForParentCNP(ctx cont
 	// Process each ClusterPolicyEndpoint object on this node.
 	// Collect all the newTargetPods and PodIdentifiers targeted by this CNP
 	for _, currentCPE := range parentCPEObjects {
-		currentTargetPods, currentPodIdentifiers := r.deriveClusterPolicyTargetPods(&currentCPE, parentCPEList)
+		currentTargetPods, currentPodIdentifiers, currentAllPodIdentifiers := r.deriveClusterPolicyTargetPods(&currentCPE, parentCPEList)
 		newTargetPods = append(newTargetPods, currentTargetPods...)
 		for podIdentifier := range currentPodIdentifiers {
 			podIdentifiers[podIdentifier] = true
-			targetPodIdentifiers = append(targetPodIdentifiers, podIdentifier)
+		}
+		// Track every pod identifier selected by this Cluster Network Policy, local or
+		// not. podIdentifierToClusterPolicyEndpointMap holds entries for non-local pods
+		// too, so stale detection must cover them or those entries are never cleaned up.
+		for podIdentifier := range currentAllPodIdentifiers {
+			if !allPodIdentifiers[podIdentifier] {
+				allPodIdentifiers[podIdentifier] = true
+				targetPodIdentifiers = append(targetPodIdentifiers, podIdentifier)
+			}
 		}
 	}
 	// Derive Pod Identifiers that are no longer selected by this policy
@@ -391,10 +401,13 @@ func (r *ClusterPolicyEndpointsReconciler) deriveTargetPodsForParentCNP(ctx cont
 		} else {
 			r.ClusterPolicyEndpointSelectorMap.Delete(ClusterPolicyEndpointResource)
 		}
+	}
 
-		for _, podIdentifier := range stalePodIdentifiers {
-			utils.DeletePolicyEndpointFromPodIdentifierMap(&r.podIdentifierToClusterPolicyEndpointMap, &r.podIdentifierToClusterPolicyEndpointMapMutex, podIdentifier, ClusterPolicyEndpointResource)
-		}
+	// Purge this parent CNP's ClusterPolicyEndpoints from stale pod identifiers by
+	// parent CNP name rather than by parentCPEList, so CPE resources that were deleted
+	// or renamed (and hence no longer appear in parentCPEList) are removed as well.
+	for _, podIdentifier := range stalePodIdentifiers {
+		utils.DeleteParentNPFromPodIdentifierMap(&r.podIdentifierToClusterPolicyEndpointMap, &r.podIdentifierToClusterPolicyEndpointMapMutex, podIdentifier, parentCNP)
 	}
 
 	if len(targetPodIdentifiers) == 0 {
@@ -409,9 +422,15 @@ func (r *ClusterPolicyEndpointsReconciler) deriveTargetPodsForParentCNP(ctx cont
 	return newTargetPods, podIdentifiers, podsToBeCleanedUp
 }
 
-func (r *ClusterPolicyEndpointsReconciler) deriveClusterPolicyTargetPods(ClusterPolicyEndpoint *policyk8sawsv1.ClusterPolicyEndpoint, parentCPEList []string) ([]npatypes.Pod, map[string]bool) {
+// Derives list of local pods the cluster policy endpoint resource selects.
+// Function returns list of target pods along with their unique identifiers. It also
+// returns the identifiers of every pod the cluster policy endpoint selects (local or
+// not), since those are all registered in podIdentifierToClusterPolicyEndpointMap and
+// the caller needs the full set for stale entry cleanup.
+func (r *ClusterPolicyEndpointsReconciler) deriveClusterPolicyTargetPods(ClusterPolicyEndpoint *policyk8sawsv1.ClusterPolicyEndpoint, parentCPEList []string) ([]npatypes.Pod, map[string]bool, map[string]bool) {
 	var targetPods []npatypes.Pod
 	podIdentifiers := make(map[string]bool)
+	allPodIdentifiers := make(map[string]bool)
 
 	nodeIP := net.ParseIP(r.nodeIP)
 	for _, pod := range ClusterPolicyEndpoint.Spec.PodSelectorEndpoints {
@@ -420,9 +439,10 @@ func (r *ClusterPolicyEndpointsReconciler) deriveClusterPolicyTargetPods(Cluster
 			targetPods = append(targetPods, npatypes.Pod{NamespacedName: types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, PodIP: pod.PodIP})
 			podIdentifiers[podIdentifier] = true
 		}
+		allPodIdentifiers[podIdentifier] = true
 		utils.UpdatePodIdentifierToPolicyEndpointMap(&r.podIdentifierToClusterPolicyEndpointMap, &r.podIdentifierToClusterPolicyEndpointMapMutex, podIdentifier, parentCPEList)
 	}
-	return targetPods, podIdentifiers
+	return targetPods, podIdentifiers, allPodIdentifiers
 }
 
 func (r *ClusterPolicyEndpointsReconciler) updateClusterPolicyEnforcementStatusForPods(ctx context.Context, ClusterPolicyEndpointName string, cleanupPods []npatypes.Pod, podIdentifiers map[string]bool, isDeleteFlow bool) error {

--- a/controllers/clusterpolicyendpoints_controller_test.go
+++ b/controllers/clusterpolicyendpoints_controller_test.go
@@ -1,0 +1,122 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	policyendpoint "github.com/aws/aws-network-policy-agent/api/v1alpha1"
+	mock_client "github.com/aws/aws-network-policy-agent/mocks/controller-runtime/client"
+	"github.com/aws/aws-network-policy-agent/pkg/ebpf"
+	"github.com/golang/mock/gomock"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestClusterPolicyEndpointReconcile(t *testing.T) {
+	namespace := "my-namespace"
+	nodeIp := "1.1.1.1"
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("Reconcile cleans up non-local pod identifiers on pod churn and CPE delete", func(t *testing.T) {
+		mockClient := mock_client.NewMockClient(ctrl)
+		reconciler := NewClusterPolicyEndpointsReconciler(mockClient, nodeIp, &ebpf.MockBpfClient{})
+
+		remotePod1 := policyendpoint.PodEndpoint{
+			HostIP:    "2.2.2.2",
+			PodIP:     "10.1.2.1",
+			Name:      "deployment1rs-1",
+			Namespace: namespace,
+		}
+		remotePod2 := policyendpoint.PodEndpoint{
+			HostIP:    "2.2.2.2",
+			PodIP:     "10.1.2.2",
+			Name:      "deployment2rs-1",
+			Namespace: namespace,
+		}
+
+		currentCPE := getClusterPolicyEndpoint("allow-all-cnp", []policyendpoint.PodEndpoint{remotePod1})
+		cpeDeleted := false
+
+		mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, key types.NamespacedName, cpe *policyendpoint.ClusterPolicyEndpoint, opts ...client.GetOption) error {
+				if cpeDeleted {
+					return apierrors.NewNotFound(schema.GroupResource{Group: policyendpoint.GroupVersion.Group, Resource: ""}, "")
+				}
+				*cpe = currentCPE
+				return nil
+			},
+		).AnyTimes()
+
+		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&policyendpoint.ClusterPolicyEndpointList{}), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, list *policyendpoint.ClusterPolicyEndpointList, opts ...*client.ListOptions) error {
+				if cpeDeleted {
+					*list = policyendpoint.ClusterPolicyEndpointList{}
+				} else {
+					*list = policyendpoint.ClusterPolicyEndpointList{
+						Items: []policyendpoint.ClusterPolicyEndpoint{currentCPE},
+					}
+				}
+				return nil
+			},
+		).AnyTimes()
+
+		req := controllerruntime.Request{
+			NamespacedName: types.NamespacedName{
+				Name: currentCPE.GetName(),
+			},
+		}
+
+		_, err := reconciler.Reconcile(context.TODO(), req)
+		assert.Nil(t, err)
+
+		// Non-local pod identifiers are tracked so a pod of the same replicaset
+		// landing on this node later gets policies applied at launch
+		val, ok := reconciler.podIdentifierToClusterPolicyEndpointMap.Load("deployment1rs@my-namespace")
+		assert.True(t, ok)
+		assert.True(t, lo.Contains(val.([]string), "allow-all-cnp-abcd"))
+		val, ok = reconciler.clusterNetworkPolicyToPodIdentifierMap.Load("allow-all-cnp")
+		assert.True(t, ok)
+		assert.True(t, lo.Contains(val.([]string), "deployment1rs@my-namespace"))
+
+		// Rollout on the remote node: old replicaset replaced by a new one
+		currentCPE = getClusterPolicyEndpoint("allow-all-cnp", []policyendpoint.PodEndpoint{remotePod2})
+		_, err = reconciler.Reconcile(context.TODO(), req)
+		assert.Nil(t, err)
+
+		_, ok = reconciler.podIdentifierToClusterPolicyEndpointMap.Load("deployment1rs@my-namespace")
+		assert.False(t, ok)
+		_, ok = reconciler.podIdentifierToClusterPolicyEndpointMap.Load("deployment2rs@my-namespace")
+		assert.True(t, ok)
+
+		cpeDeleted = true
+		_, err = reconciler.Reconcile(context.TODO(), req)
+		assert.Nil(t, err)
+		assert.Equal(t, 0, sizeOfSyncMap(&reconciler.clusterNetworkPolicyToPodIdentifierMap))
+		assert.Equal(t, 0, sizeOfSyncMap(&reconciler.podIdentifierToClusterPolicyEndpointMap))
+		assert.Equal(t, 0, sizeOfSyncMap(&reconciler.ClusterPolicyEndpointSelectorMap))
+	})
+}
+
+func getClusterPolicyEndpoint(cnpName string, podEndpoints []policyendpoint.PodEndpoint) policyendpoint.ClusterPolicyEndpoint {
+	return policyendpoint.ClusterPolicyEndpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cnpName + "-abcd",
+		},
+		Spec: policyendpoint.ClusterPolicyEndpointSpec{
+			PolicyRef: policyendpoint.ClusterPolicyReference{
+				Name: cnpName,
+			},
+			Tier:                 policyendpoint.AdminTier,
+			Priority:             1,
+			PodSelectorEndpoints: podEndpoints,
+		},
+	}
+}

--- a/controllers/policyendpoints_controller.go
+++ b/controllers/policyendpoints_controller.go
@@ -535,6 +535,7 @@ func (r *PolicyEndpointsReconciler) deriveTargetPodsForParentNP(ctx context.Cont
 	var targetPods, podsToBeCleanedUp, currentPods []npatypes.Pod
 	var targetPodIdentifiers []string
 	podIdentifiers := make(map[string]bool)
+	allPodIdentifiers := make(map[string]bool)
 
 	parentPEList := r.derivePolicyEndpointsOfParentNP(ctx, parentNP, resourceNamespace)
 	log().Infof("Parent NP resource: Name: %s Total PEs for Parent NP: Count: %d", parentNP, len(parentPEList))
@@ -569,12 +570,20 @@ func (r *PolicyEndpointsReconciler) deriveTargetPodsForParentNP(ctx context.Cont
 			}
 		}
 		log().Infof("Processing PE Name %s", policyEndpointResourceName)
-		currentTargetPods, currentPodIdentifiers := r.deriveTargetPods(ctx, currentPE, parentPEList)
+		currentTargetPods, currentPodIdentifiers, currentAllPodIdentifiers := r.deriveTargetPods(ctx, currentPE, parentPEList)
 		log().Infof("Adding to current targetPods Total pods: %d", len(currentTargetPods))
 		targetPods = append(targetPods, currentTargetPods...)
 		for podIdentifier := range currentPodIdentifiers {
 			podIdentifiers[podIdentifier] = true
-			targetPodIdentifiers = append(targetPodIdentifiers, podIdentifier)
+		}
+		// Track every pod identifier selected by this Network Policy, local or not.
+		// podIdentifierToPolicyEndpointMap holds entries for non-local pods too, so
+		// stale detection must cover them or those entries are never cleaned up.
+		for podIdentifier := range currentAllPodIdentifiers {
+			if !allPodIdentifiers[podIdentifier] {
+				allPodIdentifiers[podIdentifier] = true
+				targetPodIdentifiers = append(targetPodIdentifiers, podIdentifier)
+			}
 		}
 	}
 
@@ -590,9 +599,13 @@ func (r *PolicyEndpointsReconciler) deriveTargetPodsForParentNP(ctx context.Cont
 			log().Infof("No more target pods so deleting the entry in PE selector map for Name %s", policyEndpointResource)
 			r.policyEndpointSelectorMap.Delete(policyEndpointIdentifier)
 		}
-		for _, podIdentifier := range stalePodIdentifiers {
-			r.deletePolicyEndpointFromPodIdentifierMap(ctx, podIdentifier, policyEndpointResource)
-		}
+	}
+
+	// Purge this parent NP's PolicyEndpoints from stale pod identifiers by parent NP
+	// name rather than by parentPEList, so PE resources that were deleted or renamed
+	// (and hence no longer appear in parentPEList) are removed as well.
+	for _, podIdentifier := range stalePodIdentifiers {
+		r.deleteParentNPFromPodIdentifierMap(ctx, podIdentifier, parentNP)
 	}
 
 	// Update active podIdentifiers selected by the current Network Policy
@@ -609,11 +622,14 @@ func (r *PolicyEndpointsReconciler) deriveTargetPodsForParentNP(ctx context.Cont
 
 // Derives list of local pods the policy endpoint resource selects.
 // Function returns list of target pods along with their unique identifiers. It also
-// captures list of (any) existing pods against which this policy is no longer active.
+// returns the identifiers of every pod the policy endpoint selects (local or not),
+// since those are all registered in podIdentifierToPolicyEndpointMap and the caller
+// needs the full set for stale entry cleanup.
 func (r *PolicyEndpointsReconciler) deriveTargetPods(ctx context.Context,
-	policyEndpoint *policyk8sawsv1.PolicyEndpoint, parentPEList []string) ([]npatypes.Pod, map[string]bool) {
+	policyEndpoint *policyk8sawsv1.PolicyEndpoint, parentPEList []string) ([]npatypes.Pod, map[string]bool, map[string]bool) {
 	var targetPods []npatypes.Pod
 	podIdentifiers := make(map[string]bool)
+	allPodIdentifiers := make(map[string]bool)
 
 	// Pods are grouped by Host IP. Individual node agents will filter (local) pods
 	// by the Host IP value.
@@ -630,9 +646,10 @@ func (r *PolicyEndpointsReconciler) deriveTargetPods(ctx context.Context,
 			podIdentifiers[podIdentifier] = true
 			log().Infof("Found a matching Pod: name: %s namespace: %s podIdentifier: %s", pod.Name, pod.Namespace, podIdentifier)
 		}
+		allPodIdentifiers[podIdentifier] = true
 		r.updatePodIdentifierToPEMap(ctx, podIdentifier, parentPEList)
 	}
-	return targetPods, podIdentifiers
+	return targetPods, podIdentifiers, allPodIdentifiers
 }
 
 func (r *PolicyEndpointsReconciler) getPodListToBeCleanedUp(oldPodSet []npatypes.Pod,
@@ -708,6 +725,28 @@ func (r *PolicyEndpointsReconciler) deriveStalePodIdentifiers(ctx context.Contex
 		}
 	}
 	return stalePodIdentifiers
+}
+
+// Removes every PolicyEndpoint belonging to the given parent Network Policy from the
+// pod identifier's tracked PE list, deleting the map entry once the list is empty.
+func (r *PolicyEndpointsReconciler) deleteParentNPFromPodIdentifierMap(ctx context.Context, podIdentifier string,
+	parentNP string) {
+	r.podIdentifierToPolicyEndpointMapMutex.Lock()
+	defer r.podIdentifierToPolicyEndpointMapMutex.Unlock()
+	var currentPEList []string
+	if policyEndpointList, ok := r.podIdentifierToPolicyEndpointMap.Load(podIdentifier); ok {
+		for _, policyEndpointName := range policyEndpointList.([]string) {
+			if utils.GetParentNPNameFromPEName(policyEndpointName) == parentNP {
+				continue
+			}
+			currentPEList = append(currentPEList, policyEndpointName)
+		}
+		if len(currentPEList) == 0 {
+			r.podIdentifierToPolicyEndpointMap.Delete(podIdentifier)
+		} else {
+			r.podIdentifierToPolicyEndpointMap.Store(podIdentifier, currentPEList)
+		}
+	}
 }
 
 func (r *PolicyEndpointsReconciler) deletePolicyEndpointFromPodIdentifierMap(ctx context.Context, podIdentifier string,

--- a/controllers/policyendpoints_controller_test.go
+++ b/controllers/policyendpoints_controller_test.go
@@ -163,6 +163,86 @@ func TestPolicyEndpointReconcile(t *testing.T) {
 		assert.Equal(t, 0, sizeOfSyncMap(&policyEndpointReconciler.policyEndpointSelectorMap))
 
 	})
+
+	t.Run("Reconcile cleans up non-local pod identifiers on pod churn and PE delete", func(t *testing.T) {
+		mockClient := mock_client.NewMockClient(ctrl)
+		policyEndpointReconciler := NewPolicyEndpointsReconciler(mockClient, nodeIp, &ebpf.MockBpfClient{}, false)
+
+		remotePod1 := policyendpoint.PodEndpoint{
+			HostIP:    "2.2.2.2",
+			PodIP:     "10.1.2.1",
+			Name:      "deployment1rs-1",
+			Namespace: namespace,
+		}
+		remotePod2 := policyendpoint.PodEndpoint{
+			HostIP:    "2.2.2.2",
+			PodIP:     "10.1.2.2",
+			Name:      "deployment2rs-1",
+			Namespace: namespace,
+		}
+
+		currentPE := getPolicyEndpoint("allow-all-egress", namespace, []policyendpoint.PodEndpoint{remotePod1})
+		peDeleted := false
+
+		mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, key types.NamespacedName, pe *policyendpoint.PolicyEndpoint, opts ...client.GetOption) error {
+				if peDeleted {
+					return apierrors.NewNotFound(schema.GroupResource{Group: networking.SchemeGroupVersion.Group, Resource: ""}, "")
+				}
+				*pe = currentPE
+				return nil
+			},
+		).AnyTimes()
+
+		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&policyendpoint.PolicyEndpointList{}), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, list *policyendpoint.PolicyEndpointList, opts ...*client.ListOptions) error {
+				if peDeleted {
+					*list = policyendpoint.PolicyEndpointList{}
+				} else {
+					*list = policyendpoint.PolicyEndpointList{
+						Items: []policyendpoint.PolicyEndpoint{currentPE},
+					}
+				}
+				return nil
+			},
+		).AnyTimes()
+
+		req := controllerruntime.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      currentPE.GetName(),
+				Namespace: currentPE.GetNamespace(),
+			},
+		}
+
+		_, err := policyEndpointReconciler.Reconcile(context.TODO(), req)
+		assert.Nil(t, err)
+
+		// Non-local pod identifiers are tracked so a pod of the same replicaset
+		// landing on this node later gets policies applied at launch
+		val, ok := policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Load("deployment1rs@my-namespace")
+		assert.True(t, ok)
+		assert.True(t, lo.Contains(val.([]string), "allow-all-egress-abcd"))
+		val, ok = policyEndpointReconciler.networkPolicyToPodIdentifierMap.Load("allow-all-egress")
+		assert.True(t, ok)
+		assert.True(t, lo.Contains(val.([]string), "deployment1rs@my-namespace"))
+
+		// Rollout on the remote node: old replicaset replaced by a new one
+		currentPE = getPolicyEndpoint("allow-all-egress", namespace, []policyendpoint.PodEndpoint{remotePod2})
+		_, err = policyEndpointReconciler.Reconcile(context.TODO(), req)
+		assert.Nil(t, err)
+
+		_, ok = policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Load("deployment1rs@my-namespace")
+		assert.False(t, ok)
+		_, ok = policyEndpointReconciler.podIdentifierToPolicyEndpointMap.Load("deployment2rs@my-namespace")
+		assert.True(t, ok)
+
+		peDeleted = true
+		_, err = policyEndpointReconciler.Reconcile(context.TODO(), req)
+		assert.Nil(t, err)
+		assert.Equal(t, 0, sizeOfSyncMap(&policyEndpointReconciler.networkPolicyToPodIdentifierMap))
+		assert.Equal(t, 0, sizeOfSyncMap(&policyEndpointReconciler.podIdentifierToPolicyEndpointMap))
+		assert.Equal(t, 0, sizeOfSyncMap(&policyEndpointReconciler.policyEndpointSelectorMap))
+	})
 }
 
 func getPolicyEndpoint(npName string, namespace string, podEndpoints []policyendpoint.PodEndpoint) policyendpoint.PolicyEndpoint {
@@ -789,7 +869,7 @@ func TestDeriveTargetPods(t *testing.T) {
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			gotActivePods, _ := policyEndpointReconciler.deriveTargetPods(context.Background(),
+			gotActivePods, _, _ := policyEndpointReconciler.deriveTargetPods(context.Background(),
 				&tt.policyendpoint, tt.parentPEList)
 			assert.Equal(t, tt.want.activePods, gotActivePods)
 		})

--- a/pkg/utils/policy_utils.go
+++ b/pkg/utils/policy_utils.go
@@ -34,6 +34,29 @@ func DeriveStalePodIdentifiers(networkPolicyToPodIdentifierMap *sync.Map, resour
 	return stalePodIdentifiers
 }
 
+// DeleteParentNPFromPodIdentifierMap removes every policy endpoint belonging to the given
+// parent network policy from a pod identifier's tracked policy endpoint list, deleting the
+// map entry once the list is empty.
+func DeleteParentNPFromPodIdentifierMap(podIdentifierToPolicyEndpointMap *sync.Map, mutex *sync.Mutex, podIdentifier string, parentNP string) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	var currentList []string
+	if policyEndpointList, ok := podIdentifierToPolicyEndpointMap.Load(podIdentifier); ok {
+		for _, policyEndpointName := range policyEndpointList.([]string) {
+			if GetParentNPNameFromPEName(policyEndpointName) == parentNP {
+				continue
+			}
+			currentList = append(currentList, policyEndpointName)
+		}
+		if len(currentList) == 0 {
+			podIdentifierToPolicyEndpointMap.Delete(podIdentifier)
+		} else {
+			podIdentifierToPolicyEndpointMap.Store(podIdentifier, currentList)
+		}
+	}
+}
+
 // DeletePolicyEndpointFromPodIdentifierMap removes a policy endpoint from a pod's identifier map
 func DeletePolicyEndpointFromPodIdentifierMap(podIdentifierToPolicyEndpointMap *sync.Map, mutex *sync.Mutex, podIdentifier string, policyEndpoint string) {
 	mutex.Lock()


### PR DESCRIPTION
updatePodIdentifierToPEMap registers every pod selected by a PolicyEndpoint, including pods on other nodes, so the gRPC handler can apply policies at pod launch. However, stale entry cleanup only covered pod identifiers local to the node: networkPolicyToPodIdentifierMap was populated from local pods only, and the PE delete path only purged local podsToBeCleanedUp. As a result, every remote pod identifier ever selected by a policy stayed in the map forever, and pod churn from rollouts, jobs and cronjobs grew it without bound (~66MB retained in 25 minutes on a busy cluster, per heap profile diff).

Non-local entries are still registered, preserving at-launch policy application; they are just cleanable now.

Attached 2 profiles taken in a span of 2 hours on a cluster with high pod churn.
[heap-t0.pb.gz](https://github.com/user-attachments/files/29969299/heap-t0.pb.gz)
[heap-t3.pb.gz](https://github.com/user-attachments/files/29969304/heap-t3.pb.gz)

Also added unit tests for both controllers; they fail without the fix and pass with it.


*Issue #, if available:*
#613 

*Description of changes:*
This fixes the same leak in both the PolicyEndpoints controller (`podIdentifierToPolicyEndpointMap`) and the ClusterPolicyEndpoints controller (`podIdentifierToClusterPolicyEndpointMap`), which register pod identifiers the same way.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
