### PR TITLE
test: use family-aware host CIDR in ebpf_rules egress policy

### DIFF
--- a/test/integration/policy/ebpf_rules_test.go
+++ b/test/integration/policy/ebpf_rules_test.go
@@ -77,11 +77,8 @@ var _ = Describe("Ebpf prog protocol and port evaluation test", func() {
 	}
 
 	It("should allow traffic to both ports when policy uses ANY protocol and ANY port", func() {
-		serverCIDR, err := hostCIDR(serverIP)
-		Expect(err).ToNot(HaveOccurred())
-
 		rule := manifest.NewEgressRuleBuilder().
-			AddPeer(nil, nil, serverCIDR).
+			AddPeer(nil, nil, serverIP+hostMask(fw.Options.IpFamily)).
 			AddPort(-1, "").
 			Build()
 
@@ -103,11 +100,8 @@ var _ = Describe("Ebpf prog protocol and port evaluation test", func() {
 	})
 
 	It("should allow on portA and deny on portB when policy allows only portA and ANY protocol", func() {
-		serverCIDR, err := hostCIDR(serverIP)
-		Expect(err).ToNot(HaveOccurred())
-
 		rule := manifest.NewEgressRuleBuilder().
-			AddPeer(nil, nil, serverCIDR).
+			AddPeer(nil, nil, serverIP+hostMask(fw.Options.IpFamily)).
 			AddPort(portA, "").
 			Build()
 

--- a/test/integration/policy/ebpf_rules_test.go
+++ b/test/integration/policy/ebpf_rules_test.go
@@ -77,8 +77,11 @@ var _ = Describe("Ebpf prog protocol and port evaluation test", func() {
 	}
 
 	It("should allow traffic to both ports when policy uses ANY protocol and ANY port", func() {
+		serverCIDR, err := hostCIDR(serverIP)
+		Expect(err).ToNot(HaveOccurred())
+
 		rule := manifest.NewEgressRuleBuilder().
-			AddPeer(nil, nil, serverIP+"/32").
+			AddPeer(nil, nil, serverCIDR).
 			AddPort(-1, "").
 			Build()
 
@@ -100,8 +103,11 @@ var _ = Describe("Ebpf prog protocol and port evaluation test", func() {
 	})
 
 	It("should allow on portA and deny on portB when policy allows only portA and ANY protocol", func() {
+		serverCIDR, err := hostCIDR(serverIP)
+		Expect(err).ToNot(HaveOccurred())
+
 		rule := manifest.NewEgressRuleBuilder().
-			AddPeer(nil, nil, serverIP+"/32").
+			AddPeer(nil, nil, serverCIDR).
 			AddPort(portA, "").
 			Build()
 

--- a/test/integration/policy/except_block_test.go
+++ b/test/integration/policy/except_block_test.go
@@ -65,18 +65,14 @@ func getPrefix(ipStr string, maskLen int) (string, error) {
 	return fmt.Sprintf("%s/%d", network.String(), maskLen), nil
 }
 
-// hostCIDR returns the single-host CIDR for ip — /32 for IPv4, /128 for IPv6.
-// A bare "/32" suffix is rejected by the API server on IPv6 addresses.
-func hostCIDR(ip string) (string, error) {
-	parsed := net.ParseIP(ip)
-	if parsed == nil {
-		return "", fmt.Errorf("invalid IP address: %s", ip)
+// hostMask returns the single-host CIDR suffix for the cluster's IP family —
+// "/32" for IPv4, "/128" for IPv6. A "/32" suffix is rejected by the API server
+// on IPv6 addresses.
+func hostMask(ipFamily string) string {
+	if ipFamily == "IPv6" {
+		return "/128"
 	}
-	bits := 128
-	if parsed.To4() != nil {
-		bits = 32
-	}
-	return getPrefix(ip, bits)
+	return "/32"
 }
 
 var _ = Describe("IPBlock Except Test Cases", func() {

--- a/test/integration/policy/except_block_test.go
+++ b/test/integration/policy/except_block_test.go
@@ -65,6 +65,20 @@ func getPrefix(ipStr string, maskLen int) (string, error) {
 	return fmt.Sprintf("%s/%d", network.String(), maskLen), nil
 }
 
+// hostCIDR returns the single-host CIDR for ip — /32 for IPv4, /128 for IPv6.
+// A bare "/32" suffix is rejected by the API server on IPv6 addresses.
+func hostCIDR(ip string) (string, error) {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return "", fmt.Errorf("invalid IP address: %s", ip)
+	}
+	bits := 128
+	if parsed.To4() != nil {
+		bits = 32
+	}
+	return getPrefix(ip, bits)
+}
+
 var _ = Describe("IPBlock Except Test Cases", func() {
 	var (
 		serverPod       *v1.Pod


### PR DESCRIPTION
## What

The eBPF protocol/port evaluation specs built the egress `ipBlock` peer as `serverIP + "/32"`, where `serverIP` is the server pod's `Status.PodIP`. On an IPv6 cluster that pod IP is a 128-bit address, so a `/32` prefix leaves bits set beyond the mask and the API server rejects the NetworkPolicy.

Both specs fail in `BeforeEach`/policy creation before any dataplane assertion runs. This is IPv4-only test code; the fix makes the single-host CIDR suffix IP-family aware (`/32` for IPv4, `/128` for IPv6).

## Error before the fix

```
[FAILED] in [It] - test/integration/policy/ebpf_rules_test.go:93
Expected success, but got an error:
    NetworkPolicy.networking.k8s.io "any-port-protocol-allow" is invalid:
    spec.egress[0].to[0].ipBlock.cidr: Invalid value: "2600:1f14:1235:8601:a9e8::4/32":
    must not have bits set beyond the prefix length
```

Identical failure for the second spec at `ebpf_rules_test.go:115` (`"single-port-allow"`).

## Fix

Add a `hostMask` helper that returns the single-host CIDR suffix for the cluster IP family:

```go
// hostMask returns the single-host CIDR suffix for the cluster's IP family —
// "/32" for IPv4, "/128" for IPv6.
func hostMask(ipFamily string) string {
	if ipFamily == "IPv6" {
		return "/128"
	}
	return "/32"
}
```

Both call sites in `ebpf_rules_test.go` now use `serverIP + hostMask(fw.Options.IpFamily)` instead of `serverIP + "/32"`, deriving the suffix from the `--ip-family` flag (consistent with how the other integration suites branch on `fw.Options.IpFamily`).

## Testing

Validated on an IPv6 single-stack EKS cluster (AmazonLinux2023 nodes, network policy enforcement enabled):

- After the fix, the applied policy carries the correct host mask, e.g. `cidr: 2600:1f18:865:c100:6d7f::1/128`.
- Ran the two affected specs 11+ times on IPv6 — all passing, no flakes.
- Ran the full policy suite (all 6 specs) repeatedly on IPv6 to confirm there is no inter-test dependency — passing.
- `go vet ./test/integration/policy/...` passes.

No production behavior changes; this is test-only.
