### PR TITLE
ebpf sdk bump to v1.0.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/aws/amazon-vpc-cni-k8s v1.22.4
-	github.com/aws/aws-ebpf-sdk-go v1.0.15
+	github.com/aws/aws-ebpf-sdk-go v1.0.16
 	github.com/aws/aws-sdk-go-v2 v1.43.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.31

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/aws/amazon-vpc-cni-k8s v1.22.4 h1:040AzVL94vW4i9f8d5vz4tI83sKaxUM2KjB
 github.com/aws/amazon-vpc-cni-k8s v1.22.4/go.mod h1:H9f69VZbroA/1ns5LtTnoMA4vAdPghcgU0tIH5FX4+s=
 github.com/aws/amazon-vpc-resource-controller-k8s v1.7.18 h1:V/h33TgtVkR/1hkYVWU8RFD8i8h5G+xZ6eX9Hr0zKpk=
 github.com/aws/amazon-vpc-resource-controller-k8s v1.7.18/go.mod h1:iZa92r5f6vu42hQhyzrQa9UnxieNWcYmQ9DEKYMuXWo=
-github.com/aws/aws-ebpf-sdk-go v1.0.15 h1:iKAiGIfldszZEsAkND2T09Qz2gVfuGlMovPPhI9oRY4=
-github.com/aws/aws-ebpf-sdk-go v1.0.15/go.mod h1:2v/brJqgaXZxyg2XzOPOQX8v0CL2gOlIzgP/mMPB00o=
+github.com/aws/aws-ebpf-sdk-go v1.0.16 h1:g2cT+YTYKW/IITlM/Rq9r5ELsyul49FaF2aieGgZeI8=
+github.com/aws/aws-ebpf-sdk-go v1.0.16/go.mod h1:2v/brJqgaXZxyg2XzOPOQX8v0CL2gOlIzgP/mMPB00o=
 github.com/aws/aws-sdk-go-v2 v1.43.0 h1:fharf/WhbRAVZ1du0QL7roNFxZ6T/sWr+4Ni617bwSI=
 github.com/aws/aws-sdk-go-v2 v1.43.0/go.mod h1:5pKeft2eJj+gElQ38Jqg4ibCqh+/AK33/0X3hip7IjM=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bumped ebpf sdk to v1.0.16

No functional change

- tested image on cluster and basic NP workload 

test logs
```
{"level":"info","ts":"2026-07-28T17:50:01.822Z","caller":"runtime/proc.go:290","msg":"Starting network policy agent: 1170e1e (built: 2026-07-28T17:49:05Z, ebpf-sdk: v1.0.16), log level: debug"}
{"level":"info","ts":"2026-07-28T17:50:01.823Z","caller":"runtime/proc.go:290","msg":"Network Policy is enabled, registering controllers..."}
{"level":"info","ts":"2026-07-28T17:50:01.826Z","caller":"workspace/main.go:119","msg":"Trying to establish GRPC connection to ipamd at unix:///var/run/aws-node/ipamd.sock"}
{"level":"info","ts":"2026-07-28T17:50:04.355Z","caller":"workspace/main.go:119","msg":"Connected to ipamd at unix:///var/run/aws-node/ipamd.sock. NetworkPolicyMode: standard MultiNICEnabled: false"}
{"level":"info","ts":"2026-07-28T17:50:04.356Z","caller":"ebpf/bpf_client.go:169","msg":"Validating Probe: v4events.bpf.o"}
{"level":"info","ts":"2026-07-28T17:50:04.356Z","caller":"ebpf/bpf_client.go:169","msg":"comparing new and existing probes ..."}
{"level":"info","ts":"2026-07-28T17:50:04.361Z","caller":"ebpf/bpf_client.go:169","msg":"Validating Probe: tc.v4ingress.bpf.o"}
{"level":"info","ts":"2026-07-28T17:50:04.361Z","caller":"ebpf/bpf_client.go:169","msg":"comparing new and existing probes ..."}
{"level":"info","ts":"2026-07-28T17:50:04.411Z","caller":"ebpf/bpf_client.go:169","msg":"change detected in ingress probe binaries.. "}
{"level":"info","ts":"2026-07-28T17:50:04.411Z","caller":"ebpf/bpf_client.go:169","msg":"Validating Probe: tc.v4egress.bpf.o"}
{"level":"info","ts":"2026-07-28T17:50:04.411Z","caller":"ebpf/bpf_client.go:169","msg":"comparing new and existing probes ..."}
{"level":"info","ts":"2026-07-28T17:50:04.460Z","caller":"ebpf/bpf_client.go:169","msg":"change detected in egress probe binaries.."}
{"level":"info","ts":"2026-07-28T17:50:04.460Z","caller":"workspace/main.go:121","msg":"Probe validation Done"}
{"level":"info","ts":"2026-07-28T17:50:04.460Z","caller":"ebpf/bpf_client.go:178","msg":"Let's install BPF Binaries on to the host path....."}
{"level":"info","ts":"2026-07-28T17:50:04.460Z","caller":"ebpf/bpf_client.go:178","msg":"Installing BPF Binary..target /host/opt/cni/bin/v4events.bpf.o source v4events.bpf.o"}
{"level":"info","ts":"2026-07-28T17:50:04.460Z","caller":"ebpf/bpf_client.go:178","msg":"Successfully installed - binary /host/opt/cni/bin/v4events.bpf.o"}
{"level":"info","ts":"2026-07-28T17:50:04.460Z","caller":"ebpf/bpf_client.go:178","msg":"Installing BPF Binary..target /host/opt/cni/bin/tc.v4ingress.bpf.o source tc.v4ingress.bpf.o"}
{"level":"info","ts":"2026-07-28T17:50:04.460Z","caller":"ebpf/bpf_client.go:178","msg":"Successfully installed - binary /host/opt/cni/bin/tc.v4ingress.bpf.o"}
{"level":"info","ts":"2026-07-28T17:50:04.460Z","caller":"ebpf/bpf_client.go:178","msg":"Installing BPF Binary..target /host/opt/cni/bin/tc.v4egress.bpf.o source tc.v4egress.bpf.o"}
{"level":"info","ts":"2026-07-28T17:50:04.460Z","caller":"ebpf/bpf_client.go:178","msg":"Successfully installed - binary /host/opt/cni/bin/tc.v4egress.bpf.o"}
{"level":"info","ts":"2026-07-28T17:50:04.460Z","caller":"ebpf/bpf_client.go:178","msg":"Installing BPF Binary..target /host/opt/cni/bin/aws-eks-na-cli source aws-eks-na-cli"}
{"level":"info","ts":"2026-07-28T17:50:04.465Z","caller":"ebpf/bpf_client.go:178","msg":"Successfully installed - binary /host/opt/cni/bin/aws-eks-na-cli"}
{"level":"info","ts":"2026-07-28T17:50:04.465Z","caller":"workspace/main.go:121","msg":"Copied eBPF binaries to the host directory"}

...

{"level":"info","ts":"2026-07-28T17:50:49.535Z","caller":"rpc/rpc_grpc.pb.go:261","msg":"Received Enforce Network Policy Request for Pod: nginx Namespace: np-test Mode: standard"}
{"level":"info","ts":"2026-07-28T17:50:49.535Z","caller":"rpc/rpc_handler.go:84","msg":"No map instance found"}
{"level":"debug","ts":"2026-07-28T17:50:49.535Z","caller":"rpc/rpc_handler.go:86","msg":"Got the podIdentifierLock for Pod: nginx, Namespace: np-test, PodIdentifier: nginx@np-test"}
{"level":"info","ts":"2026-07-28T17:50:49.536Z","caller":"rpc/rpc_handler.go:86","msg":"AttacheBPFProbes for pod nginx in namespace np-test with hostVethName enieb1edf93556 at interface 0"}
{"level":"info","ts":"2026-07-28T17:50:49.536Z","caller":"ebpf/bpf_client.go:793","msg":"Load the eBPF program"}
{"level":"info","ts":"2026-07-28T17:50:49.722Z","caller":"ebpf/bpf_client.go:793","msg":"Prog Load Succeeded for ingress, progFD: 29, pinpath: /sys/fs/bpf/globals/aws/programs/nginx@np-test_handle_ingress, maps: 3"}
{"level":"info","ts":"2026-07-28T17:50:49.722Z","caller":"ebpf/bpf_client.go:736","msg":"Attempting to do an Ingress Attach with progFD: 29"}
{"level":"info","ts":"2026-07-28T17:50:49.723Z","caller":"rpc/rpc_handler.go:86","msg":"Successfully attached Ingress TC probe for pod: nginx in namespace np-test at interface 0"}
{"level":"info","ts":"2026-07-28T17:50:49.723Z","caller":"ebpf/bpf_client.go:838","msg":"Load the eBPF program"}
{"level":"info","ts":"2026-07-28T17:50:49.889Z","caller":"ebpf/bpf_client.go:838","msg":"Prog Load Succeeded for egress, progFD: 33, pinpath: /sys/fs/bpf/globals/aws/programs/nginx@np-test_handle_egress, maps: 3"}
{"level":"info","ts":"2026-07-28T17:50:49.889Z","caller":"ebpf/bpf_client.go:749","msg":"Attempting to do an Egress Attach with progFD: 33"}
{"level":"info","ts":"2026-07-28T17:50:49.889Z","caller":"rpc/rpc_handler.go:86","msg":"Successfully attached Egress TC probe for pod: nginx in namespace np-test at interface 0"}
{"level":"debug","ts":"2026-07-28T17:50:49.889Z","caller":"rpc/rpc_grpc.pb.go:261","msg":"No active policies present for podIdentifier: nginx@np-test"}
{"level":"info","ts":"2026-07-28T17:50:49.889Z","caller":"rpc/rpc_grpc.pb.go:261","msg":"Updating pod_state map to default allow/default deny for podIdentifier: nginx@np-test for network policy state, value: 1"}
{"level":"info","ts":"2026-07-28T17:50:49.889Z","caller":"rpc/rpc_handler.go:162","msg":"Pod has an Ingress hook attached. Update the corresponding map progFD: 29, mapName: ingress_pod_state_map, key: 0, value: 1"}
{"level":"info","ts":"2026-07-28T17:50:49.889Z","caller":"rpc/rpc_handler.go:162","msg":"Pod has an Egress hook attached. Update the corresponding map progFD: 33, mapName: egress_pod_state_map, key: 0, value: 1"}
{"level":"info","ts":"2026-07-28T17:50:49.889Z","caller":"rpc/rpc_grpc.pb.go:261","msg":"Updating pod_state map to default allow for podIdentifier: nginx@np-test, for cluster network policy state, value: 1"}
{"level":"info","ts":"2026-07-28T17:50:49.890Z","caller":"rpc/rpc_handler.go:170","msg":"Pod has an Ingress hook attached. Update the corresponding map progFD: 29, mapName: ingress_pod_state_map, key: 1, value: 1"}
{"level":"info","ts":"2026-07-28T17:50:49.890Z","caller":"rpc/rpc_handler.go:170","msg":"Pod has an Egress hook attached. Update the corresponding map progFD: 33, mapName: egress_pod_state_map, key: 1, value: 1"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
