### PR TITLE
fix: validate loaded BPF program has associated maps before use

### DIFF
--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -976,10 +976,27 @@ func (l *bpfClient) loadBPFProgram(fileName string, direction string,
 		return nil, -1, err
 	}
 
+	// Validate the loaded program before returning it. A successful LoadBpfFile
+	// must yield a program with a valid FD and its associated maps linked.
 	pinPath := utils.GetBPFPinPathFromPodIdentifier(podIdentifier, direction)
-	progFD := progInfo[pinPath].Program.ProgFD
+	bpfData, ok := progInfo[pinPath]
+	if !ok {
+		sdkAPIErr.WithLabelValues("LoadBpfFile-NoPinPath").Inc()
+		return nil, -1, fmt.Errorf("no program data found at pinPath %s for pod %s direction %s", pinPath, podIdentifier, direction)
+	}
 
-	log().Infof("Prog Load Succeeded for %s, progFD: %d, pinpath: %s", direction, progFD, pinPath)
+	progFD := bpfData.Program.ProgFD
+	if progFD == 0 {
+		sdkAPIErr.WithLabelValues("LoadBpfFile-InvalidFD").Inc()
+		return nil, -1, fmt.Errorf("program loaded with invalid FD 0 for pod %s direction %s", podIdentifier, direction)
+	}
+
+	if len(bpfData.Maps) == 0 {
+		sdkAPIErr.WithLabelValues("LoadBpfFile-NoMaps").Inc()
+		return nil, -1, fmt.Errorf("program loaded but has no associated maps for pod %s direction %s progFD %d", podIdentifier, direction, progFD)
+	}
+
+	log().Infof("Prog Load Succeeded for %s, progFD: %d, pinpath: %s, maps: %d", direction, progFD, pinPath, len(bpfData.Maps))
 
 	return progInfo, progFD, nil
 }

--- a/pkg/ebpf/bpf_client_test.go
+++ b/pkg/ebpf/bpf_client_test.go
@@ -123,18 +123,79 @@ func TestBpfClient_IsEBPFProbeAttached_NoCollisionAcrossPods(t *testing.T) {
 }
 
 func TestLoadBPFProgram(t *testing.T) {
-	var wantErr error
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+	pinPath := utils.GetBPFPinPathFromPodIdentifier("test-abcd", "ingress")
 
-	mockBpfClient := mock_bpfclient.NewMockBpfSDKClient(ctrl)
-	testBpfClient := &bpfClient{
-		bpfSDKClient: mockBpfClient,
+	tests := []struct {
+		name       string
+		loadReturn map[string]goelf.BpfData
+		wantErr    bool
+		wantProgFD int
+	}{
+		{
+			name: "success with associated maps",
+			loadReturn: map[string]goelf.BpfData{
+				pinPath: {
+					Program: goebpfprogs.BpfProgram{ProgFD: 7},
+					Maps: map[string]goebpfmaps.BpfMap{
+						utils.TC_INGRESS_MAP:           {MapFD: 100},
+						utils.TC_INGRESS_POD_STATE_MAP: {MapFD: 101},
+					},
+				},
+			},
+			wantErr:    false,
+			wantProgFD: 7,
+		},
+		{
+			name: "program loaded but no associated maps",
+			loadReturn: map[string]goelf.BpfData{
+				pinPath: {
+					Program: goebpfprogs.BpfProgram{ProgFD: 7},
+					Maps:    map[string]goebpfmaps.BpfMap{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "program loaded with invalid FD",
+			loadReturn: map[string]goelf.BpfData{
+				pinPath: {
+					Program: goebpfprogs.BpfProgram{ProgFD: 0},
+					Maps: map[string]goebpfmaps.BpfMap{
+						utils.TC_INGRESS_MAP: {MapFD: 100},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:       "no program data at pinPath",
+			loadReturn: map[string]goelf.BpfData{},
+			wantErr:    true,
+		},
 	}
 
-	mockBpfClient.EXPECT().LoadBpfFile(gomock.Any(), gomock.Any()).AnyTimes()
-	_, _, gotErr := testBpfClient.loadBPFProgram("handle_ingress", "ingress", "test-abcd")
-	assert.Equal(t, gotErr, wantErr)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockBpfClient := mock_bpfclient.NewMockBpfSDKClient(ctrl)
+			testBpfClient := &bpfClient{
+				bpfSDKClient: mockBpfClient,
+			}
+
+			mockBpfClient.EXPECT().LoadBpfFile(gomock.Any(), gomock.Any()).Return(
+				tt.loadReturn, map[string]goebpfmaps.BpfMap{}, nil).Times(1)
+
+			_, gotProgFD, gotErr := testBpfClient.loadBPFProgram("handle_ingress", "ingress", "test-abcd")
+			if tt.wantErr {
+				assert.Error(t, gotErr)
+			} else {
+				assert.NoError(t, gotErr)
+				assert.Equal(t, tt.wantProgFD, gotProgFD)
+			}
+		})
+	}
 }
 
 func TestBpfClient_UpdateEbpfMaps(t *testing.T) {
@@ -807,6 +868,10 @@ func TestBpfClient_AttacheBPFProbes_MultipleInterfacesFlow(t *testing.T) {
 		map[string]goelf.BpfData{
 			"/sys/fs/bpf/globals/aws/programs/multi-nic-pod-default_handle_ingress": {
 				Program: goebpfprogs.BpfProgram{ProgFD: 10},
+				Maps: map[string]goebpfmaps.BpfMap{
+					utils.TC_INGRESS_MAP:           {MapFD: 100},
+					utils.TC_INGRESS_POD_STATE_MAP: {MapFD: 101},
+				},
 			},
 		},
 		map[string]goebpfmaps.BpfMap{},
@@ -816,6 +881,10 @@ func TestBpfClient_AttacheBPFProbes_MultipleInterfacesFlow(t *testing.T) {
 		map[string]goelf.BpfData{
 			"/sys/fs/bpf/globals/aws/programs/multi-nic-pod-default_handle_egress": {
 				Program: goebpfprogs.BpfProgram{ProgFD: 11},
+				Maps: map[string]goebpfmaps.BpfMap{
+					utils.TC_EGRESS_MAP:           {MapFD: 110},
+					utils.TC_EGRESS_POD_STATE_MAP: {MapFD: 111},
+				},
 			},
 		},
 		map[string]goebpfmaps.BpfMap{},


### PR DESCRIPTION
loadBPFProgram trusts that a successful LoadBpfFile always returns a program with its associated maps linked which will not stay true in error cases

Validate the loaded program before returning it:
- error if no BpfData exists at the expected pinPath
- error if the program FD is 0
- error if the program has no associated maps

Returning an error causes AttacheBPFProbes to fail so the controller retries the reconcile with a freshly loaded program ( instead of silently persisting broken state. 

related issue - https://github.com/aws/aws-ebpf-sdk-go/pull/157


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
