### PR TITLE
attempt to fix cyclonus tests: detect cyclonus pod stalls and gate on aws-node readiness

### DIFF
--- a/scripts/lib/network-policy.sh
+++ b/scripts/lib/network-policy.sh
@@ -1,4 +1,66 @@
 
+function wait_for_aws_node_settled() {
+    local overall_timeout=${AWS_NODE_SETTLE_TIMEOUT:-300}
+    local settle_window=${AWS_NODE_SETTLE_WINDOW:-30}
+
+    echo "Waiting up to ${overall_timeout}s for aws-node to settle (all containers Ready with restartCount==0 for ${settle_window}s)..."
+
+    local start
+    start=$(date +%s)
+    local stable_since=0
+
+    while true; do
+        local now
+        now=$(date +%s)
+        local elapsed=$((now - start))
+        if [ "$elapsed" -ge "$overall_timeout" ]; then
+            echo "aws-node did not settle within ${overall_timeout}s"
+            kubectl get pods -n kube-system -l k8s-app=aws-node -owide || true
+            kubectl describe pods -n kube-system -l k8s-app=aws-node || true
+            kubectl get events -n kube-system --sort-by=.lastTimestamp | tail -50 || true
+            return 1
+        fi
+
+        local pods_json
+        pods_json=$(kubectl get pods -n kube-system -l k8s-app=aws-node -o json 2>/dev/null || echo '{"items":[]}')
+
+        local desired
+        desired=$(kubectl get ds/aws-node -n kube-system -o jsonpath='{.status.desiredNumberScheduled}' 2>/dev/null || echo 0)
+        # Count only pods that are not terminating (no deletionTimestamp).
+        local live_count
+        live_count=$(echo "$pods_json" | jq '[.items[] | select(.metadata.deletionTimestamp == null)] | length')
+
+        if [ -z "$desired" ] || [ "$desired" = "0" ] || [ "$live_count" != "$desired" ]; then
+            stable_since=0
+            sleep 5
+            continue
+        fi
+
+        # Every container in every non-terminating aws-node pod must be Ready with restartCount==0.
+        local not_ready
+        not_ready=$(echo "$pods_json" | jq '[.items[] | select(.metadata.deletionTimestamp == null) | .status.containerStatuses[]? | select(.ready != true or .restartCount != 0)] | length')
+        if [ "$not_ready" != "0" ]; then
+            stable_since=0
+            sleep 5
+            continue
+        fi
+
+        if [ "$stable_since" = "0" ]; then
+            stable_since=$now
+            echo "aws-node pods ready and quiet at $(date -Is); requiring ${settle_window}s of stability"
+        fi
+
+        if [ $((now - stable_since)) -ge "$settle_window" ]; then
+            break
+        fi
+
+        sleep 5
+    done
+
+    echo "aws-node settled: ${desired} pods Ready with restartCount==0 for ${settle_window}s"
+    return 0
+}
+
 function load_addon_details() {
 
   ADDON_NAME="vpc-cni"

--- a/scripts/lib/tests.sh
+++ b/scripts/lib/tests.sh
@@ -31,9 +31,75 @@ spec:
 EOF
 }
 
+function dump_cyclonus_diagnostics(){
+    local reason="${1:-diagnostics}"
+    echo "==== cyclonus diagnostics: ${reason} ===="
+
+    echo "---- kubectl get pods -A -owide ----"
+    kubectl get pods -A -owide || true
+
+    echo "---- kubectl get events -n netpol --sort-by=.lastTimestamp ----"
+    kubectl get events -n netpol --sort-by=.lastTimestamp || true
+
+    echo "---- kubectl describe job/cyclonus -n netpol ----"
+    kubectl describe job/cyclonus -n netpol || true
+
+    echo "---- kubectl describe pods -n netpol (cyclonus) ----"
+    kubectl describe pods -n netpol -l job-name=cyclonus || true
+
+    echo "---- kubectl get pods -n kube-system -l k8s-app=aws-node -owide ----"
+    kubectl get pods -n kube-system -l k8s-app=aws-node -owide || true
+
+    echo "---- aws-node restartCounts per container ----"
+    kubectl get pods -n kube-system -l k8s-app=aws-node \
+        -o jsonpath='{range .items[*]}{.spec.nodeName}{"\t"}{.metadata.name}{"\t"}{range .status.containerStatuses[*]}{.name}={.restartCount},{end}{"\n"}{end}' || true
+
+    echo "---- kubectl describe pods -n kube-system -l k8s-app=aws-node ----"
+    kubectl describe pods -n kube-system -l k8s-app=aws-node || true
+
+    echo "---- kubectl logs -n kube-system -l k8s-app=aws-node -c aws-eks-nodeagent --tail=200 ----"
+    kubectl logs -n kube-system -l k8s-app=aws-node -c aws-eks-nodeagent --tail=200 --prefix=true || true
+
+    echo "---- kubectl logs -n kube-system -l k8s-app=aws-node -c aws-node --tail=200 ----"
+    kubectl logs -n kube-system -l k8s-app=aws-node -c aws-node --tail=200 --prefix=true || true
+
+    echo "==== end diagnostics ===="
+}
+
+function wait_for_cyclonus_pod_running(){
+    local pod_timeout=${1:-300}
+    local start=$(date +%s)
+    echo "Waiting up to ${pod_timeout}s for the cyclonus pod to reach Running..."
+
+    while true; do
+        local pod_json
+        pod_json=$(kubectl get pods -n netpol -l job-name=cyclonus -o json 2>/dev/null || echo '{"items":[]}')
+        local phase
+        phase=$(echo "$pod_json" | jq -r '.items[0].status.phase // "Missing"')
+
+        if [ "$phase" = "Running" ] || [ "$phase" = "Succeeded" ]; then
+            echo "cyclonus pod reached phase=${phase}"
+            return 0
+        fi
+
+        local now=$(date +%s)
+        local elapsed=$((now - start))
+        if [ "$elapsed" -ge "$pod_timeout" ]; then
+            local waiting_reason
+            waiting_reason=$(echo "$pod_json" | jq -r '.items[0].status.containerStatuses[0].state.waiting.reason // "unknown"')
+            echo "cyclonus pod did not reach Running within ${pod_timeout}s (phase=${phase} waiting=${waiting_reason})"
+            dump_cyclonus_diagnostics "cyclonus pod stuck (phase=${phase} waiting=${waiting_reason})"
+            return 1
+        fi
+
+        sleep 5
+    done
+}
+
 function run_cyclonus_tests(){
 
     TIMEOUT=$((5 * 60 * 60))  # 5 hours timeout in seconds
+    POD_START_TIMEOUT=${CYCLONUS_POD_START_TIMEOUT:-300}
     START_TIME=$(date +%s)
 
     kubectl create ns netpol
@@ -41,6 +107,14 @@ function run_cyclonus_tests(){
     kubectl create sa cyclonus -n netpol
 
     generate_manifest_and_apply
+
+    if ! wait_for_cyclonus_pod_running "$POD_START_TIMEOUT"; then
+        echo "cyclonus pod failed to start; marking test failed and skipping the 5h wait"
+        TEST_FAILED=true
+        kubectl delete clusterrolebinding cyclonus || true
+        kubectl delete ns netpol x y z --ignore-not-found=true || true
+        return 0
+    fi
 
     echo "Executing cyclonus suite"
 
@@ -55,20 +129,22 @@ function run_cyclonus_tests(){
       ELAPSED_TIME=$((CURRENT_TIME - START_TIME))
       if [ "$ELAPSED_TIME" -ge "$TIMEOUT" ]; then
           echo "Timeout reached (5 hours). Exiting."
+          dump_cyclonus_diagnostics "job timeout"
+          TEST_FAILED=true
           break
       fi
 
       kubectl wait --for=condition=complete job.batch/cyclonus -n netpol --timeout=60s > /dev/null 2>&1 && break
     done
 
-    kubectl logs -n netpol job/cyclonus > ${DIR}/results.log
-    kubectl get pods -A -owide
+    kubectl logs -n netpol job/cyclonus > ${DIR}/results.log 2>&1 || echo "warning: kubectl logs failed; results.log may be empty"
+    kubectl get pods -A -owide || true
 
     # Cleanup after test finishes
-    kubectl delete clusterrolebinding cyclonus
-    kubectl delete ns netpol x y z
+    kubectl delete clusterrolebinding cyclonus || true
+    kubectl delete ns netpol x y z --ignore-not-found=true || true
 
-    cat ${DIR}/results.log
+    cat ${DIR}/results.log || true
 
     echo "Verify results against expected"
     python3 ${DIR}/lib/verify_test_results.py -f ${DIR}/results.log -ip $IP_FAMILY || TEST_FAILED=true

--- a/scripts/run-cyclonus-tests.sh
+++ b/scripts/run-cyclonus-tests.sh
@@ -86,6 +86,11 @@ if [[ $DEPLOY_NETWORK_POLICY_CONTROLLER_ON_DATAPLANE == "true" ]]; then
     make deploy-network-policy-controller-on-dataplane NP_CONTROLLER_IMAGE=$PROD_IMAGE_REGISTRY NP_CONTROLLER_ENDPOINT_CHUNK_SIZE=$NP_CONTROLLER_ENDPOINT_CHUNK_SIZE
 fi
 
+if ! wait_for_aws_node_settled; then
+    echo "aws-node readiness gate failed; refusing to run cyclonus against a not-ready dataplane"
+    exit 1
+fi
+
 run_cyclonus_tests
 
 check_path_cleanup


### PR DESCRIPTION

*Issue #, if available:*

Post-#606 non-skipped PR Cyclonus Tests runs hung the cyclonus Job pod in ContainerCreating for the full 5 h timeout (noticed 5 cases). Under bash -e, the follow-up kubectl logs failure aborted the script before kubectl get pods -A -owide could run — wiping all evidence. The branch turns that into a fast, verbose failure and gates on real aws-node readiness so the submission doesn't happen while the daemonset is still rolling.


*Description of changes:*

scripts/lib/network-policy.sh (+62) — new function:
  - wait_for_aws_node_settled() — polls until every aws-node pod is Ready with restartCount==0 for a settle window. Defaults: 300 s ceiling, 30 s
  window; overridable via AWS_NODE_SETTLE_TIMEOUT / AWS_NODE_SETTLE_WINDOW. Distroless-safe (no kubectl exec into containers). Ignores pods with
  deletionTimestamp so it correctly handles rollouts.

  scripts/lib/tests.sh (+86 / −5) — two new functions, one modified:
  - dump_cyclonus_diagnostics() — dumps pods (all-namespaces), events in netpol, describe job/pods, aws-node per-container restart counts,
  describe and logs --tail=200 for both aws-node and aws-eks-nodeagent containers. Each line has || true so nothing aborts the dump.
  - wait_for_cyclonus_pod_running() — polls the cyclonus pod's .status.phase. Returns success on Running/Succeeded, or fails with a full
  diagnostics dump if the pod is still not Running after a bounded timeout (default 300 s, overridable via CYCLONUS_POD_START_TIMEOUT).
  - run_cyclonus_tests() modified — calls wait_for_cyclonus_pod_running before the polling loop, so a stuck pod fails fast (~5 min) instead of
  hanging for 5 h. Also softens the kubectl logs / kubectl get pods / kubectl delete calls with || true / --ignore-not-found=true so set -euoE 
  pipefail can't abort the script mid-dump. On job timeout, marks TEST_FAILED=true and calls dump_cyclonus_diagnostics.

  scripts/run-cyclonus-tests.sh (+5) — inserts a call to wait_for_aws_node_settled between the addon-install path and run_cyclonus_tests. Aborts
  with exit 1 if aws-node hasn't quiesced, refusing to submit cyclonus against a not-ready dataplane.


*Testing*

Ran cyclonus tests locally successfully 

```
  ┌────────────────────┬─────────────────────────────────────────────────────────────┐
  │                    │                            Value                            │
  ├────────────────────┼─────────────────────────────────────────────────────────────┤
  │ Status             │ complete                                                    │
  ├────────────────────┼─────────────────────────────────────────────────────────────┤
  │ TEST_FAILED        │ false ✅                                                    │
  ├────────────────────┼─────────────────────────────────────────────────────────────┤
  │ Job condition      │ Complete=True                                               │
  ├────────────────────┼─────────────────────────────────────────────────────────────┤
  │ Test cases         │ 112 / 112 all passed                                        │
  ├────────────────────┼─────────────────────────────────────────────────────────────┤
  │ Cyclonus wallclock │ 3h 10m (05:00 → 08:10 UTC)                                  │
  ├────────────────────┼─────────────────────────────────────────────────────────────┤
  │ Watcher wallclock  │ 3013s (50 min, waited for cyclonus to finish then verified) │
  ├────────────────────┼─────────────────────────────────────────────────────────────┤
  │ Completed at       │ 2026-08-14 08:10:52 UTC                                     │
  └────────────────────┴─────────────────────────────────────────────────────────────┘

```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
