### PR TITLE
test: gate podNameForReplica on Running to fix strict-mode exec race

### DIFF
--- a/test/integration/strict/strict_mode_test.go
+++ b/test/integration/strict/strict_mode_test.go
@@ -134,11 +134,11 @@ var _ = Describe("Strict Mode Test Cases", func() {
 				secondPod = podNameForReplica(namespace, clientName, firstPod)
 			})
 
-			// The second replica shares the pod identifier's already-programmed maps, so it should
-			// be allowed without a cold-start deny. Consistently from the first poll asserts that
-			// instantaneous property: a replica that wrongly cold-started would probe CLOSE early.
-			// (We do not assert the first replica's initial deny window; catching it depends on
-			// racing the probe against datapath programming, which is the flake this rewrite removes.)
+			// Second replica shares the pod identifier's already-programmed maps, so it must be
+			// allowed from its first packet with no cold-start deny. podNameForReplica returns it
+			// only once Running, so Consistently probes from the start: a replica that wrongly
+			// cold-started would show an early CLOSE. (Eventually here would mask that by waiting
+			// out the deny, breaking the "instantaneous" contract.)
 			By("verifying the second replica reaches the server without a cold-start deny", func() {
 				Consistently(func() (string, error) {
 					return fw.PodManager.TCPProbe(namespace, secondPod, serverPodIP, serverPort)
@@ -209,8 +209,9 @@ func deployIdleDeployment(name, ns string, replicas int) *appsv1.Deployment {
 	return dp
 }
 
-// podNameForReplica polls for a pod with app=name, skipping excludeName, since scaling
-// does not block until the new pod registers.
+// podNameForReplica polls for a Running pod with app=name, skipping excludeName. It gates
+// on Running so callers get an exec-ready pod: a pod is listed by label before its
+// container starts, and exec-ing that early fails with "container not found".
 func podNameForReplica(ns, name, excludeName string) string {
 	var podName string
 	Eventually(func() bool {
@@ -219,12 +220,12 @@ func podNameForReplica(ns, name, excludeName string) string {
 			return false
 		}
 		for _, pod := range pods {
-			if pod.Name != excludeName {
+			if pod.Name != excludeName && pod.Status.Phase == v1.PodRunning {
 				podName = pod.Name
 				return true
 			}
 		}
 		return false
-	}, utils.ProbeTimeout, utils.ProbeInterval).Should(BeTrue(), "expected a client replica with app=%s", name)
+	}, utils.ProbeTimeout, utils.ProbeInterval).Should(BeTrue(), "expected a running client replica with app=%s", name)
 	return podName
 }


### PR DESCRIPTION
## What

Gate `podNameForReplica` (strict-mode integration suite) on the pod being **Running** before returning it.

## Why

The strict-mode "second replica" spec flaked in the IPv6 1.32 beta canary:

```
[FAILED] in [It] - strict_mode_test.go ... second replica reaches the server
  The function passed to Consistently returned the following error:
  exec failed: unable to upgrade connection: container not found ("busybox")
[FAILED] Failed after 0.022s.
```

It failed on `Consistently`'s **first poll** (0.022s). Root cause:

- `ScaleDeploymentAndWaitTillReady` only patches the replica count; it does **not** wait for the new pod.
- `podNameForReplica` returned a pod as soon as it appeared **by label** — before its container had started.
- The probe then exec'd into a pod whose container wasn't running yet → `container not found`.

Intermittent (~50%): 07-26 18:00 UTC run FAILED, 07-27 00:00 UTC run PASSED on the same code, so `network_policy_ipv6_al2023_132-Alarm` flapped.

Reproduced deterministically on an EKS cluster: exec into a `Pending` pod returns exactly `unable to upgrade connection: container not found ("busybox")`; exec after the pod reaches `Running` succeeds.

## Fix

Fix the category at the source: `podNameForReplica` now waits for `Status.Phase == Running`, so every caller receives an exec-ready pod — the exec race cannot occur regardless of the construct wrapping the probe.

The second replica keeps its `Consistently(OPEN)`-from-first-poll assertion (no `Eventually`). Because the pod is now returned only once Running, `Consistently` can probe from the start, which is what actually verifies the strict-mode contract: a replica that shares an already-programmed pod identifier must be allowed with **no cold-start deny**. An `Eventually` here would mask a wrong cold-start deny by waiting it out, so it is deliberately not used.

## Testing

- `go vet`, `gofmt`, and compile: clean.
- Reproduced the race deterministically: exec into a `Pending` pod returns the exact CI error; exec after `Running` succeeds.
- Ran the fixed scale → Running-gate → probe sequence on a live EKS cluster **10/10 with zero `container not found`** (including `Consistently` polling across the full stability window), where the pre-fix label-only path reproduced the error.
