### PR TITLE
fix: add node-IP allow to ClusterNetworkPolicy ingress path

### DIFF
--- a/pkg/fwruleprocessor/fw_rule_processor.go
+++ b/pkg/fwruleprocessor/fw_rule_processor.go
@@ -284,6 +284,19 @@ func (f *FirewallRuleProcessor) ComputeClusterPolicyMapEntriesFromEndpointRules(
 	cidrL4Rules := make(map[string][]utils.L4Rule)
 	processedCIDRs := make([]string, 0)
 
+	// Traffic from the local node should always be allowed. Add NodeIP by default to map entries.
+	// This ensures kubelet liveness/readiness probes are never blocked by cluster network policies.
+	_, mapKey, _ := net.ParseCIDR(f.nodeIP + f.hostMask)
+	key := utils.ComputeTrieKey(*mapKey, f.enableIPv6)
+	nodeIPL4Rule := []utils.L4Rule{
+		{
+			Action:   "Accept",
+			Priority: 0, // Highest priority — node-IP allow must not be overridden
+		},
+	}
+	value := utils.ComputeTrieValueForCPE(nodeIPL4Rule)
+	firewallMap[string(key)] = value
+
 	// Step 1: Sort by CIDR length
 	f.sortByCIDRLength(firewallRules)
 

--- a/pkg/fwruleprocessor/fw_rule_processor_test.go
+++ b/pkg/fwruleprocessor/fw_rule_processor_test.go
@@ -754,3 +754,102 @@ func TestFWRuleProcessor_NonCanonicalCIDRCollision(t *testing.T) {
 		}
 	}
 }
+
+func TestFWRuleProcessor_ComputeClusterPolicyMapEntriesFromEndpointRules_NodeIPAlwaysPresent(t *testing.T) {
+	nodeIP := "10.1.1.1"
+	_, nodeIPCIDR, _ := net.ParseCIDR(nodeIP + "/32")
+	nodeIPKey := string(utils.ComputeTrieKey(*nodeIPCIDR, false))
+
+	tests := []struct {
+		name          string
+		firewallRules []EbpfFirewallRules
+	}{
+		{
+			name:          "Empty rules - node IP still present",
+			firewallRules: []EbpfFirewallRules{},
+		},
+		{
+			name: "Egress-only CNP rule - node IP still present in ingress map",
+			firewallRules: []EbpfFirewallRules{
+				{
+					IPCidr:   "0.0.0.0/0",
+					Action:   "Accept",
+					Priority: 50,
+				},
+			},
+		},
+		{
+			name: "Ingress rule with specific CIDR - node IP also present",
+			firewallRules: []EbpfFirewallRules{
+				{
+					IPCidr:   "10.0.0.0/16",
+					Action:   "Accept",
+					Priority: 50,
+					L4Info: []v1alpha1.Port{
+						{
+							Protocol: func() *corev1.Protocol { p := corev1.ProtocolTCP; return &p }(),
+							Port:     Int32Ptr(80),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Rule with node IP CIDR - should be skipped but node IP entry still present",
+			firewallRules: []EbpfFirewallRules{
+				{
+					IPCidr:   "10.1.1.1/32",
+					Action:   "Accept",
+					Priority: 50,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewFirewallRuleProcessor(nodeIP, "/32", false).ComputeClusterPolicyMapEntriesFromEndpointRules(tt.firewallRules)
+			assert.NoError(t, err)
+
+			// The node IP key must always be present in the resulting map
+			_, nodeIPExists := got[nodeIPKey]
+			assert.True(t, nodeIPExists, "Node IP entry must always be present in cluster policy firewall map")
+		})
+	}
+}
+
+func TestFWRuleProcessor_ComputeClusterPolicyMapEntriesFromEndpointRules_IPv6_NodeIPAlwaysPresent(t *testing.T) {
+	nodeIP := "2001:db8:abcd:0012::1"
+	_, nodeIPCIDR, _ := net.ParseCIDR(nodeIP + "/128")
+	nodeIPKey := string(utils.ComputeTrieKey(*nodeIPCIDR, true))
+
+	tests := []struct {
+		name          string
+		firewallRules []EbpfFirewallRules
+	}{
+		{
+			name:          "Empty rules - IPv6 node IP still present",
+			firewallRules: []EbpfFirewallRules{},
+		},
+		{
+			name: "Egress-only CNP rule - IPv6 node IP still present",
+			firewallRules: []EbpfFirewallRules{
+				{
+					IPCidr:   "::/0",
+					Action:   "Accept",
+					Priority: 50,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewFirewallRuleProcessor(nodeIP, "/128", true).ComputeClusterPolicyMapEntriesFromEndpointRules(tt.firewallRules)
+			assert.NoError(t, err)
+
+			_, nodeIPExists := got[nodeIPKey]
+			assert.True(t, nodeIPExists, "IPv6 Node IP entry must always be present in cluster policy firewall map")
+		})
+	}
+}


### PR DESCRIPTION
In NETWORK_POLICY_ENFORCING_MODE=strict, pods whose only matching policy is a ClusterNetworkPolicy do not receive the implicit node-IP allow that pods with namespaced NetworkPolicies receive. This causes kubelet liveness/readiness probes to be dropped and the pod crash-loops.

Root cause:
The namespaced path (ComputeMapEntriesFromEndpointRules) unconditionally adds the node IP to the ingress firewall map, but the cluster policy path (ComputeClusterPolicyMapEntriesFromEndpointRules) was missing this entry.

Additionally, shouldSkipRule() discards any CNP rule whose CIDR matches the node IP exactly, making it impossible for users to work around this within a ClusterNetworkPolicy.

Fix:
Add the node-IP allow-all entry to ComputeClusterPolicyMapEntriesFromEndpointRules using ComputeTrieValueForCPE (the correct value format for cp_ingress_map, which includes a priority field — unlike the namespaced ingress_map which uses ComputeTrieValue with a 3-field format). 
The entry is written with Action=Accept at Priority=0 (highest), ensuring node-IP traffic is always allowed regardless of other CNP rules.

Testing:
- Reproduced on EKS cluster with v1.4.0 NPA in strict mode
- Applied egress-only ClusterNetworkPolicy + deployment with livenessProbe
- BEFORE fix: pod crash-looped every ~30s with: 'Liveness probe failed: context deadline exceeded' 
eBPF state: 
```
cp_ingress_map (Map 701): Empty ingress_map (Map 702): Empty 
ingress_pod_state_map: Key 0=2 (DEFAULT_DENY), Key 1=0 (POLICIES_APPLIED)
```
- AFTER fix (v1.4.0 + this patch): Pod stable 6+ minutes, 0 restarts, 1/1 Ready 
```
cp_ingress_map (Map 718): Contains node-IP allow entry (192.168.29.203/32) 
ingress_map (Map 719): Empty (expected - no namespaced NP) 
ingress_pod_state_map: Key 0=2 (DEFAULT_DENY), Key 1=0 (POLICIES_APPLIED)
```
 The probe traffic from node IP now matches in cp_ingress_map before falling through to the DEFAULT_DENY tier.

Unit tests added:
- TestFWRuleProcessor_ComputeClusterPolicyMapEntriesFromEndpointRules_NodeIPAlwaysPresent (4 sub-tests: empty rules, egress-only CNP, specific CIDR, node-IP CIDR)
- TestFWRuleProcessor_ComputeClusterPolicyMapEntriesFromEndpointRules_IPv6_NodeIPAlwaysPresent (2 sub-tests: empty rules, egress-only CNP)


*Issue #, if available:* https://github.com/aws/aws-network-policy-agent/issues/635


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
