### PR TITLE
handle errors with bpf state recovery

### DIFF
--- a/pkg/clihelper/show.go
+++ b/pkg/clihelper/show.go
@@ -38,14 +38,30 @@ func formatLastSeen(lastSeen, now uint64) string {
 // Show - Displays all loaded AWS BPF Programs and their associated maps
 func Show() error {
 
-	bpfSDKclient := goelf.New(goelf.Config{NamespacedMaps: utils.NamespacedBPFMaps})
+	bpfSDKclient := goelf.New(goelf.Config{NamespacedMaps: utils.NamespacedBPFMaps, GlobalMaps: utils.GlobalBPFMaps, GlobalPinPrefix: utils.GLOBAL_PIN_PREFIX})
 	bpfState, err := bpfSDKclient.GetAllBpfProgramsAndMaps()
 	if err != nil {
 		return err
 	}
 
 	for pinPath, bpfEntry := range bpfState {
-		podIdentifier, direction := utils.GetPodIdentifierFromBPFPinPath(pinPath)
+		podIdentifier, progName, isGlobal := bpfSDKclient.GetProgIdentifierFromBPFPinPath(pinPath)
+		if isGlobal {
+			// Global programs are not associated with any pod, so skip them in this output
+			continue
+		}
+
+		if podIdentifier == "" {
+			fmt.Println("Skipping unrecognized pin path: ", pinPath)
+			continue
+		}
+
+		direction := ""
+		if progName == utils.TC_INGRESS_PROG {
+			direction = "ingress"
+		} else if progName == utils.TC_EGRESS_PROG {
+			direction = "egress"
+		}
 		fmt.Println("PinPath: ", pinPath)
 		line := fmt.Sprintf("Pod Identifier : %s  Direction : %s \n", podIdentifier, direction)
 		fmt.Print(line)

--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -153,7 +153,7 @@ func NewBpfClient(ctx context.Context, nodeIP string, enablePolicyEventLogs, ena
 	isConntrackMapPresent, isPolicyEventsMapPresent := false, false
 	var err error
 
-	ebpfClient.bpfSDKClient = goelf.New(goelf.Config{NamespacedMaps: utils.NamespacedBPFMaps})
+	ebpfClient.bpfSDKClient = goelf.New(goelf.Config{NamespacedMaps: utils.NamespacedBPFMaps, GlobalMaps: utils.GlobalBPFMaps, GlobalPinPrefix: utils.GLOBAL_PIN_PREFIX})
 	ebpfClient.bpfTCClient = tc.New([]string{POD_VETH_PREFIX, BRANCH_ENI_VETH_PREFIX})
 
 	ebpfClient.fwRuleProcessor = fwrp.NewFirewallRuleProcessor(nodeIP, hostMask, enableIPv6)
@@ -191,8 +191,10 @@ func NewBpfClient(ctx context.Context, nodeIP string, enablePolicyEventLogs, ena
 		//Log the error and move on
 		log().Errorf("Failed to recover the BPF state error: %v", err)
 		sdkAPIErr.WithLabelValues("RecoverBPFState").Inc()
+	} else {
+		log().Info("Recovery phase completed")
 	}
-	log().Info("Successfully recovered BPF state")
+
 	ebpfClient.interfaceNametoIngressPinPath = interfaceNametoIngressPinPath
 	ebpfClient.interfaceNametoEgressPinPath = interfaceNametoEgressPinPath
 
@@ -208,7 +210,7 @@ func NewBpfClient(ctx context.Context, nodeIP string, enablePolicyEventLogs, ena
 		}
 		var bpfSdkInputData goelf.BpfCustomData
 		bpfSdkInputData.FilePath = eventsProbe
-		bpfSdkInputData.CustomPinPath = "global"
+		bpfSdkInputData.CustomPinPath = utils.GLOBAL_PIN_PREFIX
 		bpfSdkInputData.CustomMapSize = make(map[string]int)
 
 		bpfSdkInputData.CustomMapSize[AWS_CONNTRACK_MAP] = conntrackTableSize
@@ -411,7 +413,7 @@ func (l *bpfClient) recoverBPFState(bpfTCClient tc.BpfTc, eBPFSDKClient goelf.Bp
 		if err != nil {
 			log().Errorf("failed to recover global maps %v", err)
 			sdkAPIErr.WithLabelValues("RecoverGlobalMaps").Inc()
-			return isConntrackMapPresent, isPolicyEventsMapPresent, eventsMapFD, interfaceNametoIngressPinPath, interfaceNametoEgressPinPath, nil
+			return isConntrackMapPresent, isPolicyEventsMapPresent, eventsMapFD, interfaceNametoIngressPinPath, interfaceNametoEgressPinPath, err
 		}
 		log().Infof("Total no of  global maps recovered count: %d", len(recoveredGlobalMaps))
 		for globalMapName, globalMap := range recoveredGlobalMaps {
@@ -437,11 +439,31 @@ func (l *bpfClient) recoverBPFState(bpfTCClient tc.BpfTc, eBPFSDKClient goelf.Bp
 			//Log it and move on. We will overwrite and recreate the maps/programs
 			log().Errorf("BPF State Recovery failed error: %v", err)
 			sdkAPIErr.WithLabelValues("RecoverAllBpfProgramAndMaps").Inc()
+		} else {
+			log().Infof("BPF State Recovery completed successfully. Total no of probes/maps recovered count: %d", len(bpfState))
 		}
 
 		log().Infof("Number of probes/maps recovered - count: %d", len(bpfState))
 		for pinPath, bpfEntry := range bpfState {
-			podIdentifier, direction := utils.GetPodIdentifierFromBPFPinPath(pinPath)
+			podIdentifier, progName, isGlobal := eBPFSDKClient.GetProgIdentifierFromBPFPinPath(pinPath)
+			if isGlobal {
+				// Global Programs are not supported today
+				continue
+			}
+
+			if podIdentifier == "" {
+				log().Errorf("Skipping recovered program with unrecognized pin path: %s", pinPath)
+				sdkAPIErr.WithLabelValues("recoverBPFState-bad-pinpath").Inc()
+				continue
+			}
+
+			direction := ""
+			if progName == utils.TC_INGRESS_PROG {
+				direction = "ingress"
+			} else if progName == utils.TC_EGRESS_PROG {
+				direction = "egress"
+			}
+
 			log().Infof("Recovered program Identifier: Pin Path: %s PodIdentifier: %s direction: %s", pinPath, podIdentifier, direction)
 			var peBPFContext BPFContext
 			value, ok := policyEndpointeBPFContext.Load(podIdentifier)
@@ -576,7 +598,17 @@ func (l *bpfClient) ReAttachEbpfProbes() error {
 	}
 
 	for interfaceName, pinPath := range l.interfaceNametoIngressPinPath {
-		podIdentifier, _ := utils.GetPodIdentifierFromBPFPinPath(pinPath)
+		podIdentifier, _, isGlobal := l.bpfSDKClient.GetProgIdentifierFromBPFPinPath(pinPath)
+		if podIdentifier == "" {
+			log().Errorf("Skipping ingress reattach for interface %s, unrecognized pin path: %s", interfaceName, pinPath)
+			sdkAPIErr.WithLabelValues("reattach-bad-pinpath").Inc()
+			continue
+		}
+		if isGlobal {
+			// Global Programs are not supported in Network Policy Agent
+			continue
+		}
+
 		log().Infof("ReattachEbpfProbes attaching ingress for %s interface %s", podIdentifier, interfaceName)
 		_, err := l.attachIngressBPFProbe(interfaceName, podIdentifier)
 		if err != nil {
@@ -596,7 +628,16 @@ func (l *bpfClient) ReAttachEbpfProbes() error {
 	}
 
 	for interfaceName, pinPath := range l.interfaceNametoEgressPinPath {
-		podIdentifier, _ := utils.GetPodIdentifierFromBPFPinPath(pinPath)
+		podIdentifier, _, isGlobal := l.bpfSDKClient.GetProgIdentifierFromBPFPinPath(pinPath)
+		if podIdentifier == "" {
+			log().Errorf("Skipping egress reattach for interface %s, unrecognized pin path: %s", interfaceName, pinPath)
+			sdkAPIErr.WithLabelValues("reattach-bad-pinpath").Inc()
+			continue
+		}
+		if isGlobal {
+			// Global Programs are not supported in Network Policy Agent
+			continue
+		}
 		log().Infof("ReattachEbpfProbes attaching egress for %s interface %s", podIdentifier, interfaceName)
 		_, err := l.attachEgressBPFProbe(interfaceName, podIdentifier)
 		if err != nil {

--- a/pkg/ebpf/bpf_client_test.go
+++ b/pkg/ebpf/bpf_client_test.go
@@ -718,6 +718,41 @@ func TestRecoverBPFState(t *testing.T) {
 
 }
 
+// TestRecoverBPFState_GlobalMapRecoveryFailsFast pins the fail-fast contract for
+// global-map recovery. The conntrack and events maps are node-wide and every pod
+// program binds to them, so a partial global set is unusable. When
+// RecoverGlobalMaps errors, recoverBPFState must return that error immediately
+// and must NOT go on to recover per-pod programs and maps - proven here by
+// asserting RecoverAllBpfProgramsAndMaps is never called.
+func TestRecoverBPFState_GlobalMapRecoveryFailsFast(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockBpfClient := mock_bpfclient.NewMockBpfSDKClient(ctrl)
+	mockTCClient := mock_tc.NewMockBpfTc(ctrl)
+
+	recoveryErr := errors.New("error walking the bpfdirectory: permission denied")
+	mockBpfClient.EXPECT().RecoverGlobalMaps().Return(nil, recoveryErr).Times(1)
+	// The early return on a global-map error must prevent program recovery.
+	mockBpfClient.EXPECT().RecoverAllBpfProgramsAndMaps().Times(0)
+
+	policyEndpointeBPFContext := new(sync.Map)
+	globalMaps := new(sync.Map)
+
+	isConntrackMapPresent, isPolicyEventsMapPresent, eventsMapFD, _, _, err := NewMockBpfClient().recoverBPFState(
+		mockTCClient, mockBpfClient, policyEndpointeBPFContext, globalMaps,
+		false, false, false)
+
+	assert.Equal(t, recoveryErr, err, "global-map recovery error must propagate")
+	assert.False(t, isConntrackMapPresent)
+	assert.False(t, isPolicyEventsMapPresent)
+	assert.Equal(t, 0, eventsMapFD)
+	assert.Equal(t, 0, sizeOfSyncMap(policyEndpointeBPFContext),
+		"no program context may be recovered when global-map recovery fails")
+	assert.Equal(t, 0, sizeOfSyncMap(globalMaps),
+		"no global map may be stored when recovery fails")
+}
+
 func sizeOfSyncMap(m *sync.Map) int {
 	count := 0
 	m.Range(func(_, _ any) bool {
@@ -1206,4 +1241,193 @@ func TestCleanupDeletedPodsIfNeeded(t *testing.T) {
 		return true
 	})
 	assert.Equal(t, 400, remaining)
+}
+
+// TestRecoverBPFState_SkipsUnparseablePinPaths covers the guard added to
+// recoverBPFState's bpfState loop. The SDK now returns partial state rather than
+// discarding everything, so NPA can be handed a pin path it cannot key state
+// under - it must skip that entry instead of storing context against an empty
+// podIdentifier, which would collide for every unparseable pin on the node.
+func TestRecoverBPFState_SkipsUnparseablePinPaths(t *testing.T) {
+	const (
+		goodIngressPin = "/sys/fs/bpf/globals/aws/programs/hello-udp-748dc8d996@default_handle_ingress"
+		goodEgressPin  = "/sys/fs/bpf/globals/aws/programs/hello-udp-748dc8d996@default_handle_egress"
+		// Dotted pod name: the identifier keeps its underscores.
+		dottedPin = "/sys/fs/bpf/globals/aws/programs/journal-insights-flink-7_2_0-0d7e7aa@default_handle_ingress"
+		// A pod whose name begins with the global pin prefix is still a pod.
+		globalPrefixedPin = "/sys/fs/bpf/globals/aws/programs/global_abcd@default_handle_ingress"
+		// Neither shape: no "_handle_<direction>" suffix at all.
+		junkPin = "/sys/fs/bpf/globals/aws/programs/not-a-valid-identifier"
+	)
+
+	withProg := func(fd int) goelf.BpfData {
+		return goelf.BpfData{
+			Program: goebpfprogs.BpfProgram{ProgFD: fd},
+			Maps:    make(map[string]goebpfmaps.BpfMap),
+		}
+	}
+
+	tests := []struct {
+		name            string
+		bpfState        map[string]goelf.BpfData
+		wantContextKeys []string
+	}{
+		{
+			name: "unparseable pin is skipped, parseable ones still recovered",
+			bpfState: map[string]goelf.BpfData{
+				goodIngressPin: withProg(1),
+				goodEgressPin:  withProg(2),
+				junkPin:        withProg(3),
+			},
+			wantContextKeys: []string{"hello-udp-748dc8d996@default"},
+		},
+		{
+			name: "node-wide pin is not stored as a pod",
+			bpfState: map[string]goelf.BpfData{
+				goodIngressPin: withProg(1),
+			},
+			wantContextKeys: []string{"hello-udp-748dc8d996@default"},
+		},
+		{
+			// Both of these look unparseable to a first-underscore split but are
+			// real pods - they must be recovered, not skipped.
+			name: "dotted and global-prefixed identifiers are recovered",
+			bpfState: map[string]goelf.BpfData{
+				dottedPin:         withProg(4),
+				globalPrefixedPin: withProg(5),
+			},
+			wantContextKeys: []string{
+				"journal-insights-flink-7_2_0-0d7e7aa@default",
+				"global_abcd@default",
+			},
+		},
+		{
+			name: "every pin unparseable yields no context and no panic",
+			bpfState: map[string]goelf.BpfData{
+				junkPin: withProg(3),
+			},
+			wantContextKeys: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockBpfClient := mock_bpfclient.NewMockBpfSDKClient(ctrl)
+			mockTCClient := mock_tc.NewMockBpfTc(ctrl)
+
+			mockBpfClient.EXPECT().RecoverGlobalMaps().Return(
+				map[string]goebpfmaps.BpfMap{
+					CONNTRACK_MAP_PIN_PATH:     {MapFD: 2},
+					POLICY_EVENTS_MAP_PIN_PATH: {MapFD: 3},
+				}, nil).AnyTimes()
+
+			// The SDK reports partial recovery: some state plus a non-nil error.
+			// recoverBPFState must log it and carry on with what it got.
+			mockBpfClient.EXPECT().RecoverAllBpfProgramsAndMaps().Return(
+				tt.bpfState, errors.New("partial recovery, 1 pin(s) skipped")).AnyTimes()
+
+			policyEndpointeBPFContext := new(sync.Map)
+			globalMaps := new(sync.Map)
+
+			_, _, _, _, _, err := NewMockBpfClient().recoverBPFState(
+				mockTCClient, mockBpfClient, policyEndpointeBPFContext, globalMaps,
+				false, false, false)
+
+			// A partial-recovery error from the SDK is logged, not propagated -
+			// the agent proceeds with the state it managed to rebuild.
+			assert.NoError(t, err)
+			assert.Equal(t, len(tt.wantContextKeys), sizeOfSyncMap(policyEndpointeBPFContext),
+				"only parseable pin paths may produce context entries")
+			for _, key := range tt.wantContextKeys {
+				_, ok := policyEndpointeBPFContext.Load(key)
+				assert.True(t, ok, "expected context for podIdentifier %q", key)
+			}
+			// The empty identifier must never be used as a key.
+			_, ok := policyEndpointeBPFContext.Load("")
+			assert.False(t, ok, "empty podIdentifier must never be stored")
+		})
+	}
+}
+
+// TestReAttachEbpfProbes_SkipsUnparseablePinPaths covers the two guards added to
+// ReAttachEbpfProbes. Without them an unparseable pin path would call
+// attachIngressBPFProbe with an empty podIdentifier, loading and pinning a
+// program under a bogus name.
+func TestReAttachEbpfProbes_SkipsUnparseablePinPaths(t *testing.T) {
+	tests := []struct {
+		name            string
+		ingressPinPaths map[string]string
+		egressPinPaths  map[string]string
+		wantIngressCall int
+		wantEgressCall  int
+	}{
+		{
+			name: "unparseable pin paths are skipped in both directions",
+			ingressPinPaths: map[string]string{
+				"eni0000000000a": "/sys/fs/bpf/globals/aws/programs/not-a-valid-identifier",
+			},
+			egressPinPaths: map[string]string{
+				"eni0000000000b": "/sys/fs/bpf/globals/aws/programs/garbage",
+			},
+			wantIngressCall: 0,
+			wantEgressCall:  0,
+		},
+		{
+			name: "parseable pin paths still attach",
+			ingressPinPaths: map[string]string{
+				"eni0000000000a": "/sys/fs/bpf/globals/aws/programs/hello-udp-748dc8d996@default_handle_ingress",
+			},
+			egressPinPaths: map[string]string{
+				"eni0000000000b": "/sys/fs/bpf/globals/aws/programs/hello-udp-748dc8d996@default_handle_egress",
+			},
+			wantIngressCall: 1,
+			wantEgressCall:  1,
+		},
+		{
+			// A dotted identifier must not be mistaken for garbage.
+			name: "dotted identifier still attaches",
+			ingressPinPaths: map[string]string{
+				"eni0000000000a": "/sys/fs/bpf/globals/aws/programs/journal-insights-flink-7_2_0@default_handle_ingress",
+			},
+			egressPinPaths:  map[string]string{},
+			wantIngressCall: 1,
+			wantEgressCall:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockTCClient := mock_tc.NewMockBpfTc(ctrl)
+			// Pod-ingress programs attach to the TC egress hook and vice versa.
+			mockTCClient.EXPECT().TCEgressAttach(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil).Times(tt.wantIngressCall)
+			mockTCClient.EXPECT().TCIngressAttach(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil).Times(tt.wantEgressCall)
+
+			mockBpfClient := mock_bpfclient.NewMockBpfSDKClient(ctrl)
+			// A skipped pin path must not reach the loader at all.
+			mockBpfClient.EXPECT().LoadBpfFile(gomock.Any(), gomock.Any()).
+				Return(map[string]goelf.BpfData{}, map[string]goebpfmaps.BpfMap{}, nil).AnyTimes()
+
+			testBpfClient := NewMockBpfClient()
+			testBpfClient.bpfTCClient = mockTCClient
+			testBpfClient.bpfSDKClient = mockBpfClient
+			testBpfClient.interfaceNametoIngressPinPath = tt.ingressPinPaths
+			testBpfClient.interfaceNametoEgressPinPath = tt.egressPinPaths
+			testBpfClient.ingressInMemoryMap = new(sync.Map)
+			testBpfClient.egressInMemoryMap = new(sync.Map)
+			testBpfClient.podIdentifierLock = new(sync.Map)
+			testBpfClient.deletedPods = new(sync.Map)
+
+			// Attach failures are logged, not returned, so this asserts only that
+			// the skip guards prevented the calls counted above.
+			_ = testBpfClient.ReAttachEbpfProbes()
+		})
+	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -40,6 +40,13 @@ var (
 	TC_CLUSTER_POLICY_EGRESS_MAP    = "cp_egress_map"
 	TC_INGRESS_POD_STATE_MAP        = "ingress_pod_state_map"
 	TC_EGRESS_POD_STATE_MAP         = "egress_pod_state_map"
+	GLOBAL_CONNTRACK_MAP            = "aws_conntrack_map"
+	GLOBAL_POLICY_EVENTS_MAP        = "policy_events"
+
+	// GLOBAL_PIN_PREFIX is the pin-filename prefix used for node-wide programs
+	// and maps, e.g. "global_aws_conntrack_map". Per-pod pins instead carry a
+	// "<podName>@<namespace>" identifier.
+	GLOBAL_PIN_PREFIX = "global"
 
 	CATCH_ALL_PROTOCOL   corev1.Protocol = "ANY_IP_PROTOCOL"
 	DENY_ALL_PROTOCOL    corev1.Protocol = "RESERVED_IP_PROTOCOL_NUMBER"
@@ -59,6 +66,14 @@ var NamespacedBPFMaps = []string{
 	TC_CLUSTER_POLICY_EGRESS_MAP,
 	TC_INGRESS_POD_STATE_MAP,
 	TC_EGRESS_POD_STATE_MAP,
+}
+
+// GlobalBPFMaps lists BPF map names that are pinned once per node rather than
+// per pod-identifier, under the GLOBAL_PIN_PREFIX prefix.
+// Any new node scoped eBPF maps added in ebpf C programs needs to be added in this list for recovery
+var GlobalBPFMaps = []string{
+	GLOBAL_CONNTRACK_MAP,
+	GLOBAL_POLICY_EVENTS_MAP,
 }
 
 func log() logger.Logger {
@@ -204,18 +219,6 @@ func LegacyGetPodIdentifier(podName, podNamespace string) string {
 	return podIdentifierPrefix + "-" + podNamespace
 }
 
-func GetPodIdentifierFromBPFPinPath(pinPath string) (string, string) {
-	pinPathName := strings.Split(pinPath, "/")
-	parts := strings.Split(pinPathName[7], "_")
-
-	// Format: podIdentifier_handle_direction
-	// parts[len(parts)-2] = "handle", parts[len(parts)-1] = direction
-	podIdentifier := strings.Join(parts[:len(parts)-2], "_")
-	direction := parts[len(parts)-1]
-
-	return podIdentifier, direction
-}
-
 func GetBPFPinPathFromPodIdentifier(podIdentifier string, direction string) string {
 	progName := TC_INGRESS_PROG
 	if direction == "egress" {
@@ -257,19 +260,23 @@ func getHostLinkByName(name string) (netlink.Link, error) {
 	return getLinkByNameFunc(name)
 }
 
-var GetHostVethName = func(podName, podNamespace string, interfaceIndex int, interfacePrefixes []string) (string, error) {
-	var interfaceName string
-	var errors error
-
+// BuildHostVethName computes the host veth name the VPC CNI assigns to a pod
+// interface: "<prefix><first-11-hex-of-sha1(podNamespace.podName)>". It does not check that the interface exists on
+// the host
+func BuildHostVethName(podName, podNamespace, prefix string, interfaceIndex int) string {
 	if interfaceIndex > 0 {
 		podName = fmt.Sprintf("%s.%s", podName, strconv.Itoa(interfaceIndex))
 	}
-
 	h := sha1.New()
 	h.Write([]byte(fmt.Sprintf("%s.%s", podNamespace, podName)))
+	return fmt.Sprintf("%s%s", prefix, hex.EncodeToString(h.Sum(nil))[:11])
+}
+
+var GetHostVethName = func(podName, podNamespace string, interfaceIndex int, interfacePrefixes []string) (string, error) {
+	var errors error
 
 	for _, prefix := range interfacePrefixes {
-		interfaceName = fmt.Sprintf("%s%s", prefix, hex.EncodeToString(h.Sum(nil))[:11])
+		interfaceName := BuildHostVethName(podName, podNamespace, prefix, interfaceIndex)
 		if _, err := getHostLinkByName(interfaceName); err == nil {
 			return interfaceName, nil
 		} else {
@@ -277,7 +284,7 @@ var GetHostVethName = func(podName, podNamespace string, interfaceIndex int, int
 		}
 	}
 
-	log().Errorf("Not found any interface starting with prefixes and the hash. Prefixes searched %v hash %v error %v", interfacePrefixes, hex.EncodeToString(h.Sum(nil))[:11], errors)
+	log().Errorf("Not found any interface starting with prefixes and the hash. Prefixes searched %v error %v", interfacePrefixes, errors)
 	return "", errors
 }
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -466,109 +466,6 @@ func TestGetDotPodIdentifier(t *testing.T) {
 	}
 }
 
-func TestGetPodIdentifierFromBPFPinPath(t *testing.T) {
-	type args struct {
-		pinPath string
-	}
-
-	tests := []struct {
-		name string
-		args args
-		want [2]string
-	}{
-		{
-			name: "Ingress Pinpath",
-			args: args{
-				pinPath: "/sys/fs/bpf/globals/aws/programs/hello-udp-748dc8d996-default_handle_ingress",
-			},
-			want: [2]string{"hello-udp-748dc8d996-default", "ingress"},
-		},
-		{
-			name: "Egress Pinpath",
-			args: args{
-				pinPath: "/sys/fs/bpf/globals/aws/programs/hello-udp-748dc8d996-default_handle_egress",
-			},
-			want: [2]string{"hello-udp-748dc8d996-default", "egress"},
-		},
-		{
-			name: "Ingress Pinpath with podIdentifier name containing underscore",
-			args: args{
-				pinPath: "/sys/fs/bpf/globals/aws/programs/ylinux_app-75f4596489-k8s-omega-aws--nonprod-omega--test_handle_ingress",
-			},
-			want: [2]string{"ylinux_app-75f4596489-k8s-omega-aws--nonprod-omega--test", "ingress"},
-		},
-		{
-			name: "Egress Pinpath with podIdentifier name containing underscore",
-			args: args{
-				pinPath: "/sys/fs/bpf/globals/aws/programs/ylinux_app-75f4596489-k8s-omega-aws--nonprod-omega--test_handle_egress",
-			},
-			want: [2]string{"ylinux_app-75f4596489-k8s-omega-aws--nonprod-omega--test", "egress"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got1, got2 := GetPodIdentifierFromBPFPinPath(tt.args.pinPath)
-			assert.Equal(t, tt.want[0], got1)
-			assert.Equal(t, tt.want[1], got2)
-		})
-	}
-}
-
-func TestPodIdentifierDotConversion(t *testing.T) {
-	type args struct {
-		podName      string
-		podNamespace string
-		direction    string
-	}
-
-	tests := []struct {
-		name string
-		args args
-	}{
-		{
-			name: "Pod name with single dot",
-			args: args{
-				podName:      "my.pod-748dc8d996-fb8b2",
-				podNamespace: "default",
-				direction:    "ingress",
-			},
-		},
-		{
-			name: "Pod name with multiple dots",
-			args: args{
-				podName:      "ylinux.app.service-75f4596489-g4x8c",
-				podNamespace: "k8s-omega-aws--nonprod-omega--test",
-				direction:    "egress",
-			},
-		},
-		{
-			name: "Pod name without dots",
-			args: args{
-				podName:      "hello-udp-748dc8d996-fb8b2",
-				podNamespace: "default",
-				direction:    "ingress",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Step 1: Convert pod name to pod identifier (dots become underscores)
-			podIdentifier := GetPodIdentifier(tt.args.podName, tt.args.podNamespace)
-
-			// Step 2: Create BPF pin path from pod identifier
-			pinPath := GetBPFPinPathFromPodIdentifier(podIdentifier, tt.args.direction)
-
-			// Step 3: Extract pod identifier back from pin path
-			extractedPodId, extractedDirection := GetPodIdentifierFromBPFPinPath(pinPath)
-
-			// Verify round-trip: extracted values should match original
-			assert.Equal(t, podIdentifier, extractedPodId, "Pod identifier should match after round-trip")
-			assert.Equal(t, tt.args.direction, extractedDirection, "Direction should match after round-trip")
-		})
-	}
-}
-
 func TestGetBPFPinPathFromPodIdentifier(t *testing.T) {
 	type args struct {
 		podIdentifier string
@@ -900,4 +797,24 @@ func TestKtimeGetNs(t *testing.T) {
 	t2, err := KtimeGetNs()
 	assert.NoError(t, err)
 	assert.GreaterOrEqual(t, t2, t1, "KtimeGetNs must be monotonically non-decreasing")
+}
+
+// TestGlobalBPFMaps asserts the list handed to the SDK as Config.GlobalMaps
+// matches the maps the events binary actually declares. The SDK classifies a pin
+// as global only if its name is in this list, so a node-scoped map missing from
+// it is treated as unparseable and skipped during recovery.
+func TestGlobalBPFMaps(t *testing.T) {
+	assert.Equal(t, "global", GLOBAL_PIN_PREFIX)
+	assert.ElementsMatch(t,
+		[]string{"aws_conntrack_map", "policy_events"},
+		GlobalBPFMaps,
+		"GlobalBPFMaps must list every node-scoped map declared in the events binary")
+
+	// The namespaced and global lists must stay disjoint - a name in both would
+	// make the SDK's classification order-dependent.
+	for _, g := range GlobalBPFMaps {
+		for _, n := range NamespacedBPFMaps {
+			assert.NotEqual(t, g, n, "map %q cannot be both global and namespaced", g)
+		}
+	}
 }

--- a/test/framework/resources/k8s/pod/resource.go
+++ b/test/framework/resources/k8s/pod/resource.go
@@ -26,6 +26,7 @@ type Manager interface {
 	CreateAndWaitTillPodIsCompleted(context context.Context, pod *v1.Pod) (*v1.Pod, error)
 	DeleteAndWaitTillPodIsDeleted(context context.Context, pod *v1.Pod) error
 	GetPodsWithLabel(context context.Context, namespace string, labelKey string, labelValue string) ([]v1.Pod, error)
+	WaitTillPodWithLabelRunning(context context.Context, namespace string, labelKey string, labelValue string, timeOut time.Duration) (v1.Pod, error)
 	PatchPod(context context.Context, oldPod *v1.Pod, newPod *v1.Pod) error
 	PodLogs(namespace string, name string) (string, error)
 	ExecInPod(namespace string, podName string, command []string) (string, error)
@@ -99,6 +100,34 @@ func (d *defaultManager) GetPodsWithLabel(context context.Context, namespace str
 	})
 
 	return podList.Items, err
+}
+
+// WaitTillPodWithLabelRunning polls until a pod carrying the given label is
+// Running with a node assigned, and returns the first such pod - so callers can
+// read its generated name (e.g. a Deployment/Job pod). Intended for
+// single-pod-per-label selectors; with multiple replicas it returns an
+// arbitrary Running one. Returns an error if the timeout elapses first.
+func (d *defaultManager) WaitTillPodWithLabelRunning(ctx context.Context, namespace string,
+	labelKey string, labelValue string, timeOut time.Duration) (v1.Pod, error) {
+
+	var found v1.Pod
+	err := wait.PollUntilContextTimeout(ctx, utils.PollIntervalShort, timeOut, true, func(context.Context) (done bool, err error) {
+		pods, err := d.GetPodsWithLabel(ctx, namespace, labelKey, labelValue)
+		if err != nil {
+			return true, err
+		}
+		for _, p := range pods {
+			if p.Status.Phase == v1.PodRunning && p.Spec.NodeName != "" {
+				found = p
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return v1.Pod{}, fmt.Errorf("waiting for a Running pod with %s=%s: %w", labelKey, labelValue, err)
+	}
+	return found, nil
 }
 
 func (d *defaultManager) DeleteAndWaitTillPodIsDeleted(ctx context.Context, pod *v1.Pod) error {

--- a/test/framework/utils/bpf.go
+++ b/test/framework/utils/bpf.go
@@ -2,16 +2,58 @@ package utils
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
+	npautils "github.com/aws/aws-network-policy-agent/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// HostVethName returns the host veth a pod's TC programs attach to, using the
+// VPC CNI naming convention. It delegates to the production
+// utils.BuildHostVethName so the test and the agent share one definition of the
+// convention; the pure (no local link check) variant is used because the test
+// driver runs off-node and only needs the name to pass into an on-node command.
+//
+// prefix is normally "eni" for regular pods and "vlan" for branch-ENI pods;
+// interfaceIndex 0 is the primary interface.
+func HostVethName(namespace, podName, prefix string, interfaceIndex int) string {
+	return npautils.BuildHostVethName(podName, namespace, prefix, interfaceIndex)
+}
+
+// tcFilterProgIDRe matches the "id <N>" that `tc filter show` prints for a BPF
+// filter, e.g. "filter ... bpf ... id 1446 tag ...".
+var tcFilterProgIDRe = regexp.MustCompile(`\bid\s+(\d+)\b`)
+
+// ParseTCFilterProgIDs extracts the BPF program IDs attached at a TC hook from
+// the output of `tc filter show dev <veth> {ingress|egress}`. A hook with no BPF
+// filter yields an empty slice. Multiple IDs are returned in first-seen order.
+func ParseTCFilterProgIDs(output string) []int {
+	var ids []int
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.Contains(line, "bpf") {
+			continue
+		}
+		if m := tcFilterProgIDRe.FindStringSubmatch(line); m != nil {
+			if id, err := strconv.Atoi(m[1]); err == nil {
+				ids = append(ids, id)
+			}
+		}
+	}
+	return ids
+}
+
 // BuildBPFCheckPod creates a privileged pod that can inspect BPF state on a node
 // via chroot into the host filesystem.
+//
+// Uses the netshoot debug image so the pod ships its own network tooling
+// (curl, wget, iproute2/tc, bpftool, jq) rather than relying on the host or a
+// runtime package install. Host BPF state is still read via `chroot /host`;
+// self-contained tools (e.g. curl for scraping the agent metrics endpoint) run
+// directly in the pod.
 func BuildBPFCheckPod(namespace, nodeName string) *v1.Pod {
 	privileged := true
 	hostPathDir := v1.HostPathDirectory
@@ -22,7 +64,7 @@ func BuildBPFCheckPod(namespace, nodeName string) *v1.Pod {
 		Spec: v1.PodSpec{
 			NodeName: nodeName, HostPID: true, HostNetwork: true, RestartPolicy: v1.RestartPolicyNever,
 			Containers: []v1.Container{{
-				Name: "check", Image: "public.ecr.aws/amazonlinux/amazonlinux:2023-minimal",
+				Name: "check", Image: "nicolaka/netshoot:latest",
 				Command:         []string{"sleep", "300"},
 				SecurityContext: &v1.SecurityContext{Privileged: &privileged},
 				VolumeMounts:    []v1.VolumeMount{{Name: "host-root", MountPath: "/host"}},
@@ -37,9 +79,10 @@ func BuildBPFCheckPod(namespace, nodeName string) *v1.Pod {
 
 // BPFState is the parsed view of `aws-eks-na-cli ebpf loaded-ebpfdata` output.
 type BPFState struct {
-	ProgIDs    map[string]int // pinPath basename -> prog ID
-	MapIDs     map[string]int // "podIdentifier/mapName" -> map ID
-	GlobalMaps map[string]int // global map name -> map ID
+	ProgIDs        map[string]int    // pinPath basename -> prog ID
+	MapIDs         map[string]int    // "podIdentifier/mapName" -> map ID
+	GlobalMaps     map[string]int    // global map name -> map ID
+	PodIdentifiers map[string]string // pinPath basename -> parsed pod identifier
 }
 
 // ParseLoadedEBPFData parses the output of `aws-eks-na-cli ebpf loaded-ebpfdata`.
@@ -59,9 +102,10 @@ type BPFState struct {
 //	===...===
 func ParseLoadedEBPFData(output string) (BPFState, error) {
 	state := BPFState{
-		ProgIDs:    make(map[string]int),
-		MapIDs:     make(map[string]int),
-		GlobalMaps: make(map[string]int),
+		ProgIDs:        make(map[string]int),
+		MapIDs:         make(map[string]int),
+		GlobalMaps:     make(map[string]int),
+		PodIdentifiers: make(map[string]string),
 	}
 
 	var currentPinName, currentPodID string
@@ -79,6 +123,11 @@ func ParseLoadedEBPFData(output string) (BPFState, error) {
 			parts := strings.Split(line, "Direction")
 			if len(parts) > 0 {
 				currentPodID = strings.TrimSpace(strings.TrimPrefix(parts[0], "Pod Identifier :"))
+				// Record the parser-produced identifier against the pin it belongs
+				// to. currentPinName was set by the preceding "PinPath:" line.
+				if currentPinName != "" {
+					state.PodIdentifiers[currentPinName] = currentPodID
+				}
 			}
 		}
 

--- a/test/integration/restart/recovery_scenarios_test.go
+++ b/test/integration/restart/recovery_scenarios_test.go
@@ -1,0 +1,538 @@
+package restart
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	network "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/aws-network-policy-agent/test/framework/utils"
+)
+
+/*
+Recovery Scenarios Test Suite
+
+Four test cases covering the recovery paths:
+1. Policy lifecycle across restarts — maps update correctly post-recovery
+2. Program pin deletion → partial recovery → reconcile heals
+3. Map pin deletion → partial recovery → reconcile heals (program dropped, reloaded fresh)
+4. Shared progFD protection — delete one pod of a shared set, program stays alive
+*/
+
+var _ = Describe("Recovery Scenarios", Ordered, func() {
+
+	var (
+		checkPod *v1.Pod
+		nodeName string
+	)
+
+	BeforeAll(func() {
+		// We need at least one pod to determine a node; create the check pod later
+		// once we know the node.
+	})
+
+	AfterAll(func() {
+		if checkPod != nil {
+			fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, checkPod)
+		}
+	})
+
+	Describe("Test 1: Policy Lifecycle Across Restarts", Ordered, func() {
+		var (
+			serverPod     *v1.Pod
+			clientPod     *v1.Pod
+			networkPolicy *network.NetworkPolicy
+			serverIP      string
+			preRestartIDs map[int]bool
+		)
+
+		It("validates deny → restart → allow → restart → delete policy → restart with state cross-check", func() {
+			By("Creating server and client pods")
+			serverPod = &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "policy-lifecycle-server", Namespace: namespace,
+					Labels: map[string]string{"app": "policy-lifecycle"},
+				},
+				Spec: v1.PodSpec{Containers: []v1.Container{{
+					Name: "nginx", Image: "public.ecr.aws/nginx/nginx:latest",
+					Ports: []v1.ContainerPort{{ContainerPort: 80}},
+				}}},
+			}
+			var err error
+			serverPod, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, serverPod, podReadyTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			nodeName = serverPod.Spec.NodeName
+			serverIP = serverPod.Status.PodIP
+
+			clientPod = &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "policy-lifecycle-client", Namespace: namespace,
+					Labels: map[string]string{"app": "policy-lifecycle-client"},
+				},
+				Spec: v1.PodSpec{
+					NodeName:   nodeName,
+					Containers: []v1.Container{{Name: "curl", Image: "public.ecr.aws/docker/library/python:3.11-slim", Command: []string{"sleep", "3600"}}},
+				},
+			}
+			clientPod, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, clientPod, podReadyTimeout)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create the check pod on the same node
+			checkPod = buildRecoveryCheckPod(nodeName)
+			checkPod, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, checkPod, podReadyTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			recoveryCheckPod = checkPod
+
+			By("Step 1: Apply deny-all ingress policy")
+			networkPolicy = &network.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "policy-lifecycle-deny", Namespace: namespace},
+				Spec: network.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "policy-lifecycle"}},
+					PolicyTypes: []network.PolicyType{network.PolicyTypeIngress},
+				},
+			}
+			Expect(fw.NetworkPolicyManager.CreateNetworkPolicy(ctx, networkPolicy)).To(Succeed())
+			time.Sleep(bpfSettleInterval)
+
+			By("Verify traffic is BLOCKED")
+			Expect(execConnect(namespace, clientPod.Name, serverIP, 80)).To(Equal("BLOCKED"))
+
+			By("Step 2: Rollout restart DS")
+			rolloutRestartDaemonSet()
+			waitForDaemonSetRollout()
+			time.Sleep(bpfSettleInterval)
+
+			By("Validate state: capture prog IDs from TC")
+			vethName := utils.HostVethName(namespace, serverPod.Name, podVethPrefix, 0)
+			preRestartIDs = tcAttachedProgIDSet(vethName)
+			Expect(preRestartIDs).To(HaveLen(2), "expected 2 prog IDs attached at veth after restart")
+
+			By("Validate: CLI prog IDs match TC prog IDs")
+			allState := dumpAllBPFStateFromCLI()
+			for pin, progID := range allState.ProgIDs {
+				if strings.Contains(pin, "policy-lifecycle") {
+					Expect(preRestartIDs).To(HaveKey(progID),
+						"CLI prog ID %d for pin %s not found on TC veth", progID, pin)
+				}
+			}
+
+			By("Verify traffic still BLOCKED after restart")
+			Expect(execConnect(namespace, clientPod.Name, serverIP, 80)).To(Equal("BLOCKED"))
+
+			By("Step 3: Update policy to allow ingress from client")
+			// Re-fetch to get latest resourceVersion
+			updatedPolicy := &network.NetworkPolicy{}
+			Expect(fw.K8sClient.Get(ctx, client.ObjectKeyFromObject(networkPolicy), updatedPolicy)).To(Succeed())
+			updatedPolicy.Spec.Ingress = []network.NetworkPolicyIngressRule{{
+				From: []network.NetworkPolicyPeer{{
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "policy-lifecycle-client"}},
+				}},
+			}}
+			Expect(fw.K8sClient.Update(ctx, updatedPolicy)).To(Succeed())
+			networkPolicy = updatedPolicy
+			time.Sleep(bpfSettleInterval)
+
+			By("Verify traffic is now ALLOWED")
+			Expect(execConnect(namespace, clientPod.Name, serverIP, 80)).To(Equal("CONNECTED"))
+
+			By("Step 4: Rollout restart DS again")
+			rolloutRestartDaemonSet()
+			waitForDaemonSetRollout()
+			time.Sleep(bpfSettleInterval)
+
+			By("Validate state: prog IDs preserved (same programs reused)")
+			postRestartIDs := tcAttachedProgIDSet(vethName)
+			Expect(postRestartIDs).To(Equal(preRestartIDs),
+				"prog IDs should be preserved across same-binary restart")
+
+			By("Verify traffic still ALLOWED after second restart")
+			Expect(execConnect(namespace, clientPod.Name, serverIP, 80)).To(Equal("CONNECTED"))
+
+			By("Step 5: Delete the allow policy (revert to no policy = default allow)")
+			Expect(fw.K8sClient.Delete(ctx, networkPolicy)).To(Succeed())
+			time.Sleep(bpfSettleInterval)
+
+			By("Verify traffic ALLOWED (no policy = no enforcement)")
+			Expect(execConnect(namespace, clientPod.Name, serverIP, 80)).To(Equal("CONNECTED"))
+
+			By("Step 6: Rollout restart DS one more time")
+			rolloutRestartDaemonSet()
+			waitForDaemonSetRollout()
+			time.Sleep(bpfSettleInterval)
+
+			By("Validate state: progs still attached at veth")
+			finalIDs := tcAttachedProgIDSet(vethName)
+			Expect(finalIDs).ToNot(BeEmpty(), "progs should still be attached after final restart")
+		})
+
+		AfterAll(func() {
+			if serverPod != nil {
+				fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, serverPod)
+			}
+			if clientPod != nil {
+				fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, clientPod)
+			}
+			if networkPolicy != nil {
+				_ = fw.K8sClient.Delete(ctx, networkPolicy)
+			}
+		})
+	})
+
+	Describe("Test 2: Program Pin Deletion → Partial Recovery → Reconcile Heals", Ordered, func() {
+		var (
+			serverPod     *v1.Pod
+			networkPolicy *network.NetworkPolicy
+		)
+
+		It("recovers after a program pin is manually deleted", func() {
+			By("Creating a pod targeted by a network policy")
+			serverPod = &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pin-delete-server", Namespace: namespace,
+					Labels: map[string]string{"app": "pin-delete"},
+				},
+				Spec: v1.PodSpec{Containers: []v1.Container{{
+					Name: "nginx", Image: "public.ecr.aws/nginx/nginx:latest",
+					Ports: []v1.ContainerPort{{ContainerPort: 80}},
+				}}},
+			}
+			var err error
+			serverPod, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, serverPod, podReadyTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			if nodeName == "" {
+				nodeName = serverPod.Spec.NodeName
+			}
+
+			// Ensure check pod exists on this node
+			if recoveryCheckPod == nil {
+				checkPod = buildRecoveryCheckPod(nodeName)
+				checkPod, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, checkPod, podReadyTimeout)
+				Expect(err).ToNot(HaveOccurred())
+				recoveryCheckPod = checkPod
+			}
+			time.Sleep(bpfSettleInterval)
+
+			networkPolicy = &network.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "pin-delete-policy", Namespace: namespace},
+				Spec: network.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "pin-delete"}},
+					PolicyTypes: []network.PolicyType{network.PolicyTypeIngress},
+					Ingress:     []network.NetworkPolicyIngressRule{{From: []network.NetworkPolicyPeer{{PodSelector: &metav1.LabelSelector{}}}}},
+				},
+			}
+			Expect(fw.NetworkPolicyManager.CreateNetworkPolicy(ctx, networkPolicy)).To(Succeed())
+			time.Sleep(bpfSettleInterval)
+
+			By("Capturing pre-state: prog IDs on TC veth")
+			vethName := utils.HostVethName(namespace, serverPod.Name, podVethPrefix, 0)
+			preProgIDs := tcAttachedProgIDSet(vethName)
+			Expect(preProgIDs).To(HaveLen(2))
+
+			By("Deleting the ingress program pin from bpffs")
+			podIdentifier := getPodIdentifierFromCLI(serverPod.Name)
+			ingressPinPath := fmt.Sprintf("/sys/fs/bpf/globals/aws/programs/%s_handle_ingress", podIdentifier)
+			execInCheckPod([]string{"chroot", "/host", "rm", "-f", ingressPinPath})
+
+			By("Verifying pin is gone")
+			out, _ := execInCheckPodSoft([]string{"chroot", "/host", "ls", ingressPinPath})
+			Expect(out).To(Or(ContainSubstring("No such file"), BeEmpty()))
+
+			By("Rollout restart DS — triggers recovery")
+			rolloutRestartDaemonSet()
+			waitForDaemonSetRollout()
+			time.Sleep(bpfSettleInterval)
+
+			// After recovery + reconcile, the pin should be recreated
+			By("Waiting for reconcile to heal — pin should be recreated")
+			Eventually(func() bool {
+				out := execInCheckPod([]string{"chroot", "/host", "ls", "/sys/fs/bpf/globals/aws/programs/"})
+				return strings.Contains(out, podIdentifier+"_handle_ingress")
+			}, 30*time.Second, 2*time.Second).Should(BeTrue(), "ingress pin should be recreated by reconcile")
+
+			By("Validating TC still has progs attached (may have new prog ID for ingress)")
+			postProgIDs := tcAttachedProgIDSet(vethName)
+			Expect(postProgIDs).To(HaveLen(2), "both ingress and egress progs should be attached")
+
+			By("Verify enforcement still works")
+			// Create a quick client to test
+			clientPod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pin-delete-client", Namespace: namespace,
+					Labels: map[string]string{"app": "pin-delete-client"},
+				},
+				Spec: v1.PodSpec{
+					NodeName:   nodeName,
+					Containers: []v1.Container{{Name: "curl", Image: "public.ecr.aws/docker/library/python:3.11-slim", Command: []string{"sleep", "300"}}},
+				},
+			}
+			clientPod, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, clientPod, podReadyTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			defer fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, clientPod)
+
+			Expect(execConnect(namespace, clientPod.Name, serverPod.Status.PodIP, 80)).To(Equal("CONNECTED"))
+		})
+
+		AfterAll(func() {
+			if serverPod != nil {
+				fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, serverPod)
+			}
+			if networkPolicy != nil {
+				_ = fw.K8sClient.Delete(ctx, networkPolicy)
+			}
+		})
+	})
+
+	Describe("Test 3: Map Pin Deletion → Partial Recovery → Reconcile Heals", Ordered, func() {
+		var (
+			serverPod     *v1.Pod
+			networkPolicy *network.NetworkPolicy
+		)
+
+		It("recovers after a map pin is manually deleted (program dropped during recovery, then reloaded)", func() {
+			By("Creating a pod targeted by a network policy")
+			serverPod = &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "map-delete-server", Namespace: namespace,
+					Labels: map[string]string{"app": "map-delete"},
+				},
+				Spec: v1.PodSpec{Containers: []v1.Container{{
+					Name: "nginx", Image: "public.ecr.aws/nginx/nginx:latest",
+					Ports: []v1.ContainerPort{{ContainerPort: 80}},
+				}}},
+			}
+			var err error
+			serverPod, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, serverPod, podReadyTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			if nodeName == "" {
+				nodeName = serverPod.Spec.NodeName
+			}
+
+			// Ensure check pod exists on this node
+			if recoveryCheckPod == nil {
+				checkPod = buildRecoveryCheckPod(nodeName)
+				checkPod, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, checkPod, podReadyTimeout)
+				Expect(err).ToNot(HaveOccurred())
+				recoveryCheckPod = checkPod
+			}
+			time.Sleep(bpfSettleInterval)
+
+			networkPolicy = &network.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "map-delete-policy", Namespace: namespace},
+				Spec: network.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "map-delete"}},
+					PolicyTypes: []network.PolicyType{network.PolicyTypeIngress},
+					Ingress:     []network.NetworkPolicyIngressRule{{From: []network.NetworkPolicyPeer{{PodSelector: &metav1.LabelSelector{}}}}},
+				},
+			}
+			Expect(fw.NetworkPolicyManager.CreateNetworkPolicy(ctx, networkPolicy)).To(Succeed())
+			time.Sleep(bpfSettleInterval)
+
+			By("Capturing pre-state: prog IDs on TC veth")
+			vethName := utils.HostVethName(namespace, serverPod.Name, podVethPrefix, 0)
+			preProgIDs := tcAttachedProgIDSet(vethName)
+			Expect(preProgIDs).To(HaveLen(2))
+
+			By("Deleting the ingress MAP pin from bpffs (not the program)")
+			podIdentifier := getPodIdentifierFromCLI(serverPod.Name)
+			mapPinPath := fmt.Sprintf("/sys/fs/bpf/globals/aws/maps/%s_ingress_map", podIdentifier)
+			execInCheckPod([]string{"chroot", "/host", "rm", "-f", mapPinPath})
+
+			By("Rollout restart DS — recovery should partially fail for this pod's ingress program")
+			rolloutRestartDaemonSet()
+			waitForDaemonSetRollout()
+			time.Sleep(bpfSettleInterval)
+
+			// The reconcile should reload the program (overwriting the stale pin)
+			By("Waiting for reconcile to heal — program and map pins should be recreated")
+			Eventually(func() bool {
+				out := execInCheckPod([]string{"chroot", "/host", "ls", "/sys/fs/bpf/globals/aws/maps/"})
+				return strings.Contains(out, podIdentifier+"_ingress_map")
+			}, 30*time.Second, 2*time.Second).Should(BeTrue(), "ingress map pin should be recreated by reconcile")
+
+			By("Validating TC has progs attached (ingress should have new prog ID)")
+			postProgIDs := tcAttachedProgIDSet(vethName)
+			Expect(postProgIDs).To(HaveLen(2), "both progs should be attached after heal")
+
+			By("Verify enforcement still works")
+			clientPod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "map-delete-client", Namespace: namespace,
+					Labels: map[string]string{"app": "map-delete-client"},
+				},
+				Spec: v1.PodSpec{
+					NodeName:   nodeName,
+					Containers: []v1.Container{{Name: "curl", Image: "public.ecr.aws/docker/library/python:3.11-slim", Command: []string{"sleep", "300"}}},
+				},
+			}
+			var clientErr error
+			clientPod, clientErr = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, clientPod, podReadyTimeout)
+			Expect(clientErr).ToNot(HaveOccurred())
+			defer fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, clientPod)
+
+			Expect(execConnect(namespace, clientPod.Name, serverPod.Status.PodIP, 80)).To(Equal("CONNECTED"))
+		})
+
+		AfterAll(func() {
+			if serverPod != nil {
+				fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, serverPod)
+			}
+			if networkPolicy != nil {
+				_ = fw.K8sClient.Delete(ctx, networkPolicy)
+			}
+		})
+	})
+
+	Describe("Test 4: Shared ProgFD Protection — Delete One Pod, Program Stays for Siblings", Ordered, func() {
+		var (
+			networkPolicy *network.NetworkPolicy
+			pod1          *v1.Pod
+			pod2          *v1.Pod
+		)
+
+		It("does not delete shared program pins when one of multiple pods sharing a podIdentifier is deleted", func() {
+			By("Creating two pods that share the same podIdentifier (same RS hash pattern)")
+			// Use a deployment with 2 replicas to get shared podIdentifier
+			labels := map[string]string{"app": "shared-prog"}
+			replicas := int32(2)
+			deploy := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "shared-prog", Namespace: namespace},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &replicas,
+					Selector: &metav1.LabelSelector{MatchLabels: labels},
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: labels},
+						Spec: v1.PodSpec{
+							NodeName:   nodeName,
+							Containers: []v1.Container{{Name: "nginx", Image: "public.ecr.aws/nginx/nginx:latest", Ports: []v1.ContainerPort{{ContainerPort: 80}}}},
+						},
+					},
+				},
+			}
+
+			// Determine node if not set
+			if nodeName == "" {
+				nodes := &v1.NodeList{}
+				Expect(fw.K8sClient.List(ctx, nodes)).To(Succeed())
+				Expect(nodes.Items).ToNot(BeEmpty())
+				nodeName = nodes.Items[0].Name
+				deploy.Spec.Template.Spec.NodeName = nodeName
+			}
+
+			Expect(fw.K8sClient.Create(ctx, deploy)).To(Succeed())
+			defer func() {
+				_ = fw.K8sClient.Delete(ctx, deploy)
+				time.Sleep(10 * time.Second)
+			}()
+
+			// Wait for both pods
+			Eventually(func() int {
+				pods := &v1.PodList{}
+				_ = fw.K8sClient.List(ctx, pods, client.InNamespace(namespace), client.MatchingLabels(labels))
+				running := 0
+				for _, p := range pods.Items {
+					if p.Status.Phase == v1.PodRunning {
+						running++
+					}
+				}
+				return running
+			}, podReadyTimeout, 2*time.Second).Should(Equal(2))
+
+			By("Applying a network policy to trigger probe attachment")
+			networkPolicy = &network.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "shared-prog-policy", Namespace: namespace},
+				Spec: network.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{MatchLabels: labels},
+					PolicyTypes: []network.PolicyType{network.PolicyTypeIngress},
+					Ingress:     []network.NetworkPolicyIngressRule{{From: []network.NetworkPolicyPeer{{PodSelector: &metav1.LabelSelector{}}}}},
+				},
+			}
+			Expect(fw.NetworkPolicyManager.CreateNetworkPolicy(ctx, networkPolicy)).To(Succeed())
+
+			// Ensure check pod exists on this node
+			if recoveryCheckPod == nil {
+				var cpErr error
+				checkPod = buildRecoveryCheckPod(nodeName)
+				checkPod, cpErr = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, checkPod, podReadyTimeout)
+				Expect(cpErr).ToNot(HaveOccurred())
+				recoveryCheckPod = checkPod
+			}
+			time.Sleep(bpfSettleInterval)
+
+			By("Getting both pods and their shared podIdentifier")
+			pods := &v1.PodList{}
+			Expect(fw.K8sClient.List(ctx, pods, client.InNamespace(namespace), client.MatchingLabels(labels))).To(Succeed())
+			Expect(pods.Items).To(HaveLen(2))
+			pod1 = &pods.Items[0]
+			pod2 = &pods.Items[1]
+
+			By("Verifying both pods share the same prog IDs (shared program)")
+			veth1 := utils.HostVethName(namespace, pod1.Name, podVethPrefix, 0)
+			veth2 := utils.HostVethName(namespace, pod2.Name, podVethPrefix, 0)
+			progIDs1 := tcAttachedProgIDSet(veth1)
+			progIDs2 := tcAttachedProgIDSet(veth2)
+			Expect(progIDs1).To(Equal(progIDs2), "both pods should share the same prog IDs")
+
+			By("Capturing the pin state before deletion")
+			podIdentifier := getPodIdentifierFromCLI(pod1.Name)
+			pinsBefore := listProgramPinBasenames()
+			Expect(pinsBefore).To(ContainElement(podIdentifier + "_handle_ingress"))
+
+			By("Deleting one of the two pods")
+			Expect(fw.K8sClient.Delete(ctx, pod1)).To(Succeed())
+			time.Sleep(bpfSettleInterval)
+
+			By("Verifying program pins still exist (shared, not deleted)")
+			pinsAfter := listProgramPinBasenames()
+			Expect(pinsAfter).To(ContainElement(podIdentifier+"_handle_ingress"),
+				"shared ingress program pin should NOT be deleted when one pod is removed")
+			Expect(pinsAfter).To(ContainElement(podIdentifier+"_handle_egress"),
+				"shared egress program pin should NOT be deleted when one pod is removed")
+
+			By("Verifying surviving pod still has progs attached on TC")
+			postProgIDs := tcAttachedProgIDSet(veth2)
+			Expect(postProgIDs).To(Equal(progIDs2), "surviving pod's TC attachment should be unchanged")
+		})
+
+		AfterAll(func() {
+			if networkPolicy != nil {
+				_ = fw.K8sClient.Delete(ctx, networkPolicy)
+			}
+		})
+	})
+})
+
+// getPodIdentifierFromCLI gets the pod identifier for a pod by looking it up
+// in the CLI's loaded-ebpfdata dump. This ensures we use the same identifier
+// the agent uses, avoiding test-vs-agent naming divergence.
+func getPodIdentifierFromCLI(podName string) string {
+	allState := dumpAllBPFStateFromCLI()
+	for pin, id := range allState.PodIdentifiers {
+		// The pin basename contains the podIdentifier; find it by checking if
+		// the pod name prefix matches.
+		_ = id
+		if strings.Contains(pin, "_handle_ingress") {
+			identifier := strings.TrimSuffix(pin, "_handle_ingress")
+			// Check if this identifier could belong to our pod by verifying
+			// the pod name starts with the identifier prefix (before @)
+			parts := strings.SplitN(identifier, "@", 2)
+			if len(parts) == 2 {
+				// Pod name minus the last random segment should match the
+				// identifier prefix
+				nameParts := strings.Split(podName, "-")
+				prefix := strings.Join(nameParts[:len(nameParts)-1], "-")
+				if strings.ReplaceAll(prefix, ".", "_") == parts[0] {
+					return identifier
+				}
+			}
+		}
+	}
+	Fail(fmt.Sprintf("could not find pod identifier for pod %s in CLI dump", podName))
+	return ""
+}

--- a/test/integration/restart/rollout_restart_recovery_test.go
+++ b/test/integration/restart/rollout_restart_recovery_test.go
@@ -1,0 +1,463 @@
+package restart
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	network "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	npautils "github.com/aws/aws-network-policy-agent/pkg/utils"
+	"github.com/aws/aws-network-policy-agent/test/framework/manifest"
+	"github.com/aws/aws-network-policy-agent/test/framework/utils"
+)
+
+// A same-binary aws-node rollout must REUSE pinned programs/maps, not reload
+// them: only the agent restarts, so pods keep their veths and pinned state.
+// Verification uses host ground truth cross-checked against itself (see the
+// Describe/It text), never an identifier computed in Go and asserted back -
+// that would test the agent's naming code against itself.
+
+const (
+	recoveryLabelKey   = "recovery"
+	recoveryLabelValue = "rollout"
+	dottedPodName      = "my.app"
+	recoveryDeployName = "recovery-deploy"
+	recoveryJobName    = "recovery-job"
+	// The CNI host-veth prefix for regular (non-branch-ENI) pods.
+	podVethPrefix = "eni"
+)
+
+// recoveryCheckPod is the single privileged pod all host commands exec into.
+// Package-scoped so the package-level helpers below can reach it, matching how
+// the suite exposes fw/ctx/namespace.
+var recoveryCheckPod *v1.Pod
+
+// workload couples a running pod with the host veth its TC programs attach to.
+type workload struct {
+	label    string // human label for messages: "standalone" | "deployment" | "job"
+	pod      v1.Pod
+	vethName string
+}
+
+var _ = Describe("BPF Recovery Across Rollout Restart: reuses pinned progs/maps for standalone (dotted-name), Deployment, and Job pods, cross-checking bpffs pins, the loaded-ebpfdata CLI, and tc-attached prog IDs at each veth before and after the restart", Ordered, func() {
+	var (
+		networkPolicy *network.NetworkPolicy
+		serverPod     *v1.Pod
+		clientPod     *v1.Pod
+		deployment    *appsv1.Deployment
+		job           *batchv1.Job
+		nodeName      string
+		serverIP      string
+		workloads     []workload
+	)
+
+	It("keeps each pod's pin path, prog ID, and map IDs identical across the restart, and keeps the CLI-reported prog IDs equal to the tc-attached prog IDs at the veth (the dotted-name pod's identifier must stay 'my_app@ns', not truncate to 'my@ns')", func() {
+		By("Deploying the dotted-name standalone pod (nginx server)")
+		serverPod = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: dottedPodName, Namespace: namespace,
+				Labels: map[string]string{recoveryLabelKey: recoveryLabelValue, "role": "standalone"},
+			},
+			Spec: v1.PodSpec{Containers: []v1.Container{{
+				Name: "nginx", Image: "public.ecr.aws/nginx/nginx:latest",
+				Ports: []v1.ContainerPort{{ContainerPort: 80}},
+			}}},
+		}
+		var err error
+		serverPod, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, serverPod, podReadyTimeout)
+		Expect(err).ToNot(HaveOccurred())
+		nodeName = serverPod.Spec.NodeName
+		serverIP = serverPod.Status.PodIP
+		Expect(nodeName).ToNot(BeEmpty())
+
+		By("Bringing up the single host check pod on the workloads' node")
+		recoveryCheckPod, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, buildRecoveryCheckPod(nodeName), podReadyTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Deploying a Deployment pinned to the same node")
+		deployment = buildRecoveryDeployment(nodeName)
+		Expect(fw.K8sClient.Create(ctx, deployment)).To(Succeed())
+		deployPod, err := fw.PodManager.WaitTillPodWithLabelRunning(ctx, namespace, "role", "deploy", podReadyTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Deploying a Job pinned to the same node")
+		job = buildRecoveryJob(nodeName)
+		Expect(fw.K8sClient.Create(ctx, job)).To(Succeed())
+		jobPod, err := fw.PodManager.WaitTillPodWithLabelRunning(ctx, namespace, "role", "job", podReadyTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Locate each pod's host veth via the CNI's sha1 naming convention. This
+		// is ground truth for "where are this pod's TC programs attached", and is
+		// independent of the pin-path parser the recovery code uses.
+		workloads = []workload{
+			{label: "standalone", pod: *serverPod, vethName: utils.HostVethName(namespace, serverPod.Name, podVethPrefix, 0)},
+			{label: "deployment", pod: deployPod, vethName: utils.HostVethName(namespace, deployPod.Name, podVethPrefix, 0)},
+			{label: "job", pod: jobPod, vethName: utils.HostVethName(namespace, jobPod.Name, podVethPrefix, 0)},
+		}
+		for _, w := range workloads {
+			GinkgoWriter.Printf("Workload %-11s pod=%s veth=%s\n", w.label, w.pod.Name, w.vethName)
+		}
+
+		By("Applying a deny-all ingress+egress policy selecting all three workloads")
+		networkPolicy = manifest.NewNetworkPolicyBuilder().
+			Namespace(namespace).
+			Name("rollout-recovery-deny").
+			PodSelector(recoveryLabelKey, recoveryLabelValue).
+			SetPolicyType(true, true).
+			Build()
+		Expect(fw.NetworkPolicyManager.CreateNetworkPolicy(ctx, networkPolicy)).To(Succeed())
+		time.Sleep(bpfSettleInterval)
+
+		By("Deploying an unrestricted client and confirming the server is blocked (enforcement is live)")
+		clientPod = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "rollout-client", Namespace: namespace,
+				Labels: map[string]string{"role": "client"}, // not selected by the policy
+			},
+			Spec: v1.PodSpec{
+				NodeName:   nodeName,
+				Containers: []v1.Container{{Name: "curl", Image: "public.ecr.aws/docker/library/python:3.11-slim", Command: []string{"sleep", "3600"}}},
+			},
+		}
+		clientPod, err = fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, clientPod, podReadyTimeout)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(execConnect(namespace, clientPod.Name, serverIP, 80)).To(Equal("BLOCKED"))
+
+		// ================= PRE-RESTART: capture host state =================
+		By("PRE-RESTART: capturing pin paths, CLI-described IDs, and tc-attached IDs")
+		GinkgoWriter.Printf("Pre-restart program pins on node:\n%s\n", strings.Join(listProgramPinBasenames(), "\n"))
+
+		// allBPFStateBeforeRestart: whole-node CLI dump (every pin's prog ID +
+		// parsed identifier). podProgramsBeforeRestart: narrowed to just our test
+		// pods' programs, keyed by workload label.
+		allBPFCLIStateBeforeRestart := dumpAllBPFStateFromCLI()
+		podProgramsCLIStateBeforeRestart := map[string]podPrograms{}
+		for _, w := range workloads {
+			podProgramsCLIStateBeforeRestart[w.label] = selectPodProgramsViaTC(w, allBPFCLIStateBeforeRestart)
+		}
+
+		// The identifier the agent parsed out of the pin (CLI "Pod Identifier")
+		// must equal the identifier derived from the pod name. Guards the pin-path
+		// parser against regressions like truncating "my_app@ns" to "my".
+		By("Step 1: the parsed Pod Identifier for each pod matches the name-derived identifier")
+		for _, w := range workloads {
+			expectedIdentifier := npautils.GetPodIdentifier(w.pod.Name, namespace)
+			progs := podProgramsCLIStateBeforeRestart[w.label]
+			Expect(allBPFCLIStateBeforeRestart.PodIdentifiers[progs.ingressPin]).To(Equal(expectedIdentifier),
+				"%s (pod %s): CLI-parsed identifier for pin %s must match name-derived %q",
+				w.label, w.pod.Name, progs.ingressPin, expectedIdentifier)
+			Expect(allBPFCLIStateBeforeRestart.PodIdentifiers[progs.egressPin]).To(Equal(expectedIdentifier),
+				"%s (pod %s): CLI-parsed identifier for pin %s must match name-derived %q",
+				w.label, w.pod.Name, progs.egressPin, expectedIdentifier)
+		}
+
+		By("Step 2: each pod's CLI-reported prog IDs match the prog IDs tc has attached at its veth")
+		for _, w := range workloads {
+			assertCLIAndTCAgree(w, podProgramsCLIStateBeforeRestart[w.label], allBPFCLIStateBeforeRestart)
+		}
+
+		// ================= RESTART
+		// =================
+		By("Rollout-restarting the aws-node DaemonSet (same binary)")
+		rolloutRestartDaemonSet()
+		waitForDaemonSetRollout()
+		time.Sleep(bpfSettleInterval)
+
+		// ================= POST-RESTART: re-capture and compare =================
+		By("POST-RESTART: capturing pin paths, CLI-described IDs, and tc-attached IDs")
+		GinkgoWriter.Printf("Post-restart program pins on node:\n%s\n", strings.Join(listProgramPinBasenames(), "\n"))
+
+		allBPFStateAfterRestart := dumpAllBPFStateFromCLI()
+		podProgramsAfterRestart := map[string]podPrograms{}
+		for _, w := range workloads {
+			podProgramsAfterRestart[w.label] = selectPodProgramsViaTC(w, allBPFStateAfterRestart)
+		}
+
+		By("Step 3: each pod's pin paths are unchanged after restart")
+		for _, w := range workloads {
+			before, after := podProgramsCLIStateBeforeRestart[w.label], podProgramsAfterRestart[w.label]
+			Expect(after.ingressPin).To(Equal(before.ingressPin), "%s: ingress pin path should be unchanged after restart", w.label)
+			Expect(after.egressPin).To(Equal(before.egressPin), "%s: egress pin path should be unchanged after restart", w.label)
+		}
+
+		// A same-binary rollout reuses programs rather than reloading them, so the
+		// prog ID is the same kernel object before and after. Map bindings are
+		// frozen into a program at load and cannot change while it lives, so a
+		// preserved prog ID already implies preserved map IDs.
+		By("Step 4: each pod's prog IDs are preserved (same-binary recovery reuses, not reloads)")
+		for _, w := range workloads {
+			before, after := podProgramsCLIStateBeforeRestart[w.label], podProgramsAfterRestart[w.label]
+			Expect(after.ingressProgID).To(Equal(before.ingressProgID), "%s: ingress prog ID should be preserved", w.label)
+			Expect(after.egressProgID).To(Equal(before.egressProgID), "%s: egress prog ID should be preserved", w.label)
+		}
+
+		By("Step 5: each pod's CLI-reported prog IDs still match tc-attached prog IDs after restart")
+		for _, w := range workloads {
+			assertCLIAndTCAgree(w, podProgramsAfterRestart[w.label], allBPFStateAfterRestart)
+		}
+
+		By("Enforcement continues after restart")
+		Expect(execConnect(namespace, clientPod.Name, serverIP, 80)).To(Equal("BLOCKED"))
+	})
+
+	AfterAll(func() {
+		if networkPolicy != nil {
+			fw.NetworkPolicyManager.DeleteNetworkPolicy(ctx, networkPolicy)
+		}
+		if clientPod != nil {
+			fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, clientPod)
+		}
+		if serverPod != nil {
+			fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, serverPod)
+		}
+		if deployment != nil {
+			_ = fw.K8sClient.Delete(ctx, deployment)
+		}
+		if job != nil {
+			policy := metav1.DeletePropagationForeground
+			_ = fw.K8sClient.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: &policy})
+		}
+		if recoveryCheckPod != nil {
+			fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, recoveryCheckPod)
+			recoveryCheckPod = nil
+		}
+	})
+})
+
+// podPrograms is one pod's two TC programs, as observed on the host: the pin
+// filenames and the prog IDs the CLI reports for them.
+type podPrograms struct {
+	identifier    string // pod identifier read off the pin basename
+	ingressPin    string // "<identifier>_handle_ingress"
+	egressPin     string // "<identifier>_handle_egress"
+	ingressProgID int    // prog ID the CLI reports for the ingress pin
+	egressProgID  int    // prog ID the CLI reports for the egress pin
+}
+
+// selectPodProgramsViaTC picks one pod's two programs out of the node-wide CLI
+// dump, using tc as the selector: tc reports which prog IDs are attached at the
+// pod's veth (kernel ground truth), and we keep only the CLI pins whose prog ID
+// is in that set. Those two pins are this pod's; their shared basename is its
+// identifier.
+//
+// Using the tc-attached prog IDs (not a name match) is what keeps this
+// independent of the pin-path parser under test. The combined set of both hooks
+// is used only to find which two pins belong to the veth; which hook holds which
+// direction is asserted separately in assertCLIAndTCAgree.
+func selectPodProgramsViaTC(w workload, allBPFState utils.BPFState) podPrograms {
+	attachedProgIDs := tcAttachedProgIDSet(w.vethName)
+	Expect(attachedProgIDs).ToNot(BeEmpty(), "%s (%s): expected BPF programs attached at the veth's TC hooks", w.label, w.vethName)
+
+	progs := podPrograms{}
+	for pin, progID := range allBPFState.ProgIDs {
+		if !attachedProgIDs[progID] {
+			continue // belongs to a different pod
+		}
+		switch {
+		case strings.HasSuffix(pin, "_handle_ingress"):
+			progs.identifier = strings.TrimSuffix(pin, "_handle_ingress")
+			progs.ingressPin = pin
+			progs.ingressProgID = progID
+		case strings.HasSuffix(pin, "_handle_egress"):
+			progs.identifier = strings.TrimSuffix(pin, "_handle_egress")
+			progs.egressPin = pin
+			progs.egressProgID = progID
+		}
+	}
+	Expect(progs.identifier).ToNot(BeEmpty(),
+		"%s (%s): no program pin in the CLI dump matched the tc-attached prog IDs %v", w.label, w.vethName, keysOfBool(attachedProgIDs))
+
+	return progs
+}
+
+// assertCLIAndTCAgree checks the load-bearing cross-source equality with the
+// exact hook<->direction mapping, so it also guards NPA's TC-hook inversion:
+// a pod's INGRESS program attaches to the TC EGRESS hook, and its EGRESS
+// program attaches to the TC INGRESS hook (attachIngressBPFProbe ->
+// TCEgressAttach, attachEgressBPFProbe -> TCIngressAttach). So the prog ID the
+// CLI reports for the pod's ingress pin must be the one tc shows on the egress
+// hook, and vice versa. Each hook carries exactly one filter (fixed handle), so
+// we assert a single ID per hook, not a set.
+//
+// This intentionally couples the test to the inversion convention: if the
+// agent's hook mapping ever changes, this assertion is meant to fail.
+func assertCLIAndTCAgree(w workload, progState podPrograms, allBPFCLIState utils.BPFState) {
+	// Read the prog IDs straight from the CLI dump keyed by pin name, so the
+	// values compared here come purely from the CLI - NOT from progs, whose IDs
+	// were already filtered through the tc set during selection. This keeps the
+	// comparison a genuine CLI-vs-tc cross-check rather than tc-vs-tc.
+	cliIngressProgID := allBPFCLIState.ProgIDs[progState.ingressPin]
+	cliEgressProgID := allBPFCLIState.ProgIDs[progState.egressPin]
+	Expect(cliIngressProgID).ToNot(BeZero(), "%s: CLI dump has no prog ID for ingress pin %s", w.label, progState.ingressPin)
+	Expect(cliEgressProgID).ToNot(BeZero(), "%s: CLI dump has no prog ID for egress pin %s", w.label, progState.egressPin)
+
+	tcIngressHook := tcAttachedProgIDs(w.vethName, "ingress")
+	tcEgressHook := tcAttachedProgIDs(w.vethName, "egress")
+	Expect(tcIngressHook).To(HaveLen(1), "%s (%s): expected exactly one filter on the TC ingress hook, got %v", w.label, w.vethName, tcIngressHook)
+	Expect(tcEgressHook).To(HaveLen(1), "%s (%s): expected exactly one filter on the TC egress hook, got %v", w.label, w.vethName, tcEgressHook)
+
+	// Inversion: ingress program -> egress hook, egress program -> ingress hook.
+	Expect(tcEgressHook[0]).To(Equal(cliIngressProgID),
+		"%s: pod ingress program (pin %s, CLI prog ID %d) must be attached at the TC EGRESS hook, but tc shows %d there",
+		w.label, progState.ingressPin, cliIngressProgID, tcEgressHook[0])
+	Expect(tcIngressHook[0]).To(Equal(cliEgressProgID),
+		"%s: pod egress program (pin %s, CLI prog ID %d) must be attached at the TC INGRESS hook, but tc shows %d there",
+		w.label, progState.egressPin, cliEgressProgID, tcIngressHook[0])
+}
+
+// listProgramPinBasenames returns the basenames of every program pin under the
+// agent's programs pin directory on the node.
+func listProgramPinBasenames() []string {
+	out := execInCheckPod([]string{"chroot", "/host", "ls", "-1", "/sys/fs/bpf/globals/aws/programs/"})
+	var names []string
+	for _, line := range strings.Split(out, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			names = append(names, line)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// dumpAllBPFStateFromCLI runs `loaded-ebpfdata` in the check pod and parses the
+// whole-node dump: every pin's prog ID and the agent's parsed Pod Identifier.
+func dumpAllBPFStateFromCLI() utils.BPFState {
+	out := execInCheckPod([]string{"chroot", "/host", "/opt/cni/bin/aws-eks-na-cli", "ebpf", "loaded-ebpfdata"})
+	Expect(out).ToNot(BeEmpty(), "empty loaded-ebpfdata output")
+	state, err := utils.ParseLoadedEBPFData(out)
+	Expect(err).ToNot(HaveOccurred(), "failed to parse loaded-ebpfdata output")
+	return state
+}
+
+// tcAttachedProgIDs returns the BPF prog IDs attached at the given TC hook of a
+// host veth, read straight from `tc filter show`.
+//
+// tc runs from the netshoot image itself (which ships iproute2), NOT via
+// chroot /host: the AL2023 node image does not carry tc on the chroot PATH. The
+// check pod is hostNetwork, so the pod's own tc sees the host veths and their
+// TC filters directly.
+func tcAttachedProgIDs(vethName, direction string) []int {
+	out := execInCheckPod([]string{"tc", "filter", "show", "dev", vethName, direction})
+	return utils.ParseTCFilterProgIDs(out)
+}
+
+// tcAttachedProgIDSet returns the union of BPF prog IDs attached at both TC
+// hooks (ingress + egress) of a veth, as a set. This is the hook-agnostic view
+// used to cross-check against the CLI dump - see selectPodProgramsViaTC.
+func tcAttachedProgIDSet(vethName string) map[int]bool {
+	set := map[int]bool{}
+	for _, dir := range []string{"ingress", "egress"} {
+		for _, id := range tcAttachedProgIDs(vethName, dir) {
+			set[id] = true
+		}
+	}
+	return set
+}
+
+// keysOfBool returns the keys of a set as a slice, for readable failure output.
+func keysOfBool(m map[int]bool) []int {
+	out := make([]int, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Ints(out)
+	return out
+}
+
+// fetchAgentMetrics scrapes the aws-node agent's Prometheus endpoint from the
+// check pod. The check pod runs with hostNetwork and the netshoot image ships
+// curl, so the agent's metrics endpoint is reachable on the node's loopback
+// without chroot or a package install. Soft: returns the error instead of
+// failing, since step 6 is gathered and logged, not asserted.
+func fetchAgentMetrics() (string, error) {
+	return execInCheckPodSoft([]string{"curl", "-s", "--max-time", "10", "http://127.0.0.1:8162/metrics"})
+}
+
+// execInCheckPod runs a command in the shared check pod and requires success.
+func execInCheckPod(command []string) string {
+	Expect(recoveryCheckPod).ToNot(BeNil(), "check pod must be created before host exec")
+	out, err := fw.PodManager.ExecInPod(namespace, recoveryCheckPod.Name, command)
+	Expect(err).ToNot(HaveOccurred(), "exec in check pod failed: %v", command)
+	return out
+}
+
+// execInCheckPodSoft runs a command in the shared check pod and returns the
+// error rather than failing the test.
+func execInCheckPodSoft(command []string) (string, error) {
+	if recoveryCheckPod == nil {
+		return "", fmt.Errorf("check pod not created")
+	}
+	return fw.PodManager.ExecInPod(namespace, recoveryCheckPod.Name, command)
+}
+
+// rolloutRestartDaemonSet triggers a rolling restart of the agent DaemonSet the
+// same way `kubectl rollout restart` does: by stamping the pod-template
+// restartedAt annotation, which bumps the DaemonSet generation and recreates its
+// pods from the unchanged image.
+func rolloutRestartDaemonSet() {
+	ds := &appsv1.DaemonSet{}
+	Expect(fw.K8sClient.Get(ctx, client.ObjectKey{Name: agentDaemonSet, Namespace: agentNamespace}, ds)).To(Succeed())
+	if ds.Spec.Template.Annotations == nil {
+		ds.Spec.Template.Annotations = map[string]string{}
+	}
+	ds.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = fmt.Sprintf("%d", time.Now().UnixNano())
+	Expect(fw.K8sClient.Update(ctx, ds)).To(Succeed())
+}
+
+// buildRecoveryCheckPod is the shared BPF check pod, kept alive for the whole
+// spec. The netshoot base image already ships curl/tc/bpftool, so this only
+// extends the sleep past the base 300s: the pod must outlive the rollout
+// restart (up to rolloutTimeout) plus the pre/post capture phases.
+func buildRecoveryCheckPod(nodeName string) *v1.Pod {
+	p := utils.BuildBPFCheckPod(namespace, nodeName)
+	p.Spec.Containers[0].Command = []string{"sleep", "1800"}
+	return p
+}
+
+func buildRecoveryDeployment(nodeName string) *appsv1.Deployment {
+	replicas := int32(1)
+	labels := map[string]string{recoveryLabelKey: recoveryLabelValue, "role": "deploy"}
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: recoveryDeployName, Namespace: namespace},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"role": "deploy"}},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: v1.PodSpec{
+					NodeName:   nodeName,
+					Containers: []v1.Container{{Name: "app", Image: "public.ecr.aws/nginx/nginx:latest", Command: []string{"sleep", "3600"}}},
+				},
+			},
+		},
+	}
+}
+
+func buildRecoveryJob(nodeName string) *batchv1.Job {
+	backoffLimit := int32(0)
+	labels := map[string]string{recoveryLabelKey: recoveryLabelValue, "role": "job"}
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: recoveryJobName, Namespace: namespace},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: &backoffLimit,
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: v1.PodSpec{
+					NodeName:      nodeName,
+					RestartPolicy: v1.RestartPolicyNever,
+					// Long-lived so the pod survives the agent rollout restart.
+					Containers: []v1.Container{{Name: "job", Image: "public.ecr.aws/amazonlinux/amazonlinux:2023-minimal", Command: []string{"sleep", "3600"}}},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*
Handle partial/failed BPF recovery from the updated SDK, and add an integration test verifying recovery across a same-binary agent restart.


*Description of changes:*
 Makes eBPF state recovery resilient to per-pin failures, fixes pin-path parsing for pod names containing dots, and adds integration coverage for recovery across a same-binary agent restart.

  - **`bpf_client.go`**: `recoverBPFState` / `ReAttachEbpfProbes` skip recovered entries with an unparseable pin path (empty identifier) instead of storing state under an empty key; log + metric on skip. Handle the SDK's partial recovery (non-nil error with usable state).
  - **Integration test** (`rollout_restart_recovery_test.go`): same-binary rollout restart reuses pinned programs (not reload), across standalone-dotted / Deployment / Job pods. Verified from host ground truth — CLI-parsed identifier vs name-derived, CLI prog IDs vs tc-attached (with hook inversion), pins + IDs preserved before/after, enforcement continuous.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
