### PR TITLE
Fix stale eBPF entries when a pod is deselected from a PolicyEndpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,16 @@ ENVTEST_K8S_VERSION = 1.25.0
 # Skip installing the latest managed addon while running cyclonus test
 SKIP_ADDON_INSTALLATION ?= "false"
 
+# Defaults for the integration test suite flags (see test/framework/options.go).
+KUBECONFIG ?= $(HOME)/.kube/config
+TEST_IMAGE_REGISTRY ?= registry.k8s.io
+AWS_REGION ?= us-west-2
+# IP family for the test suite. Derived from IP_FAMILY rather than defaulting it, so
+# targets that pass IP_FAMILY through to scripts keep their existing behaviour.
+TEST_IP_FAMILY = $(if $(IP_FAMILY),$(IP_FAMILY),IPv4)
+# Ginkgo focus regex matching only the PolicyEndpoint selector-narrowing specs.
+SELECTOR_NARROWING_FOCUS ?= PolicyEndpoint Selector Narrowing
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -318,6 +328,21 @@ cleanup-ebpf-sdk-override:
 run-cyclonus-test: ## Runs cyclonus tests on an existing cluster. Call with CLUSTER_NAME=<name of your cluster>, SKIP_ADDON_INSTALLATION=<true/false> to execute cyclonus test
 ifdef CLUSTER_NAME
 	CLUSTER_NAME=$(CLUSTER_NAME) SKIP_ADDON_INSTALLATION=$(SKIP_ADDON_INSTALLATION) ./scripts/run-cyclonus-tests.sh
+else
+	@echo 'Pass CLUSTER_NAME parameter'
+endif
+
+.PHONY: test-selector-narrowing
+test-selector-narrowing: ## Runs only the PolicyEndpoint selector-narrowing integration specs against an existing cluster. Call with CLUSTER_NAME=<name of your cluster>, optionally KUBECONFIG=<path>, TEST_IMAGE_REGISTRY=<registry>, AWS_REGION=<region>, IP_FAMILY=<IPv4|IPv6>
+ifdef CLUSTER_NAME
+	CGO_ENABLED=0 ginkgo -v -timeout 30m --no-color --fail-on-pending \
+		--focus='$(SELECTOR_NARROWING_FOCUS)' \
+		./test/integration/policy -- \
+		--cluster-kubeconfig=$(KUBECONFIG) \
+		--cluster-name=$(CLUSTER_NAME) \
+		--aws-region=$(AWS_REGION) \
+		--test-image-registry=$(TEST_IMAGE_REGISTRY) \
+		--ip-family=$(TEST_IP_FAMILY)
 else
 	@echo 'Pass CLUSTER_NAME parameter'
 endif

--- a/controllers/policyendpoints_controller.go
+++ b/controllers/policyendpoints_controller.go
@@ -415,6 +415,32 @@ func (r *PolicyEndpointsReconciler) cleanupPod(ctx context.Context, targetPod np
 			}
 		}
 
+	} else {
+		// No PolicyEndpoint resources remain against this podIdentifier. The controller
+		// cache is already clean, but the dataplane may still be programmed with the
+		// stale policy maps and a POLICIES_APPLIED pod_state (for instance when a
+		// NetworkPolicy podSelector is narrowed and this pod gets deselected). Reset it
+		// to the mode's default state so the pod recovers without a restart.
+		// Skip pods whose eBPF context is already gone: the probes are detached once the last
+		// pod of a podIdentifier leaves the node, so there is nothing left to clear and
+		// updateeBPFMaps would fail. Returning an error there would make routine pod deletion
+		// fail the reconcile and requeue forever.
+		if !r.ebpfClient.HasBPFContext(podIdentifier) {
+			log().Debugf("Skipping cleanup for podIdentifier %s: no eBPF context registered", podIdentifier)
+			return nil
+		}
+
+		state := DEFAULT_ALLOW
+		if utils.IsStrictMode(r.GeteBPFClient().GetNetworkPolicyMode()) {
+			state = DEFAULT_DENY
+		}
+
+		log().Infof("No policies remain. Resetting maps and pod_state for podIdentifier: %s networkPolicyMode: %s", podIdentifier, r.GeteBPFClient().GetNetworkPolicyMode())
+		err = r.updateeBPFMaps(podIdentifier, nil, nil, state)
+		if err != nil {
+			log().Errorf("Map update(s) failed for podIdentifier %s: %v", podIdentifier, err)
+			return err
+		}
 	}
 	return nil
 }

--- a/controllers/policyendpoints_controller_test.go
+++ b/controllers/policyendpoints_controller_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-network-policy-agent/pkg/ebpf"
 	fwrp "github.com/aws/aws-network-policy-agent/pkg/fwruleprocessor"
 	npatypes "github.com/aws/aws-network-policy-agent/pkg/types"
+	"github.com/aws/aws-network-policy-agent/pkg/utils"
 	"github.com/golang/mock/gomock"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -1554,4 +1556,583 @@ func TestCleanupPod_BothDirectionsActiveNoCatchAll(t *testing.T) {
 	assert.NotContains(t, mockBpf.LastEgressRules, catchAll)
 	assert.NotEmpty(t, mockBpf.LastIngressRules)
 	assert.NotEmpty(t, mockBpf.LastEgressRules)
+}
+
+// Shared fixture for the selector-narrowing scenario (the design's bug
+// condition). Used by TestCleanupPodStaleDataplane and by the task 3.4
+// fix-checking tests below so every variant exercises the exact same setup and
+// only the MockBpfClient configuration differs.
+const (
+	narrowingNamespace     = "my-namespace"
+	narrowingNodeIP        = "1.1.1.1"
+	narrowingParentNP      = "allow-all-egress"
+	narrowingPodName       = "deployment1rs-1"
+	narrowingPodIdentifier = "deployment1rs@my-namespace"
+)
+
+// runSelectorNarrowingReconcile drives one Reconcile over the selector-narrowing
+// scenario: the PolicyEndpoint no longer selects any local pod
+// (PodSelectorEndpoints is empty) while the controller caches still hold the old
+// pod and its podIdentifier. deriveTargetPodsForParentNP() drops the
+// podIdentifier from podIdentifierToPolicyEndpointMap before cleanupPod() runs,
+// so cleanupPod() takes the "no policies remain" path.
+//
+// mockBpf is supplied by the caller so each test can configure
+// PodIdentifiersWithoutBPFContext / NetworkPolicyMode and then assert on the
+// recorded calls.
+func runSelectorNarrowingReconcile(t *testing.T, mockBpf *ebpf.MockBpfClient) (*PolicyEndpointsReconciler, error) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockClient := mock_client.NewMockClient(ctrl)
+	r := NewPolicyEndpointsReconciler(mockClient, narrowingNodeIP, mockBpf, false)
+
+	// PolicyEndpoint after the podSelector narrowing: no local pod is selected
+	// anymore, so PodSelectorEndpoints is empty.
+	narrowedPE := getPolicyEndpoint(narrowingParentNP, narrowingNamespace, []policyendpoint.PodEndpoint{})
+
+	stalePod := npatypes.Pod{
+		NamespacedName: types.NamespacedName{Name: narrowingPodName, Namespace: narrowingNamespace},
+		PodIP:          "10.1.1.1",
+	}
+
+	// Controller caches still reflect the pre-narrowing state.
+	r.policyEndpointSelectorMap.Store(utils.GetPolicyEndpointIdentifier(narrowedPE.Name, narrowingNamespace),
+		[]npatypes.Pod{stalePod})
+	r.podIdentifierToPolicyEndpointMap.Store(narrowingPodIdentifier, []string{narrowedPE.Name})
+	r.networkPolicyToPodIdentifierMap.Store(narrowingParentNP, []string{narrowingPodIdentifier})
+
+	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{
+		Name:      narrowedPE.GetName(),
+		Namespace: narrowedPE.GetNamespace(),
+	}, gomock.Any()).DoAndReturn(
+		func(ctx context.Context, key types.NamespacedName, currentPE *policyendpoint.PolicyEndpoint, opts ...client.GetOption) error {
+			*currentPE = narrowedPE
+			return nil
+		},
+	).AnyTimes()
+
+	mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&policyendpoint.PolicyEndpointList{}), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, list *policyendpoint.PolicyEndpointList, opts ...*client.ListOptions) error {
+			*list = policyendpoint.PolicyEndpointList{
+				Items: []policyendpoint.PolicyEndpoint{narrowedPE},
+			}
+			return nil
+		},
+	).AnyTimes()
+
+	_, err := r.Reconcile(context.TODO(), controllerruntime.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      narrowedPE.GetName(),
+			Namespace: narrowedPE.GetNamespace(),
+		},
+	})
+	return r, err
+}
+
+// TestCleanupPodStaleDataplane reproduces the selector-narrowing scenario: a
+// NetworkPolicy's podSelector is narrowed so the local pod is no longer selected
+// (PolicyEndpoint.Spec.PodSelectorEndpoints becomes empty) while the controller
+// caches still hold the pod and its podIdentifier.
+//
+// This is the bug condition from the design doc:
+//
+//	NOT exists(podIdentifierToPolicyEndpointMap[podIdentifier]) AND ebpfClient.HasBPFContext(podIdentifier) == true
+//
+// The assertions below encode the EXPECTED behavior (design `expectedBehavior`):
+// the dataplane is cleaned to the mode's default state with empty rule sets.
+//
+// **Validates: Requirements 1.1, 1.2, 1.3, 1.4**
+func TestCleanupPodStaleDataplane(t *testing.T) {
+	podIdentifier := narrowingPodIdentifier
+
+	mockBpf := &ebpf.MockBpfClient{}
+	r, err := runSelectorNarrowingReconcile(t, mockBpf)
+
+	assert.NoError(t, err)
+
+	// Bug condition precondition 1: the control plane cache no longer tracks any
+	// PolicyEndpoint for this podIdentifier.
+	_, ok := r.podIdentifierToPolicyEndpointMap.Load(podIdentifier)
+	assert.False(t, ok, "podIdentifierToPolicyEndpointMap should no longer track the deselected podIdentifier")
+	assert.Equal(t, 0, sizeOfSyncMap(&r.networkPolicyToPodIdentifierMap))
+
+	// Bug condition precondition 2: the dataplane is still programmed for it.
+	assert.True(t, mockBpf.HasBPFContext(podIdentifier))
+
+	// Expected behavior: a full map update with empty rule sets, pod state reset
+	// to the standard-mode default (DEFAULT_ALLOW).
+	assert.Contains(t, mockBpf.CallLog, "UpdateEbpfMaps",
+		"stale dataplane must be cleared via UpdateEbpfMaps when no policies remain")
+	assert.Contains(t, mockBpf.CallLog, "UpdatePodStateEbpfMaps",
+		"pod state must be reset when no policies remain")
+	assert.Equal(t, ebpf.POD_STATE_MAP_KEY, mockBpf.LastPodStateKey)
+	assert.Equal(t, ebpf.DEFAULT_ALLOW, mockBpf.LastPodState)
+	assert.Empty(t, mockBpf.LastIngressRules)
+	assert.Empty(t, mockBpf.LastEgressRules)
+
+	// Task 3.4 fix checking, standard mode. Companion assertions that pin down
+	// HOW the default state was reached: the no-policies-remain branch must reuse
+	// the existing updateeBPFMaps() path end to end, in order, and nothing else
+	// may touch the bpf client during this reconcile.
+	t.Run("reuses the full updateeBPFMaps sequence", func(t *testing.T) {
+		assert.Equal(t,
+			[]string{"UpdateEbpfMaps", "UpdatePodStateEbpfMaps", "CreatePodStateEbpfEntryIfNotExists"},
+			mockBpf.CallLog)
+	})
+
+	// DEFAULT_ALLOW above is only meaningful if the mode under test really is
+	// standard - otherwise the assertion would pass vacuously.
+	t.Run("standard mode drives the DEFAULT_ALLOW selection", func(t *testing.T) {
+		assert.Equal(t, "standard", r.GeteBPFClient().GetNetworkPolicyMode())
+		assert.False(t, utils.IsStrictMode(r.GeteBPFClient().GetNetworkPolicyMode()))
+	})
+}
+
+// TestCleanupPodStaleDataplaneWithoutBPFContextIsNoOp is task 3.4 test 2: the
+// same selector-narrowing scenario, but the pod no longer holds an eBPF context
+// (it is already gone from the node). The no-policies-remain branch must bail out
+// before touching any map and must not report an error.
+//
+// **Validates: Requirements 2.4**
+func TestCleanupPodStaleDataplaneWithoutBPFContextIsNoOp(t *testing.T) {
+	mockBpf := &ebpf.MockBpfClient{
+		PodIdentifiersWithoutBPFContext: map[string]bool{narrowingPodIdentifier: true},
+	}
+	r, err := runSelectorNarrowingReconcile(t, mockBpf)
+
+	assert.NoError(t, err)
+
+	// Same control-plane precondition as TestCleanupPodStaleDataplane: the cache
+	// entry is gone. Only the dataplane side of the bug condition differs.
+	_, ok := r.podIdentifierToPolicyEndpointMap.Load(narrowingPodIdentifier)
+	assert.False(t, ok, "podIdentifierToPolicyEndpointMap should no longer track the deselected podIdentifier")
+	assert.False(t, mockBpf.HasBPFContext(narrowingPodIdentifier))
+
+	assert.NotContains(t, mockBpf.CallLog, "UpdateEbpfMaps",
+		"no map update expected when the pod has no eBPF context")
+	assert.NotContains(t, mockBpf.CallLog, "UpdatePodStateEbpfMaps",
+		"no pod state update expected when the pod has no eBPF context")
+	assert.Empty(t, mockBpf.CallLog, "cleanup must be a complete no-op")
+}
+
+// TestCleanupPodStaleDataplaneStrictMode is task 3.4 test 3: identical to
+// TestCleanupPodStaleDataplane except the agent runs in strict mode, so the
+// stale dataplane must be reset to DEFAULT_DENY instead of DEFAULT_ALLOW.
+//
+// **Validates: Requirements 2.1, 2.2, 2.5**
+func TestCleanupPodStaleDataplaneStrictMode(t *testing.T) {
+	mockBpf := &ebpf.MockBpfClient{NetworkPolicyMode: "strict"}
+	r, err := runSelectorNarrowingReconcile(t, mockBpf)
+
+	assert.NoError(t, err)
+	assert.True(t, utils.IsStrictMode(r.GeteBPFClient().GetNetworkPolicyMode()))
+
+	_, ok := r.podIdentifierToPolicyEndpointMap.Load(narrowingPodIdentifier)
+	assert.False(t, ok, "podIdentifierToPolicyEndpointMap should no longer track the deselected podIdentifier")
+	assert.Equal(t, 0, sizeOfSyncMap(&r.networkPolicyToPodIdentifierMap))
+	assert.True(t, mockBpf.HasBPFContext(narrowingPodIdentifier))
+
+	assert.Contains(t, mockBpf.CallLog, "UpdateEbpfMaps",
+		"stale dataplane must be cleared via UpdateEbpfMaps when no policies remain")
+	assert.Contains(t, mockBpf.CallLog, "UpdatePodStateEbpfMaps",
+		"pod state must be reset when no policies remain")
+	assert.Equal(t, ebpf.POD_STATE_MAP_KEY, mockBpf.LastPodStateKey)
+	assert.Equal(t, ebpf.DEFAULT_DENY, mockBpf.LastPodState,
+		"strict mode must fall back to DEFAULT_DENY, not DEFAULT_ALLOW")
+	assert.Empty(t, mockBpf.LastIngressRules)
+	assert.Empty(t, mockBpf.LastEgressRules)
+}
+
+// --- Property 2: Preservation ------------------------------------------------
+//
+// Baseline observed on UNFIXED code. These assertions are a snapshot of the
+// current behavior of cleanupPod() for inputs where isBugCondition(X) is FALSE,
+// i.e. everything the fix in task 3.3 must leave untouched:
+//
+//	(a) podIdentifier IS still present in podIdentifierToPolicyEndpointMap
+//	    -> rules are re-derived from the remaining PolicyEndpoints, a
+//	       0.0.0.0/0 catch-all is appended to whichever direction has no
+//	       active policy, and pod state stays at POLICIES_APPLIED.
+//	(b) podIdentifier is ABSENT from the map AND HasBPFContext() == false
+//	    -> complete no-op: err == nil and CallLog records no map updates.
+//
+// Go has no built-in property-based testing framework, so the property is
+// approximated by exhaustive combinatorial enumeration over the input space:
+//
+//	remaining PE count {1, 2} x isolation {none, ingress-only, egress-only, both}
+//	x HasBPFContext {true, false}
+//
+// The HasBPFContext dimension is a structural invariant check for case (a):
+// the value must not influence the outcome, because the guard in cleanupPod()
+// takes the cache-present path before HasBPFContext() is ever consulted.
+
+// peIsolationShape describes how a remaining PolicyEndpoint is built for the
+// preservation matrix.
+type peIsolationShape string
+
+const (
+	// shapeNone: rules on both directions, no PodIsolation.
+	shapeNone peIsolationShape = "none"
+	// shapeIngressOnly: ingress isolation only, no rules.
+	shapeIngressOnly peIsolationShape = "ingress-only"
+	// shapeEgressOnly: egress isolation only, no rules.
+	shapeEgressOnly peIsolationShape = "egress-only"
+	// shapeBoth: ingress and egress isolation, no rules.
+	shapeBoth peIsolationShape = "both"
+)
+
+// buildRemainingPE builds one of the four isolation shapes above.
+func buildRemainingPE(name, parentNP, namespace string, shape peIsolationShape) policyendpoint.PolicyEndpoint {
+	protocolTCP := corev1.ProtocolTCP
+	var port80 int32 = 80
+
+	pe := policyendpoint.PolicyEndpoint{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: policyendpoint.PolicyEndpointSpec{
+			PodSelector: &metav1.LabelSelector{},
+			PolicyRef:   policyendpoint.PolicyReference{Name: parentNP, Namespace: namespace},
+		},
+	}
+
+	switch shape {
+	case shapeNone:
+		pe.Spec.Ingress = []policyendpoint.EndpointInfo{
+			{CIDR: "10.0.0.0/24", Ports: []policyendpoint.Port{{Port: &port80, Protocol: &protocolTCP}}},
+		}
+		pe.Spec.Egress = []policyendpoint.EndpointInfo{
+			{CIDR: "10.0.1.0/24", Ports: []policyendpoint.Port{{Port: &port80, Protocol: &protocolTCP}}},
+		}
+	case shapeIngressOnly:
+		pe.Spec.PodIsolation = []networking.PolicyType{networking.PolicyTypeIngress}
+	case shapeEgressOnly:
+		pe.Spec.PodIsolation = []networking.PolicyType{networking.PolicyTypeEgress}
+	case shapeBoth:
+		pe.Spec.PodIsolation = []networking.PolicyType{networking.PolicyTypeIngress, networking.PolicyTypeEgress}
+	}
+	return pe
+}
+
+type preservationCombo struct {
+	peCount       int
+	shape         peIsolationShape
+	hasBPFContext bool
+}
+
+// preservationCombos enumerates the full 2 x 4 x 2 input space.
+func preservationCombos() []preservationCombo {
+	var combos []preservationCombo
+	for _, peCount := range []int{1, 2} {
+		for _, shape := range []peIsolationShape{shapeNone, shapeIngressOnly, shapeEgressOnly, shapeBoth} {
+			for _, hasBPFContext := range []bool{true, false} {
+				combos = append(combos, preservationCombo{peCount: peCount, shape: shape, hasBPFContext: hasBPFContext})
+			}
+		}
+	}
+	return combos
+}
+
+// wantRuleCounts returns the observed ingress/egress rule-set sizes and whether
+// each direction carries the 0.0.0.0/0 catch-all, for a given combo.
+func wantRuleCounts(c preservationCombo) (wantIngress, wantEgress int, ingressCatchAll, egressCatchAll bool) {
+	switch c.shape {
+	case shapeNone:
+		// One ingress and one egress rule per remaining PE; both directions
+		// active so no catch-all is appended.
+		return c.peCount, c.peCount, false, false
+	case shapeIngressOnly:
+		// Ingress isolated -> no ingress rules, no ingress catch-all.
+		// Egress has no active policy -> catch-all appended.
+		return 0, 1, false, true
+	case shapeEgressOnly:
+		return 1, 0, true, false
+	default: // shapeBoth
+		// Both directions isolated -> both rule sets stay empty.
+		return 0, 0, false, false
+	}
+}
+
+// TestCleanupPodPreservationProperty freezes the baseline behavior of
+// cleanupPod() for all non-bug-condition inputs (Property 2: Preservation).
+//
+// **Validates: Requirements 2.4, 3.1, 3.2, 3.3, 3.4, 3.6, 3.7, 3.8**
+func TestCleanupPodPreservationProperty(t *testing.T) {
+	namespace := "my-namespace"
+	nodeIP := "1.1.1.1"
+	podIdentifier := "deployment1rs@my-namespace"
+	cleanedUpPE := "cleaned-np-abcd"
+	catchAll := fwrp.EbpfFirewallRules{IPCidr: "0.0.0.0/0"}
+
+	targetPod := npatypes.Pod{
+		NamespacedName: types.NamespacedName{Name: "deployment1rs-1", Namespace: namespace},
+		PodIP:          "10.1.1.1",
+	}
+
+	// Case (a): the podIdentifier is still tracked in
+	// podIdentifierToPolicyEndpointMap. Rules are re-derived, catch-all entries
+	// are appended where a direction has no active policy, and pod state stays
+	// at POLICIES_APPLIED - independent of HasBPFContext.
+	for _, combo := range preservationCombos() {
+		c := combo
+		name := fmt.Sprintf("cache-present/pe=%d/isolation=%s/hasBPFContext=%t", c.peCount, c.shape, c.hasBPFContext)
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockClient := mock_client.NewMockClient(ctrl)
+			mockBpf := &ebpf.MockBpfClient{}
+			if !c.hasBPFContext {
+				mockBpf.PodIdentifiersWithoutBPFContext = map[string]bool{podIdentifier: true}
+			}
+			r := NewPolicyEndpointsReconciler(mockClient, nodeIP, mockBpf, false)
+
+			var remainingPEs []string
+			for i := 0; i < c.peCount; i++ {
+				parentNP := fmt.Sprintf("remaining-%d", i)
+				peName := parentNP + "-abcd"
+				pe := buildRemainingPE(peName, parentNP, namespace, c.shape)
+				remainingPEs = append(remainingPEs, peName)
+
+				mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: peName, Namespace: namespace}, gomock.Any()).DoAndReturn(
+					func(ctx context.Context, key types.NamespacedName, currentPE *policyendpoint.PolicyEndpoint, opts ...client.GetOption) error {
+						*currentPE = pe
+						return nil
+					},
+				).AnyTimes()
+			}
+			r.podIdentifierToPolicyEndpointMap.Store(podIdentifier, remainingPEs)
+
+			err := r.cleanupPod(context.Background(), targetPod, cleanedUpPE, true)
+			assert.NoError(t, err)
+
+			// Observed baseline: the existing update path runs end to end.
+			assert.Equal(t,
+				[]string{"UpdateEbpfMaps", "UpdatePodStateEbpfMaps", "CreatePodStateEbpfEntryIfNotExists"},
+				mockBpf.CallLog)
+			assert.Equal(t, ebpf.POD_STATE_MAP_KEY, mockBpf.LastPodStateKey)
+			assert.Equal(t, ebpf.POLICIES_APPLIED, mockBpf.LastPodState,
+				"pod state must stay at POLICIES_APPLIED while any PolicyEndpoint remains")
+
+			wantIngress, wantEgress, ingressCatchAll, egressCatchAll := wantRuleCounts(c)
+			assert.Len(t, mockBpf.LastIngressRules, wantIngress)
+			assert.Len(t, mockBpf.LastEgressRules, wantEgress)
+			if ingressCatchAll {
+				assert.Contains(t, mockBpf.LastIngressRules, catchAll)
+			} else {
+				assert.NotContains(t, mockBpf.LastIngressRules, catchAll)
+			}
+			if egressCatchAll {
+				assert.Contains(t, mockBpf.LastEgressRules, catchAll)
+			} else {
+				assert.NotContains(t, mockBpf.LastEgressRules, catchAll)
+			}
+
+			// The podIdentifier entry itself is untouched by cleanupPod().
+			val, ok := r.podIdentifierToPolicyEndpointMap.Load(podIdentifier)
+			assert.True(t, ok)
+			assert.Equal(t, remainingPEs, val.([]string))
+		})
+	}
+
+	// Case (b): the podIdentifier is absent from the map AND the pod no longer
+	// holds an eBPF context. Observed baseline is a complete no-op.
+	// HasBPFContext == true with an absent podIdentifier is the bug condition
+	// (Property 1) and is deliberately excluded here.
+	for _, combo := range preservationCombos() {
+		c := combo
+		if c.hasBPFContext {
+			continue
+		}
+		name := fmt.Sprintf("cache-absent-no-bpf-context/pe=%d/isolation=%s", c.peCount, c.shape)
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockClient := mock_client.NewMockClient(ctrl)
+			mockBpf := &ebpf.MockBpfClient{
+				PodIdentifiersWithoutBPFContext: map[string]bool{podIdentifier: true},
+			}
+			r := NewPolicyEndpointsReconciler(mockClient, nodeIP, mockBpf, false)
+
+			// Nothing is stored in podIdentifierToPolicyEndpointMap: the entry
+			// was already removed by deriveTargetPodsForParentNP().
+			mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+			err := r.cleanupPod(context.Background(), targetPod, cleanedUpPE, true)
+			assert.NoError(t, err)
+
+			assert.Empty(t, mockBpf.CallLog, "no-op expected when the pod has no eBPF context")
+			assert.NotContains(t, mockBpf.CallLog, "UpdateEbpfMaps")
+			assert.NotContains(t, mockBpf.CallLog, "UpdatePodStateEbpfMaps")
+			assert.False(t, mockBpf.HasBPFContext(podIdentifier))
+		})
+	}
+
+	// Mock default-mode regression from the controller's point of view: an
+	// unconfigured MockBpfClient still reports standard mode, so the
+	// DEFAULT_ALLOW / DEFAULT_DENY selection in cleanupPod() keeps its current
+	// behavior. The mock-level equivalent lives in
+	// pkg/ebpf/bpf_client_mock_behavior_test.go:TestMockBpfClientGetNetworkPolicyModeBehavior.
+	t.Run("mock defaults to standard network policy mode", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		r := NewPolicyEndpointsReconciler(mock_client.NewMockClient(ctrl), nodeIP, &ebpf.MockBpfClient{}, false)
+		assert.Equal(t, "standard", r.GeteBPFClient().GetNetworkPolicyMode())
+		assert.False(t, utils.IsStrictMode(r.GeteBPFClient().GetNetworkPolicyMode()))
+	})
+}
+
+// --- Task 3.5: property-based / combinatorial enumeration --------------------
+//
+// Property 1 is enumerated over the network-policy-mode dimension below.
+// Property 2 (preservation) is already enumerated exhaustively over
+// remaining PE count {1, 2} x isolation {none, ingress-only, egress-only, both}
+// x HasBPFContext {true, false} by TestCleanupPodPreservationProperty above, so
+// it is not repeated here. What that matrix does NOT reach is the
+// cache-present-but-no-active-policy path, which is the only input where the
+// original inner branch and the new no-policies-remain branch produce the same
+// pod state - that gap is closed by
+// TestCleanupPodGuardNeverEntersNoPoliciesRemainBranch below.
+
+// networkPolicyModeCombos enumerates the mode dimension of Property 1. The
+// mixed casing pins down that utils.IsStrictMode() is case-insensitive, and the
+// empty value pins down the mock's fallback to standard mode.
+func networkPolicyModeCombos() []string {
+	return []string{"", "standard", "Strict", "strict"}
+}
+
+// wantDefaultPodState derives the expected pod state from utils.IsStrictMode()
+// itself rather than from a per-string lookup table, so the expectation cannot
+// drift away from the production decision the fix makes.
+func wantDefaultPodState(effectiveMode string) int {
+	if utils.IsStrictMode(effectiveMode) {
+		return ebpf.DEFAULT_DENY
+	}
+	return ebpf.DEFAULT_ALLOW
+}
+
+// TestCleanupPodStaleDataplaneModeProperty enumerates Property 1 (bug
+// condition) over NetworkPolicyMode ∈ {"", "standard", "Strict", "strict"} with
+// HasBPFContext == true. For every mode the stale dataplane must be reset to the
+// state utils.IsStrictMode() dictates, with empty ingress/egress rule sets.
+//
+// **Validates: Requirements 2.2, 2.5**
+func TestCleanupPodStaleDataplaneModeProperty(t *testing.T) {
+	for _, mode := range networkPolicyModeCombos() {
+		mode := mode
+		t.Run(fmt.Sprintf("mode=%q", mode), func(t *testing.T) {
+			mockBpf := &ebpf.MockBpfClient{NetworkPolicyMode: mode}
+			r, err := runSelectorNarrowingReconcile(t, mockBpf)
+			assert.NoError(t, err)
+
+			// Bug condition holds: cache entry gone, dataplane still programmed.
+			_, ok := r.podIdentifierToPolicyEndpointMap.Load(narrowingPodIdentifier)
+			assert.False(t, ok, "podIdentifierToPolicyEndpointMap should no longer track the deselected podIdentifier")
+			assert.True(t, mockBpf.HasBPFContext(narrowingPodIdentifier))
+
+			effectiveMode := r.GeteBPFClient().GetNetworkPolicyMode()
+			wantState := wantDefaultPodState(effectiveMode)
+
+			assert.Equal(t,
+				[]string{"UpdateEbpfMaps", "UpdatePodStateEbpfMaps", "CreatePodStateEbpfEntryIfNotExists"},
+				mockBpf.CallLog)
+			assert.Equal(t, ebpf.POD_STATE_MAP_KEY, mockBpf.LastPodStateKey)
+			assert.Equal(t, wantState, mockBpf.LastPodState,
+				"pod state must follow utils.IsStrictMode(%q)", effectiveMode)
+			assert.Empty(t, mockBpf.LastIngressRules)
+			assert.Empty(t, mockBpf.LastEgressRules)
+		})
+	}
+}
+
+// TestCleanupPodGuardNeverEntersNoPoliciesRemainBranch is the structural guard
+// invariant: whenever the podIdentifier IS present in
+// podIdentifierToPolicyEndpointMap, the new no-policies-remain branch must never
+// run, no matter what HasBPFContext() would answer.
+//
+// The remaining PolicyEndpoint here carries no rules and no PodIsolation, so the
+// original inner branch also lands on DEFAULT_ALLOW / DEFAULT_DENY. Pod state
+// alone therefore cannot tell the two paths apart - HasBPFContext == false is
+// what discriminates them: the new branch would short-circuit to a complete
+// no-op, while the cache-present path must still push a full map update. The
+// combos where remaining policies keep the pod at POLICIES_APPLIED are already
+// enumerated by TestCleanupPodPreservationProperty.
+//
+// **Validates: Requirements 3.1, 3.2, 3.8**
+func TestCleanupPodGuardNeverEntersNoPoliciesRemainBranch(t *testing.T) {
+	namespace := "my-namespace"
+	nodeIP := "1.1.1.1"
+	podIdentifier := "deployment1rs@my-namespace"
+	cleanedUpPE := "cleaned-np-abcd"
+
+	targetPod := npatypes.Pod{
+		NamespacedName: types.NamespacedName{Name: "deployment1rs-1", Namespace: namespace},
+		PodIP:          "10.1.1.1",
+	}
+
+	for _, peCount := range []int{1, 2} {
+		for _, hasBPFContext := range []bool{true, false} {
+			for _, mode := range networkPolicyModeCombos() {
+				peCount, hasBPFContext, mode := peCount, hasBPFContext, mode
+				name := fmt.Sprintf("pe=%d/hasBPFContext=%t/mode=%q", peCount, hasBPFContext, mode)
+				t.Run(name, func(t *testing.T) {
+					ctrl := gomock.NewController(t)
+					defer ctrl.Finish()
+
+					mockClient := mock_client.NewMockClient(ctrl)
+					mockBpf := &ebpf.MockBpfClient{NetworkPolicyMode: mode}
+					if !hasBPFContext {
+						mockBpf.PodIdentifiersWithoutBPFContext = map[string]bool{podIdentifier: true}
+					}
+					r := NewPolicyEndpointsReconciler(mockClient, nodeIP, mockBpf, false)
+
+					var remainingPEs []string
+					for i := 0; i < peCount; i++ {
+						parentNP := fmt.Sprintf("empty-%d", i)
+						peName := parentNP + "-abcd"
+						// No rules and no PodIsolation: the cache-present path
+						// resolves to "no active policies".
+						pe := policyendpoint.PolicyEndpoint{
+							ObjectMeta: metav1.ObjectMeta{Name: peName, Namespace: namespace},
+							Spec: policyendpoint.PolicyEndpointSpec{
+								PodSelector: &metav1.LabelSelector{},
+								PolicyRef:   policyendpoint.PolicyReference{Name: parentNP, Namespace: namespace},
+							},
+						}
+						remainingPEs = append(remainingPEs, peName)
+
+						mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: peName, Namespace: namespace}, gomock.Any()).DoAndReturn(
+							func(ctx context.Context, key types.NamespacedName, currentPE *policyendpoint.PolicyEndpoint, opts ...client.GetOption) error {
+								*currentPE = pe
+								return nil
+							},
+						).AnyTimes()
+					}
+					r.podIdentifierToPolicyEndpointMap.Store(podIdentifier, remainingPEs)
+
+					err := r.cleanupPod(context.Background(), targetPod, cleanedUpPE, true)
+					assert.NoError(t, err)
+
+					// Path signature of the cache-present branch: the full update
+					// sequence ran even when HasBPFContext() is false, so the new
+					// no-policies-remain branch was never entered.
+					assert.Equal(t,
+						[]string{"UpdateEbpfMaps", "UpdatePodStateEbpfMaps", "CreatePodStateEbpfEntryIfNotExists"},
+						mockBpf.CallLog)
+					assert.Equal(t, ebpf.POD_STATE_MAP_KEY, mockBpf.LastPodStateKey)
+					assert.Equal(t, wantDefaultPodState(r.GeteBPFClient().GetNetworkPolicyMode()), mockBpf.LastPodState)
+					assert.Empty(t, mockBpf.LastIngressRules)
+					assert.Empty(t, mockBpf.LastEgressRules)
+
+					// The cache entry itself is untouched by cleanupPod().
+					val, ok := r.podIdentifierToPolicyEndpointMap.Load(podIdentifier)
+					assert.True(t, ok)
+					assert.Equal(t, remainingPEs, val.([]string))
+				})
+			}
+		}
+	}
 }

--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -110,6 +110,7 @@ type BpfClient interface {
 	GetNetworkPolicyMode() string
 	CreatePodStateEbpfEntryIfNotExists(podIdentifier string, key int, state int) error
 	ClearDeletedPod(podNamespacedName string)
+	HasBPFContext(podIdentifier string) bool
 }
 
 type BPFContext struct {
@@ -1324,6 +1325,15 @@ func (l *bpfClient) IsFirstPodInPodIdentifier(podIdentifier string) bool {
 		}
 	}
 	return firstPodInPodIdentifier
+}
+
+// HasBPFContext reports whether an eBPF context is currently registered for the given
+// podIdentifier. The context is created when probes are attached and removed once the last
+// pod of the identifier leaves the node, so callers can use this to skip map updates that
+// would otherwise fail with "no bpf context registered".
+func (l *bpfClient) HasBPFContext(podIdentifier string) bool {
+	_, ok := l.policyEndpointeBPFContext.Load(podIdentifier)
+	return ok
 }
 
 func (l *bpfClient) isProgFdShared(targetPodName string, targetPodNamespace string) (bool, error) {

--- a/pkg/ebpf/bpf_client_mock.go
+++ b/pkg/ebpf/bpf_client_mock.go
@@ -36,6 +36,19 @@ type MockBpfClient struct {
 	// Captured args from the most recent UpdateEbpfMaps call.
 	LastIngressRules []fwrp.EbpfFirewallRules
 	LastEgressRules  []fwrp.EbpfFirewallRules
+
+	// Captured args from the most recent UpdatePodStateEbpfMaps call.
+	LastPodStateKey int
+	LastPodState    int
+
+	// PodIdentifiersWithoutBPFContext lets tests simulate pods whose eBPF
+	// context has already been torn down. HasBPFContext returns false for any
+	// podIdentifier present here, and true otherwise.
+	PodIdentifiersWithoutBPFContext map[string]bool
+
+	// NetworkPolicyMode overrides the value returned by GetNetworkPolicyMode.
+	// An empty value falls back to "standard" to preserve existing behavior.
+	NetworkPolicyMode string
 }
 
 func (m *MockBpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier string, numInterfaces int) error {
@@ -62,7 +75,13 @@ func (m *MockBpfClient) UpdateClusterPolicyEbpfMaps(podIdentifier string, ingres
 
 func (m *MockBpfClient) UpdatePodStateEbpfMaps(podIdentifier string, key int, state int, updateIngress bool, updateEgress bool) error {
 	m.CallLog = append(m.CallLog, "UpdatePodStateEbpfMaps")
+	m.LastPodStateKey = key
+	m.LastPodState = state
 	return m.UpdatePodStateEbpfMapsErr
+}
+
+func (m *MockBpfClient) HasBPFContext(podIdentifier string) bool {
+	return !m.PodIdentifiersWithoutBPFContext[podIdentifier]
 }
 
 func (m *MockBpfClient) IsFirstPodInPodIdentifier(podIdentifier string) bool {
@@ -76,7 +95,10 @@ func (m *MockBpfClient) ReAttachEbpfProbes() error {
 }
 
 func (m *MockBpfClient) GetNetworkPolicyMode() string {
-	return "standard"
+	if m.NetworkPolicyMode == "" {
+		return "standard"
+	}
+	return m.NetworkPolicyMode
 }
 
 func (m *MockBpfClient) CreatePodStateEbpfEntryIfNotExists(podIdentifier string, key int, state int) error {

--- a/pkg/ebpf/bpf_client_mock_behavior_test.go
+++ b/pkg/ebpf/bpf_client_mock_behavior_test.go
@@ -1,0 +1,50 @@
+package ebpf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockBpfClientHasBPFContextBehavior(t *testing.T) {
+	t.Run("defaults to true when no overrides are set", func(t *testing.T) {
+		m := &MockBpfClient{}
+		assert.True(t, m.HasBPFContext("foo@default"))
+	})
+
+	t.Run("returns false only for listed pod identifiers", func(t *testing.T) {
+		m := &MockBpfClient{
+			PodIdentifiersWithoutBPFContext: map[string]bool{
+				"gone@default": true,
+			},
+		}
+		assert.False(t, m.HasBPFContext("gone@default"))
+		assert.True(t, m.HasBPFContext("present@default"))
+	})
+}
+
+func TestMockBpfClientGetNetworkPolicyModeBehavior(t *testing.T) {
+	t.Run("falls back to standard when unset", func(t *testing.T) {
+		m := &MockBpfClient{}
+		assert.Equal(t, "standard", m.GetNetworkPolicyMode())
+	})
+
+	t.Run("returns the configured mode", func(t *testing.T) {
+		m := &MockBpfClient{NetworkPolicyMode: "strict"}
+		assert.Equal(t, "strict", m.GetNetworkPolicyMode())
+	})
+}
+
+func TestMockBpfClientRecordsLastPodState(t *testing.T) {
+	m := &MockBpfClient{}
+
+	err := m.UpdatePodStateEbpfMaps("foo@default", POD_STATE_MAP_KEY, DEFAULT_ALLOW, true, true)
+	assert.NoError(t, err)
+	assert.Equal(t, POD_STATE_MAP_KEY, m.LastPodStateKey)
+	assert.Equal(t, DEFAULT_ALLOW, m.LastPodState)
+
+	err = m.UpdatePodStateEbpfMaps("foo@default", CLUSTER_POLICY_POD_STATE_MAP_KEY, DEFAULT_DENY, true, true)
+	assert.NoError(t, err)
+	assert.Equal(t, CLUSTER_POLICY_POD_STATE_MAP_KEY, m.LastPodStateKey)
+	assert.Equal(t, DEFAULT_DENY, m.LastPodState)
+}

--- a/test/integration/policy/selector_narrowing_deselection_test.go
+++ b/test/integration/policy/selector_narrowing_deselection_test.go
@@ -1,0 +1,431 @@
+package policy
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-network-policy-agent/test/framework/manifest"
+	"github.com/aws/aws-network-policy-agent/test/framework/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	network "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+/*
+Dataplane validation for the two remaining PolicyEndpoint deselection triggers.
+selector_narrowing_test.go covers the first trigger (the NetworkPolicy podSelector is
+narrowed). This file covers:
+
+  - Pod label removal: the podSelector is untouched, the POD loses the label. The pod
+    keeps running, so the agent must clear its policy maps and move
+    egress_pod_state_map[POD_STATE_MAP_KEY] from POLICIES_APPLIED to the mode default
+    in place. The label is patched on a bare pod, never on a Deployment template -
+    patching a template recreates the pod and a fresh pod would pass even with the bug.
+
+  - Two policies selecting one pod: dropping the pod from one of them must leave the
+    other policy's rules programmed (the pod still has a PolicyEndpoint, so the
+    reset-with-nil-rules path must not run). Only when the pod is dropped from the
+    second policy as well does the reset happen.
+*/
+
+const (
+	// Pod-label-removal scenario. Pod names avoid a "-<suffix>" form: the agent
+	// derives the pin-path identifier by dropping everything after the last "-",
+	// so names sharing a prefix would collapse onto one identifier.
+	labelRemovalPolicyName    = "label-removal-egress-deny"
+	labelRemovalSelectorKey   = "selector-group"
+	labelRemovalSelectorValue = "labelremoval"
+	labelRemovalClientName    = "labelremovalclient"
+	labelRemovalServerName    = "labelremovalserver"
+
+	// Two-policy scenario.
+	multiPolicyAllowName         = "multi-policy-allow-server"
+	multiPolicyDenyName          = "multi-policy-deny-all"
+	multiPolicyAllowKey          = "multipolicy-allow-group"
+	multiPolicyDenyKey           = "multipolicy-deny-group"
+	multiPolicySelectorValue     = "multipolicy"
+	multiPolicyClientName        = "multipolicyclient"
+	multiPolicyAllowedServerName = "multipolicyallowedserver"
+	multiPolicyBlockedServerName = "multipolicyblockedserver"
+)
+
+var _ = Describe("PolicyEndpoint Selector Narrowing on Pod Label Removal", Ordered, func() {
+	var (
+		serverPod  *v1.Pod
+		clientPod  *v1.Pod
+		serverIP   string
+		clientNode string
+		policy     *network.NetworkPolicy
+		liveClient podSnapshot
+	)
+
+	It("should clear stale egress state when the pod loses the selector label, without a pod restart", func() {
+		By("Deploying a target server pod exposing a probe-able port", func() {
+			serverPod = buildNarrowingServer(labelRemovalServerName)
+			pod, err := fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, serverPod, narrowingPodTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			serverIP = pod.Status.PodIP
+			Expect(serverIP).ToNot(BeEmpty())
+		})
+
+		By("Deploying a client pod carrying the selector label", func() {
+			clientPod = buildIdleClient(labelRemovalClientName,
+				map[string]string{labelRemovalSelectorKey: labelRemovalSelectorValue})
+			pod, err := fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, clientPod, narrowingPodTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			clientNode = pod.Spec.NodeName
+			Expect(clientNode).ToNot(BeEmpty())
+		})
+
+		By("Applying an egress-deny policy whose podSelector matches the client label", func() {
+			policy = manifest.NewNetworkPolicyBuilder().
+				Namespace(namespace).
+				Name(labelRemovalPolicyName).
+				PodSelector(labelRemovalSelectorKey, labelRemovalSelectorValue).
+				SetPolicyType(false, true).
+				Build()
+
+			printNetworkPolicyYAML(policy)
+			Expect(fw.NetworkPolicyManager.CreateNetworkPolicy(ctx, policy)).To(Succeed())
+		})
+
+		By("Verifying the client cannot reach the server", func() {
+			Eventually(func() (string, error) {
+				return fw.PodManager.TCPProbe(namespace, labelRemovalClientName, serverIP, narrowingProbePort)
+			}, utils.EnforcementTimeout, utils.ProbeInterval).Should(Equal("CLOSE"),
+				"expected egress from %s to the server to be denied", labelRemovalClientName)
+		})
+
+		By("Confirming the client's egress pod state is POLICIES_APPLIED before the label is removed", func() {
+			withBPFCheckPod(clientNode, func(checkPodName string) {
+				Eventually(func() (int, error) {
+					return egressPodState(checkPodName, podIdentifierFor(labelRemovalClientName, namespace))
+				}, podStateTimeout, podStateInterval).Should(Equal(statePoliciesApplied),
+					"egress_pod_state_map[%d] should be POLICIES_APPLIED while the policy selects %s",
+					podStateMapKey, labelRemovalClientName)
+			})
+		})
+
+		By("Removing the selector label from the live pod", func() {
+			// Snapshot first so the post-transition assertion compares against the
+			// instance that was actually denied.
+			liveClient = snapshotPod(labelRemovalClientName)
+			removePodLabel(labelRemovalClientName, labelRemovalSelectorKey)
+		})
+
+		By("Verifying the client recovers connectivity without a restart", func() {
+			// Polling waits for the controller to regenerate the PolicyEndpoint and
+			// for the agent to reconcile it - no fixed sleep.
+			Eventually(func() (string, error) {
+				return fw.PodManager.TCPProbe(namespace, labelRemovalClientName, serverIP, narrowingProbePort)
+			}, utils.EnforcementTimeout, utils.ProbeInterval).Should(Equal("OPEN"),
+				"%s should regain egress once it no longer carries the selector label", labelRemovalClientName)
+		})
+
+		By("Confirming the same pod instance served the whole transition", func() {
+			expectSamePodInstance(labelRemovalClientName, liveClient)
+		})
+
+		By("Confirming the client's egress pod state is reset to DEFAULT_ALLOW", func() {
+			withBPFCheckPod(clientNode, func(checkPodName string) {
+				Eventually(func() (int, error) {
+					return egressPodState(checkPodName, podIdentifierFor(labelRemovalClientName, namespace))
+				}, podStateTimeout, podStateInterval).Should(Equal(stateDefaultAllow),
+					"egress_pod_state_map[%d] should fall back to DEFAULT_ALLOW once no policy selects %s",
+					podStateMapKey, labelRemovalClientName)
+			})
+		})
+	})
+
+	AfterAll(func() {
+		if policy != nil {
+			fw.NetworkPolicyManager.DeleteNetworkPolicy(ctx, policy)
+		}
+		for _, pod := range []*v1.Pod{clientPod, serverPod} {
+			if pod != nil {
+				fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, pod)
+			}
+		}
+	})
+})
+
+var _ = Describe("PolicyEndpoint Selector Narrowing with Multiple Policies", Ordered, func() {
+	var (
+		allowedServerPod *v1.Pod
+		blockedServerPod *v1.Pod
+		clientPod        *v1.Pod
+		allowedServerIP  string
+		blockedServerIP  string
+		clientNode       string
+		allowPolicy      *network.NetworkPolicy
+		denyPolicy       *network.NetworkPolicy
+		liveClient       podSnapshot
+	)
+
+	It("should keep the remaining policy's rules when the pod is dropped from only one of two policies", func() {
+		By("Deploying two server pods - one the allow policy permits, one it does not", func() {
+			allowedServerPod = buildNarrowingServer(multiPolicyAllowedServerName)
+			pod, err := fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, allowedServerPod, narrowingPodTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			allowedServerIP = pod.Status.PodIP
+			Expect(allowedServerIP).ToNot(BeEmpty())
+
+			blockedServerPod = buildNarrowingServer(multiPolicyBlockedServerName)
+			pod, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, blockedServerPod, narrowingPodTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			blockedServerIP = pod.Status.PodIP
+			Expect(blockedServerIP).ToNot(BeEmpty())
+		})
+
+		By("Deploying a client pod carrying both policies' selector labels", func() {
+			clientPod = buildIdleClient(multiPolicyClientName, map[string]string{
+				multiPolicyAllowKey: multiPolicySelectorValue,
+				multiPolicyDenyKey:  multiPolicySelectorValue,
+			})
+			pod, err := fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, clientPod, narrowingPodTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			clientNode = pod.Spec.NodeName
+			Expect(clientNode).ToNot(BeEmpty())
+		})
+
+		By("Applying two policies against the same client - one allows the first server, one denies all egress", func() {
+			// NetworkPolicy semantics union the allow sets, so with both policies in
+			// place egress is permitted to the allowed server only. That gives us a
+			// concrete rule (not just an isolation flag) whose survival we can observe.
+			allowRule := manifest.NewEgressRuleBuilder().
+				AddPeer(nil, nil, allowedServerIP+hostMask(fw.Options.IpFamily)).
+				AddPort(narrowingProbePort, v1.ProtocolTCP).
+				Build()
+
+			allowPolicy = manifest.NewNetworkPolicyBuilder().
+				Namespace(namespace).
+				Name(multiPolicyAllowName).
+				PodSelector(multiPolicyAllowKey, multiPolicySelectorValue).
+				AddEgressRule(allowRule).
+				Build()
+
+			denyPolicy = manifest.NewNetworkPolicyBuilder().
+				Namespace(namespace).
+				Name(multiPolicyDenyName).
+				PodSelector(multiPolicyDenyKey, multiPolicySelectorValue).
+				SetPolicyType(false, true).
+				Build()
+
+			printNetworkPolicyYAML(allowPolicy)
+			printNetworkPolicyYAML(denyPolicy)
+			Expect(fw.NetworkPolicyManager.CreateNetworkPolicy(ctx, allowPolicy)).To(Succeed())
+			Expect(fw.NetworkPolicyManager.CreateNetworkPolicy(ctx, denyPolicy)).To(Succeed())
+		})
+
+		By("Verifying both policies are enforced - allowed server reachable, other server denied", func() {
+			Eventually(func() (string, error) {
+				return fw.PodManager.TCPProbe(namespace, multiPolicyClientName, blockedServerIP, narrowingProbePort)
+			}, utils.EnforcementTimeout, utils.ProbeInterval).Should(Equal("CLOSE"),
+				"%s must not reach a server no policy allows", multiPolicyClientName)
+
+			Eventually(func() (string, error) {
+				return fw.PodManager.TCPProbe(namespace, multiPolicyClientName, allowedServerIP, narrowingProbePort)
+			}, utils.ProbeTimeout, utils.ProbeInterval).Should(Equal("OPEN"),
+				"%s should reach the server the allow policy permits", multiPolicyClientName)
+		})
+
+		By("Confirming the client's egress pod state is POLICIES_APPLIED", func() {
+			withBPFCheckPod(clientNode, func(checkPodName string) {
+				Eventually(func() (int, error) {
+					return egressPodState(checkPodName, podIdentifierFor(multiPolicyClientName, namespace))
+				}, podStateTimeout, podStateInterval).Should(Equal(statePoliciesApplied),
+					"egress_pod_state_map[%d] should be POLICIES_APPLIED while both policies select %s",
+					podStateMapKey, multiPolicyClientName)
+			})
+		})
+
+		By("Dropping the client from the deny-all policy only", func() {
+			// Snapshot first so the post-transition assertion compares against the
+			// instance that was actually under both policies.
+			liveClient = snapshotPod(multiPolicyClientName)
+			removePodLabel(multiPolicyClientName, multiPolicyDenyKey)
+		})
+
+		By("Verifying the allow policy's rules survive - only its destination stays reachable", func() {
+			// The window is the same budget the enforcement assertions use, so the
+			// controller has regenerated the PolicyEndpoint and the agent has
+			// reconciled it well inside it. A regression that clears the maps with nil
+			// rules shows up here as the blocked server becoming reachable.
+			Consistently(func() (string, error) {
+				return fw.PodManager.TCPProbe(namespace, multiPolicyClientName, blockedServerIP, narrowingProbePort)
+			}, utils.EnforcementTimeout, utils.ProbeInterval).Should(Equal("CLOSE"),
+				"%s is still selected by the allow policy, so egress outside its rules must stay denied",
+				multiPolicyClientName)
+
+			Consistently(func() (string, error) {
+				return fw.PodManager.TCPProbe(namespace, multiPolicyClientName, allowedServerIP, narrowingProbePort)
+			}, utils.StabilityWindow, utils.ProbeInterval).Should(Equal("OPEN"),
+				"the allow policy's rule for %s must stay programmed", multiPolicyClientName)
+		})
+
+		By("Confirming the client's egress pod state stays POLICIES_APPLIED", func() {
+			withBPFCheckPod(clientNode, func(checkPodName string) {
+				Consistently(func() (int, error) {
+					return egressPodState(checkPodName, podIdentifierFor(multiPolicyClientName, namespace))
+				}, utils.StabilityWindow, podStateInterval).Should(Equal(statePoliciesApplied),
+					"egress_pod_state_map[%d] must stay POLICIES_APPLIED while one policy still selects %s",
+					podStateMapKey, multiPolicyClientName)
+			})
+		})
+
+		By("Dropping the client from the allow policy as well", func() {
+			removePodLabel(multiPolicyClientName, multiPolicyAllowKey)
+		})
+
+		By("Verifying egress is finally unrestricted", func() {
+			Eventually(func() (string, error) {
+				return fw.PodManager.TCPProbe(namespace, multiPolicyClientName, blockedServerIP, narrowingProbePort)
+			}, utils.EnforcementTimeout, utils.ProbeInterval).Should(Equal("OPEN"),
+				"%s should regain full egress once no policy selects it", multiPolicyClientName)
+		})
+
+		By("Confirming the same pod instance served the whole transition", func() {
+			expectSamePodInstance(multiPolicyClientName, liveClient)
+		})
+
+		By("Confirming the client's egress pod state is reset to DEFAULT_ALLOW", func() {
+			withBPFCheckPod(clientNode, func(checkPodName string) {
+				Eventually(func() (int, error) {
+					return egressPodState(checkPodName, podIdentifierFor(multiPolicyClientName, namespace))
+				}, podStateTimeout, podStateInterval).Should(Equal(stateDefaultAllow),
+					"egress_pod_state_map[%d] should fall back to DEFAULT_ALLOW once no policy selects %s",
+					podStateMapKey, multiPolicyClientName)
+			})
+		})
+	})
+
+	AfterAll(func() {
+		for _, np := range []*network.NetworkPolicy{allowPolicy, denyPolicy} {
+			if np != nil {
+				fw.NetworkPolicyManager.DeleteNetworkPolicy(ctx, np)
+			}
+		}
+		for _, pod := range []*v1.Pod{clientPod, allowedServerPod, blockedServerPod} {
+			if pod != nil {
+				fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, pod)
+			}
+		}
+	})
+})
+
+// buildNarrowingServer returns a server pod that keeps a TCP listener up on
+// narrowingProbePort. busybox `nc -l` exits after one connection, so re-listen in a
+// loop.
+func buildNarrowingServer(name string) *v1.Pod {
+	cmd := fmt.Sprintf("while true; do nc -l -p %d; done", narrowingProbePort)
+	srv := manifest.NewBusyBoxContainerBuilder().
+		ImageRepository(fw.Options.TestImageRegistry).
+		Command([]string{"/bin/sh", "-c"}).
+		Args([]string{cmd}).
+		Build()
+
+	return manifest.NewDefaultPodBuilder().
+		Name(name).
+		Namespace(namespace).
+		AddLabel("app", name).
+		Container(srv).
+		Build()
+}
+
+// buildIdleClient returns an idle pod we exec probes into, carrying exactly the
+// labels given. Unlike buildNarrowingClient it adds no implicit selector label, so
+// the caller controls which policies select it.
+func buildIdleClient(name string, labels map[string]string) *v1.Pod {
+	ctnr := manifest.NewBusyBoxContainerBuilder().
+		ImageRepository(fw.Options.TestImageRegistry).
+		Command([]string{"/bin/sh", "-c"}).
+		Args([]string{"sleep 1000000"}).
+		Build()
+
+	builder := manifest.NewDefaultPodBuilder().
+		Name(name).
+		Namespace(namespace).
+		Container(ctnr)
+
+	for key, value := range labels {
+		builder = builder.AddLabel(key, value)
+	}
+	return builder.Build()
+}
+
+// removePodLabel drops labelKey from a live pod with a merge patch. The pod keeps
+// running, which is the whole point: patching a Deployment's pod template would
+// recreate the pod and a fresh pod would come up clean even with the bug present.
+func removePodLabel(podName string, labelKey string) {
+	Eventually(func() error {
+		current := &v1.Pod{}
+		if err := fw.K8sClient.Get(ctx,
+			client.ObjectKey{Namespace: namespace, Name: podName}, current); err != nil {
+			return err
+		}
+		if _, ok := current.Labels[labelKey]; !ok {
+			return nil
+		}
+		updated := current.DeepCopy()
+		delete(updated.Labels, labelKey)
+		// MergeFrom renders the removal as a null value for the key.
+		return fw.PodManager.PatchPod(ctx, current, updated)
+	}, policyUpdateTimeout, utils.PollIntervalShort).Should(Succeed())
+
+	Eventually(func() (map[string]string, error) {
+		current := &v1.Pod{}
+		if err := fw.K8sClient.Get(ctx,
+			client.ObjectKey{Namespace: namespace, Name: podName}, current); err != nil {
+			return nil, err
+		}
+		return current.Labels, nil
+	}, policyUpdateTimeout, utils.PollIntervalShort).ShouldNot(HaveKey(labelKey),
+		"label %s should be gone from pod %s", labelKey, podName)
+}
+
+// podSnapshot captures a running pod's identity so a later assertion can prove the
+// recovery happened on the same instance instead of on a replacement.
+type podSnapshot struct {
+	uid          types.UID
+	createdUnix  int64
+	restartCount int32
+}
+
+func snapshotPod(podName string) podSnapshot {
+	pod := &v1.Pod{}
+	Expect(fw.K8sClient.Get(ctx,
+		client.ObjectKey{Namespace: namespace, Name: podName}, pod)).To(Succeed())
+
+	return podSnapshot{
+		uid:          pod.UID,
+		createdUnix:  pod.CreationTimestamp.Unix(),
+		restartCount: totalRestarts(pod),
+	}
+}
+
+// expectSamePodInstance asserts the pod was neither recreated nor restarted since
+// the snapshot - the fix is about a live pod recovering in place.
+func expectSamePodInstance(podName string, before podSnapshot) {
+	pod := &v1.Pod{}
+	Expect(fw.K8sClient.Get(ctx,
+		client.ObjectKey{Namespace: namespace, Name: podName}, pod)).To(Succeed())
+
+	Expect(pod.UID).To(Equal(before.uid),
+		"pod %s was recreated - it must stay live across the transition", podName)
+	Expect(pod.CreationTimestamp.Unix()).To(Equal(before.createdUnix),
+		"pod %s creationTimestamp changed - it was replaced", podName)
+	Expect(totalRestarts(pod)).To(Equal(before.restartCount),
+		"pod %s containers restarted - recovery must not require a restart", podName)
+	Expect(pod.Status.Phase).To(Equal(v1.PodRunning),
+		"pod %s should still be running", podName)
+}
+
+func totalRestarts(pod *v1.Pod) int32 {
+	var total int32
+	for _, status := range pod.Status.ContainerStatuses {
+		total += status.RestartCount
+	}
+	return total
+}

--- a/test/integration/policy/selector_narrowing_test.go
+++ b/test/integration/policy/selector_narrowing_test.go
@@ -1,0 +1,312 @@
+package policy
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-network-policy-agent/test/framework/manifest"
+	"github.com/aws/aws-network-policy-agent/test/framework/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	network "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+/*
+Dataplane validation for PolicyEndpoint stale cleanup on selector narrowing.
+
+When a NetworkPolicy's podSelector is narrowed, the deselected pod loses its last
+PolicyEndpoint. The agent must clear that pod's policy maps and move
+egress_pod_state_map[POD_STATE_MAP_KEY] from POLICIES_APPLIED back to the mode
+default (DEFAULT_ALLOW in standard mode) so traffic recovers without a pod restart.
+Before the fix the maps kept the stale deny state and the pod stayed cut off.
+*/
+
+const (
+	// Mirrors pkg/ebpf: POD_STATE_MAP_KEY is the namespaced-policy key in the
+	// per-pod pod_state map (key 1 is the cluster-policy slot).
+	podStateMapKey = 0
+	// Mirrors pkg/ebpf pod states.
+	statePoliciesApplied = 0
+	stateDefaultAllow    = 1
+
+	// Mirrors pkg/utils.TC_EGRESS_POD_STATE_MAP — the per-pod egress state map
+	// name as reported by `aws-eks-na-cli ebpf loaded-ebpfdata`.
+	egressPodStateMapName = "egress_pod_state_map"
+
+	// These constants are duplicated rather than imported so the integration
+	// suite stays independent of the agent packages, which pull in linux-only
+	// eBPF and netlink dependencies.
+
+	narrowingProbePort  = 8080
+	narrowingPodTimeout = 2 * time.Minute
+	podStateTimeout     = 2 * time.Minute
+	podStateInterval    = 5 * time.Second
+	policyUpdateTimeout = 30 * time.Second
+	narrowingLabelKey   = "app"
+	narrowingLabelValue = "narrowingclient"
+	narrowingModeKey    = "network-mode"
+	narrowingModeValue  = "private"
+	narrowingPolicyName = "selector-narrowing-egress-deny"
+	narrowingServerName = "narrowingserver"
+	narrowingOpenClient = "selectoropen"
+	narrowingPrivClient = "selectorprivate"
+)
+
+var _ = Describe("PolicyEndpoint Selector Narrowing", Ordered, func() {
+	var (
+		serverPod     *v1.Pod
+		openClient    *v1.Pod
+		privateClient *v1.Pod
+		serverIP      string
+		openNodeName  string
+		policy        *network.NetworkPolicy
+	)
+
+	It("should clear stale egress state so a deselected pod recovers without a restart", func() {
+		By("Deploying a target server pod exposing a probe-able port", func() {
+			// busybox `nc -l` exits after one connection, so re-listen in a loop.
+			cmd := fmt.Sprintf("while true; do nc -l -p %d; done", narrowingProbePort)
+			srv := manifest.NewBusyBoxContainerBuilder().
+				ImageRepository(fw.Options.TestImageRegistry).
+				Command([]string{"/bin/sh", "-c"}).
+				Args([]string{cmd}).
+				Build()
+
+			serverPod = manifest.NewDefaultPodBuilder().
+				Name(narrowingServerName).
+				Namespace(namespace).
+				AddLabel("app", narrowingServerName).
+				Container(srv).
+				Build()
+
+			pod, err := fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, serverPod, narrowingPodTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			serverIP = pod.Status.PodIP
+			Expect(serverIP).ToNot(BeEmpty())
+		})
+
+		By("Deploying both client pods - selectoropen (unlabelled) and selectorprivate (network-mode=private)", func() {
+			// Pod names deliberately avoid a "-<suffix>" form: the agent derives the
+			// pin-path identifier by dropping everything after the last "-", so
+			// "client-open" and "client-private" would collapse to one identifier and
+			// the per-pod maps could no longer be told apart.
+			openClient = buildNarrowingClient(narrowingOpenClient, nil)
+			pod, err := fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, openClient, narrowingPodTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			openNodeName = pod.Spec.NodeName
+			Expect(openNodeName).ToNot(BeEmpty())
+
+			privateClient = buildNarrowingClient(narrowingPrivClient,
+				map[string]string{narrowingModeKey: narrowingModeValue})
+			_, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, privateClient, narrowingPodTimeout)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("Applying a broad egress-deny policy whose podSelector matches both clients", func() {
+			policy = manifest.NewNetworkPolicyBuilder().
+				Namespace(namespace).
+				Name(narrowingPolicyName).
+				PodSelector(narrowingLabelKey, narrowingLabelValue).
+				SetPolicyType(false, true).
+				Build()
+
+			printNetworkPolicyYAML(policy)
+			Expect(fw.NetworkPolicyManager.CreateNetworkPolicy(ctx, policy)).To(Succeed())
+		})
+
+		By("Verifying neither client can reach the server", func() {
+			for _, clientName := range []string{narrowingOpenClient, narrowingPrivClient} {
+				Eventually(func() (string, error) {
+					return fw.PodManager.TCPProbe(namespace, clientName, serverIP, narrowingProbePort)
+				}, utils.EnforcementTimeout, utils.ProbeInterval).Should(Equal("CLOSE"),
+					"expected egress from %s to the server to be denied", clientName)
+			}
+		})
+
+		By("Confirming selectoropen's egress pod state is POLICIES_APPLIED before narrowing", func() {
+			withBPFCheckPod(openNodeName, func(checkPodName string) {
+				Eventually(func() (int, error) {
+					return egressPodState(checkPodName, podIdentifierFor(narrowingOpenClient, namespace))
+				}, podStateTimeout, podStateInterval).Should(Equal(statePoliciesApplied),
+					"egress_pod_state_map[%d] should be POLICIES_APPLIED while the policy selects %s",
+					podStateMapKey, narrowingOpenClient)
+			})
+		})
+
+		By("Narrowing the podSelector to network-mode=private", func() {
+			// Retry on conflict - the API server may have a newer resourceVersion.
+			Eventually(func() error {
+				current := &network.NetworkPolicy{}
+				if err := fw.K8sClient.Get(ctx,
+					client.ObjectKey{Namespace: namespace, Name: narrowingPolicyName}, current); err != nil {
+					return err
+				}
+				current.Spec.PodSelector = metav1.LabelSelector{
+					MatchLabels: map[string]string{narrowingModeKey: narrowingModeValue},
+				}
+				return fw.K8sClient.Update(ctx, current)
+			}, policyUpdateTimeout, utils.PollIntervalShort).Should(Succeed())
+		})
+
+		By("Verifying selectoropen recovers connectivity without a restart", func() {
+			// Polling here is what waits for the controller to regenerate the
+			// PolicyEndpoint and for the agent to reconcile it - no fixed sleep.
+			Eventually(func() (string, error) {
+				return fw.PodManager.TCPProbe(namespace, narrowingOpenClient, serverIP, narrowingProbePort)
+			}, utils.EnforcementTimeout, utils.ProbeInterval).Should(Equal("OPEN"),
+				"%s should regain egress once the policy no longer selects it", narrowingOpenClient)
+		})
+
+		By("Verifying selectorprivate is still denied", func() {
+			Consistently(func() (string, error) {
+				return fw.PodManager.TCPProbe(namespace, narrowingPrivClient, serverIP, narrowingProbePort)
+			}, utils.StabilityWindow, utils.ProbeInterval).Should(Equal("CLOSE"),
+				"%s is still selected by the narrowed policy and must stay denied", narrowingPrivClient)
+		})
+
+		By("Confirming selectoropen's egress pod state is reset to DEFAULT_ALLOW", func() {
+			withBPFCheckPod(openNodeName, func(checkPodName string) {
+				Eventually(func() (int, error) {
+					return egressPodState(checkPodName, podIdentifierFor(narrowingOpenClient, namespace))
+				}, podStateTimeout, podStateInterval).Should(Equal(stateDefaultAllow),
+					"egress_pod_state_map[%d] should fall back to DEFAULT_ALLOW once no policy selects %s",
+					podStateMapKey, narrowingOpenClient)
+			})
+		})
+	})
+
+	AfterAll(func() {
+		if policy != nil {
+			fw.NetworkPolicyManager.DeleteNetworkPolicy(ctx, policy)
+		}
+		for _, pod := range []*v1.Pod{openClient, privateClient, serverPod} {
+			if pod != nil {
+				fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, pod)
+			}
+		}
+	})
+})
+
+// buildNarrowingClient returns an idle client pod we exec probes into. Every client
+// carries the broad selector label; extraLabels adds the narrowed selector label.
+func buildNarrowingClient(name string, extraLabels map[string]string) *v1.Pod {
+	ctnr := manifest.NewBusyBoxContainerBuilder().
+		ImageRepository(fw.Options.TestImageRegistry).
+		Command([]string{"/bin/sh", "-c"}).
+		Args([]string{"sleep 1000000"}).
+		Build()
+
+	builder := manifest.NewDefaultPodBuilder().
+		Name(name).
+		Namespace(namespace).
+		AddLabel(narrowingLabelKey, narrowingLabelValue).
+		Container(ctnr)
+
+	for key, value := range extraLabels {
+		builder = builder.AddLabel(key, value)
+	}
+	return builder.Build()
+}
+
+// withBPFCheckPod runs fn against a privileged pod on nodeName that can inspect the
+// node's BPF state through chroot. The pod is torn down when fn returns.
+func withBPFCheckPod(nodeName string, fn func(checkPodName string)) {
+	checkPod := utils.BuildBPFCheckPod(namespace, nodeName)
+	checkPod, err := fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, checkPod, narrowingPodTimeout)
+	Expect(err).ToNot(HaveOccurred())
+	defer fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, checkPod)
+
+	fn(checkPod.Name)
+}
+
+// egressPodState reads egress_pod_state_map[POD_STATE_MAP_KEY] for podIdentifier by
+// resolving the map ID from `ebpf loaded-ebpfdata` and then dumping that map.
+// Errors are returned (not asserted) so callers can poll with Eventually while the
+// agent reconciles.
+func egressPodState(checkPodName string, podIdentifier string) (int, error) {
+	output, err := fw.PodManager.ExecInPod(namespace, checkPodName,
+		[]string{"chroot", "/host", "/opt/cni/bin/aws-eks-na-cli", "ebpf", "loaded-ebpfdata"})
+	if err != nil {
+		return -1, fmt.Errorf("loaded-ebpfdata exec failed: %w", err)
+	}
+
+	state, err := utils.ParseLoadedEBPFData(output)
+	if err != nil {
+		return -1, fmt.Errorf("parse loaded-ebpfdata: %w", err)
+	}
+
+	mapKey := podIdentifier + "/" + egressPodStateMapName
+	mapID, ok := state.MapIDs[mapKey]
+	if !ok {
+		return -1, fmt.Errorf("map %q not found in loaded bpf data (available: %v)", mapKey, mapNames(state))
+	}
+
+	dump, err := fw.PodManager.ExecInPod(namespace, checkPodName,
+		[]string{"chroot", "/host", "/opt/cni/bin/aws-eks-na-cli", "ebpf", "dump-maps", strconv.Itoa(mapID)})
+	if err != nil {
+		return -1, fmt.Errorf("dump-maps %d exec failed: %w", mapID, err)
+	}
+
+	states := parsePodStateDump(dump)
+	value, ok := states[podStateMapKey]
+	if !ok {
+		return -1, fmt.Errorf("key %d absent from map %q (id %d), dump:\n%s", podStateMapKey, mapKey, mapID, dump)
+	}
+	GinkgoWriter.Printf("%s (map id %d) key %d state = %d\n", mapKey, mapID, podStateMapKey, value)
+	return value, nil
+}
+
+// parsePodStateDump parses `ebpf dump-maps <id>` output for a HASH pod_state map:
+//
+//	Key :  0
+//	State -  1
+//	*******************************
+func parsePodStateDump(output string) map[int]int {
+	states := make(map[int]int)
+	currentKey := -1
+
+	for _, raw := range strings.Split(output, "\n") {
+		line := strings.TrimSpace(raw)
+		switch {
+		case strings.HasPrefix(line, "Key :"):
+			key, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(line, "Key :")))
+			if err != nil {
+				currentKey = -1
+				continue
+			}
+			currentKey = key
+		case strings.HasPrefix(line, "State -"):
+			value, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(line, "State -")))
+			if err != nil || currentKey < 0 {
+				continue
+			}
+			states[currentKey] = value
+			currentKey = -1
+		}
+	}
+	return states
+}
+
+// podIdentifierFor mirrors pkg/utils.GetPodIdentifier: "." becomes "_", everything
+// after the last "-" in the pod name is dropped, and the namespace is joined with
+// "@". Kept local so this suite does not depend on the agent's linux-only packages.
+func podIdentifierFor(podName string, podNamespace string) string {
+	prefix := strings.ReplaceAll(podName, ".", "_")
+	if idx := strings.LastIndex(prefix, "-"); idx != -1 {
+		prefix = prefix[:idx]
+	}
+	return prefix + "@" + podNamespace
+}
+
+func mapNames(state utils.BPFState) []string {
+	names := make([]string, 0, len(state.MapIDs))
+	for name := range state.MapIDs {
+		names = append(names, name)
+	}
+	return names
+}


### PR DESCRIPTION
### Issue #, if available:  

When a pod stops being selected by a NetworkPolicy while the policy itself still exists — the `podSelector` is narrowed, or the pod loses the matching label — the nodeagent must clear that pod's eBPF maps. Today it does not: the pod stays at `POLICIES_APPLIED` with the previously programmed rules and traffic that no policy denies any more stays blocked until the pod is restarted.

Previously every dataplane update in `cleanupPod` sat behind `podIdentifierToPolicyEndpointMap.Load(podIdentifier)`, but `deriveTargetPodsForParentNP` had already dropped that identifier from the map. The guard was false, the whole body was skipped, and the function returned `nil` as if cleanup had succeeded.

### Description of changes:

The fix:

1. Adds the missing `else` ("no policies remain") branch to `cleanupPod`, which clears the ingress/egress maps with empty rule sets and resets `pod_state_map[POD_STATE_MAP_KEY]` to `DEFAULT_ALLOW`, or `DEFAULT_DENY` in strict mode.
2. Clearing with empty rules is safe because the guard is the absence of the *whole* map entry. `deriveTargetPodsForParentNP` iterates `parentPEList` and removes every PolicyEndpoint of the parent NP from a stale identifier, and `deletePolicyEndpointFromPodIdentifierMap` only drops the key once its list is empty — so a missing entry means no PolicyEndpoint selects the identifier at all. If another policy still applies, the entry survives and the existing re-derivation path runs unchanged.
3. Skips identifiers whose eBPF context is already gone instead of erroring: probes are detached once the last pod of an identifier leaves the node, so the map update would fail and make routine pod deletion requeue forever. This needs a read-only dataplane lookup, so `BpfClient` gains `HasBPFContext`.

No change to `deriveTargetPodsForParentNP`, `getPodListToBeCleanedUp`, `deriveStalePodIdentifiers`, the `deletePolicyEndpointFromPodIdentifierMap` call site, or `updateeBPFMaps`. This is the namespaced PolicyEndpoint counterpart of #605, which fixes the same defect on the ClusterPolicyEndpoint path.

## Test steps:

1. Deployed the PR image to the `aws-node` daemonset (`aws-eks-nodeagent` container) on a 2-node EKS cluster, VPC CNI v1.22.4, `NETWORK_POLICY_ENFORCING_MODE=standard`
2. Ran `make test-selector-narrowing CLUSTER_NAME=<cluster>` — three dataplane specs, each reading `egress_pod_state_map` through `aws-eks-na-cli` before and after the transition
3. `podSelector` narrowing: policy initially selects two clients, then is narrowed to one. Deselected client regains egress with no restart
4. Pod label removal: policy unchanged, the label is removed from the *live* pod. Client regains egress; the spec asserts UID, `creationTimestamp` and container restart counts are unchanged to prove no restart happened
5. Two policies, one pod (control case): the pod is dropped from one policy only. The surviving policy's rules must stay programmed; only after it is dropped from the second policy does the state fall back to `DEFAULT_ALLOW`

## Result: PASSED

```
Ran 3 of 9 Specs in 301.650 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 6 Skipped
```

`egress_pod_state_map` key 0 — `0` = `POLICIES_APPLIED`, `1` = `DEFAULT_ALLOW`:

```
selectoropen@policy/egress_pod_state_map        key 0 state = 0   # policy selects it
selectoropen@policy/egress_pod_state_map        key 0 state = 1   # after narrowing

labelremovalclient@policy/egress_pod_state_map  key 0 state = 0   # label present
labelremovalclient@policy/egress_pod_state_map  key 0 state = 1   # after label removal

multipolicyclient@policy/egress_pod_state_map   key 0 state = 0   # both policies
multipolicyclient@policy/egress_pod_state_map   key 0 state = 0   # dropped from one - rules preserved
multipolicyclient@policy/egress_pod_state_map   key 0 state = 0
multipolicyclient@policy/egress_pod_state_map   key 0 state = 1   # dropped from both
```

The three consecutive `state = 0` readings for `multipolicyclient` are the evidence that clearing with empty rules does not over-clear: while one policy still selects the pod, its rules stay programmed and the state stays `POLICIES_APPLIED`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
