### PR TITLE
perf(events): rework policy event consumption

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.31
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.65.0
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.317.0
+	github.com/cilium/ebpf v0.21.0
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/zapr v1.3.0
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cilium/ebpf v0.21.0 h1:4dpx1J/B/1apeTmWBH5BkVLayHTkFrMovVPnHEk+l3k=
+github.com/cilium/ebpf v0.21.0/go.mod h1:1kHKv6Kvh5a6TePP5vvvoMa1bclRyzUXELSs272fmIQ=
 github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEmnuFjskwo=
 github.com/containernetworking/cni v1.3.0/go.mod h1:Bs8glZjjFfGPHMw6hQu82RUgEPNGEaBb9KS5KtNMnJ4=
 github.com/containernetworking/plugins v1.9.0 h1:Mg3SXBdRGkdXyFC4lcwr6u2ZB2SDeL6LC3U+QrEANuQ=
@@ -85,6 +87,8 @@ github.com/go-openapi/jsonreference v0.21.0 h1:Rs+Y7hSXT83Jacb7kFyjn4ijOuVGSvOdF
 github.com/go-openapi/jsonreference v0.21.0/go.mod h1:LmZmgsrTkVg9LG4EaHeY8cBDslNPMo06cago5JNLkm4=
 github.com/go-openapi/swag v0.23.1 h1:lpsStH0n2ittzTnbaSloVZLuB5+fvSY/+hnagBjSNZU=
 github.com/go-openapi/swag v0.23.1/go.mod h1:STZs8TbRvEQQKUA+JZNAm3EWlgaOBGpyFDqQnDHMef0=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=

--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -249,7 +249,7 @@ func NewBpfClient(ctx context.Context, nodeIP string, enablePolicyEventLogs, ena
 	log().Info("Initialized Conntrack client")
 
 	if enablePolicyEventLogs {
-		err = events.ConfigurePolicyEventsLogging(enableCloudWatchLogs, eventBufferFD, enableIPv6, logLevel)
+		err = events.ConfigurePolicyEventsLogging(enableCloudWatchLogs, eventBufferFD, enableIPv6)
 		if err != nil {
 			log().Errorf("unable to initialize event buffer for Policy event exiting..error: %v", err)
 			sdkAPIErr.WithLabelValues("ConfigurePolicyEventsLogging").Inc()

--- a/pkg/ebpf/events/decode_check_test.go
+++ b/pkg/ebpf/events/decode_check_test.go
@@ -1,0 +1,134 @@
+package events
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"testing"
+	"unsafe"
+)
+
+// Verifies the unsafe struct view + netip formatting produce identical results
+// to the old binary.Read-based decode path.
+func TestDecodeMatchesLegacy(t *testing.T) {
+	// Pin the Go struct to the C struct data_t layout (sizeof 32).
+	if got := unsafe.Sizeof(ringBufferDataV4_t{}); got != 32 {
+		t.Fatalf("ringBufferDataV4_t size = %d, want 32 (must match C struct data_t)", got)
+	}
+	// raw sample as the bpf program writes it: struct data_t, little-endian fields
+	src := ringBufferDataV4_t{
+		SourceIP:   0x0501a8c0, // 192.168.1.5 in wire order read LE
+		SourcePort: 54321,
+		DestIP:     0x0201a8c0, // 192.168.1.2
+		DestPort:   80,
+		Protocol:   17,
+		Verdict:    0,
+		PacketSz:   64,
+		IsEgress:   1,
+		Tier:       2,
+	}
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.LittleEndian, &src); err != nil {
+		t.Fatal(err)
+	}
+	// RawSample carries the C struct data_t (30 bytes of fields, sizeof 32
+	// with trailing padding); allocate the padded size.
+	raw := make([]byte, 32)
+	copy(raw, buf.Bytes())
+
+	// legacy decode
+	var legacy ringBufferDataV4_t
+	if err := binary.Read(bytes.NewBuffer(raw), binary.LittleEndian, &legacy); err != nil {
+		t.Fatal(err)
+	}
+	// new decode
+	got := (*ringBufferDataV4_t)(unsafe.Pointer(&raw[0]))
+	if *got != legacy {
+		t.Fatalf("struct mismatch: got %+v want %+v", *got, legacy)
+	}
+	// IP formatting parity
+	// IP fields hold the packet's big-endian bytes read as a little-endian
+	// u32. Cases include leading-zero octets.
+	for v, want := range map[uint32]string{
+		src.SourceIP: "192.168.1.5",
+		src.DestIP:   "192.168.1.2",
+		0xffffffff:   "255.255.255.255",
+		0x0100007f:   "127.0.0.1",
+		0x01000000:   "0.0.0.1",
+		0x00000001:   "1.0.0.0",
+		0:            "0.0.0.0",
+	} {
+		if got := ipv4Str(v); got != want {
+			t.Fatalf("ip mismatch for %#x: got %s want %s", v, got, want)
+		}
+	}
+}
+
+// Verifies formatFlowLine output is byte-identical to the previous
+// fmt-based Infof format string.
+func TestFormatFlowLineParity(t *testing.T) {
+	got := formatFlowLine(false, "192.168.1.5", 54321, "10.0.0.2", 80, "TCP", "DENY", "egress", "NETWORK_POLICY")
+	want := fmt.Sprintf("Flow Info: Src IP: %s Src Port: %d Dest IP: %s Dest Port: %d Proto %s Verdict %s Direction %s, Tier %s",
+		"192.168.1.5", 54321, "10.0.0.2", 80, "TCP", "DENY", "egress", "NETWORK_POLICY")
+	if got != want {
+		t.Fatalf("v4 format mismatch:\ngot  %q\nwant %q", got, want)
+	}
+
+	// The legacy v6 path used a different format string (colons, no comma).
+	got = formatFlowLine(true, "2600:1f14::5", 54321, "2600:1f14::2", 80, "TCP", "DENY", "egress", "NETWORK_POLICY")
+	want = fmt.Sprintf("Flow Info: Src IP: %s Src Port: %d Dest IP: %s Dest Port: %d Proto: %s Verdict: %s Direction: %s Tier: %s",
+		"2600:1f14::5", 54321, "2600:1f14::2", 80, "TCP", "DENY", "egress", "NETWORK_POLICY")
+	if got != want {
+		t.Fatalf("v6 format mismatch:\ngot  %q\nwant %q", got, want)
+	}
+}
+
+// ipv6Str must match the legacy net.IP.String() rendering, including
+// v4-mapped addresses rendering as dotted-quad.
+func TestIPv6StrParity(t *testing.T) {
+	cases := [][16]byte{
+		{0x26, 0x00, 0x1f, 0x14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x05}, // plain v6
+		{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 10, 0, 0, 1},         // v4-mapped
+		{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},                // ::1
+	}
+	for _, c := range cases {
+		legacy := net.IP(c[:]).String()
+		if got := ipv6Str(c); got != legacy {
+			t.Fatalf("ipv6 render mismatch for %v: got %q legacy %q", c, got, legacy)
+		}
+	}
+}
+
+// Same as TestDecodeMatchesLegacy for the v6 record layout (sizeof 56).
+func TestDecodeV6MatchesLegacy(t *testing.T) {
+	if got := unsafe.Sizeof(ringBufferDataV6_t{}); got != 56 {
+		t.Fatalf("ringBufferDataV6_t size = %d, want 56 (must match C struct data_t)", got)
+	}
+	src := ringBufferDataV6_t{
+		SourceIP:   [16]byte{0x26, 0x00, 0x1f, 0x14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5},
+		SourcePort: 54321,
+		DestIP:     [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 10, 0, 0, 1},
+		DestPort:   80,
+		Protocol:   6,
+		Verdict:    1,
+		PacketSz:   1500,
+		IsEgress:   0,
+		Tier:       1,
+	}
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.LittleEndian, &src); err != nil {
+		t.Fatal(err)
+	}
+	raw := make([]byte, 56)
+	copy(raw, buf.Bytes())
+
+	var legacy ringBufferDataV6_t
+	if err := binary.Read(bytes.NewBuffer(raw), binary.LittleEndian, &legacy); err != nil {
+		t.Fatal(err)
+	}
+	got := (*ringBufferDataV6_t)(unsafe.Pointer(&raw[0]))
+	if *got != legacy {
+		t.Fatalf("struct mismatch: got %+v want %+v", *got, legacy)
+	}
+}

--- a/pkg/ebpf/events/events.go
+++ b/pkg/ebpf/events/events.go
@@ -1,14 +1,15 @@
 package events
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"net/netip"
 	"os"
 	"strconv"
 	"time"
+	"unsafe"
 
 	awsWrapper "github.com/aws/aws-network-policy-agent/pkg/aws"
 	"github.com/aws/aws-network-policy-agent/pkg/aws/services"
@@ -19,7 +20,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
-	goebpfevents "github.com/aws/aws-ebpf-sdk-go/pkg/events"
+	cebpf "github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/ringbuf"
+	"go.uber.org/zap/zapcore"
+	"golang.org/x/sys/unix"
+
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/google/uuid"
@@ -27,13 +32,12 @@ import (
 )
 
 var (
-	RING_BUFFER_PINPATH = "/sys/fs/bpf/globals/aws/maps/global_policy_events"
-	cwl                 services.CloudWatchLogs
-	logStreamName       = ""
-	logGroupName        = ""
-	sequenceToken       = ""
-	EKS_CW_PATH         = "/aws/eks/"
-	NON_EKS_CW_PATH     = "/aws/"
+	cwl             services.CloudWatchLogs
+	logStreamName   = ""
+	logGroupName    = ""
+	sequenceToken   = ""
+	EKS_CW_PATH     = "/aws/eks/"
+	NON_EKS_CW_PATH = "/aws/"
 )
 
 func log() logger.Logger {
@@ -88,7 +92,7 @@ type ringBufferDataV6_t struct {
 	Tier       uint8
 }
 
-func ConfigurePolicyEventsLogging(enableCloudWatchLogs bool, mapFD int, enableIPv6 bool, logLevel string) error {
+func ConfigurePolicyEventsLogging(enableCloudWatchLogs bool, mapFD int, enableIPv6 bool) error {
 	// Enable logging and setup ring buffer
 	ctx := context.Background()
 	if mapFD <= 0 {
@@ -96,26 +100,92 @@ func ConfigurePolicyEventsLogging(enableCloudWatchLogs bool, mapFD int, enableIP
 		return fmt.Errorf("Invalid Ringbuffer FD: %d", mapFD)
 	}
 
-	var mapFDList []int
-	mapFDList = append(mapFDList, mapFD)
-	eventsClient := goebpfevents.New()
-	eventChanList, err := eventsClient.InitRingBuffer(mapFDList)
+	// Consume the ring buffer with cilium/ebpf's pull-model reader.
+	// Duplicate the recovered map FD so cilium/ebpf owns its own descriptor,
+	// independent of the SDK's map cache.
+	dupFD, err := unix.Dup(mapFD)
 	if err != nil {
+		log().Errorf("Failed to dup ring buffer map FD %d err: %v", mapFD, err)
+		return err
+	}
+	// NewMapFromFD takes ownership of dupFD on success and on failure
+	// (cilium closes it before returning an error) - never close it here.
+	ringMap, err := cebpf.NewMapFromFD(dupFD)
+	if err != nil {
+		log().Errorf("Failed to open ring buffer map from FD %d err: %v", mapFD, err)
+		return err
+	}
+	rd, err := ringbuf.NewReader(ringMap)
+	if err != nil {
+		ringMap.Close()
 		log().Errorf("Failed to Initialize Ring Buffer err: %v", err)
 		return err
-	} else {
-		if enableCloudWatchLogs {
-			log().Info("Cloudwatch log support is enabled")
-			err = setupCW(ctx)
-			if err != nil {
-				log().Errorf("unable to initialize Cloudwatch Logs for Policy events %v", err)
-				return err
-			}
-		}
-		log().Debug("Configure Event loop ... ")
-		capturePolicyEvents(ctx, eventChanList[mapFD], enableCloudWatchLogs, enableIPv6, logLevel)
 	}
+	if enableCloudWatchLogs {
+		log().Info("Cloudwatch log support is enabled")
+		err = setupCW(ctx)
+		if err != nil {
+			rd.Close()
+			ringMap.Close()
+			log().Errorf("unable to initialize Cloudwatch Logs for Policy events %v", err)
+			return err
+		}
+	}
+	log().Debug("Configure Event loop ... ")
+	capturePolicyEvents(ctx, rd, ringMap, enableCloudWatchLogs, enableIPv6)
 	return nil
+}
+
+// ipv4Str converts the u32 IP field from the ring buffer record (raw packet
+// bytes read little-endian) back to dotted-quad.
+func ipv4Str(v uint32) string {
+	var b [4]byte
+	binary.LittleEndian.PutUint32(b[:], v)
+	return netip.AddrFrom4(b).String()
+}
+
+// ipv6Str renders a 16-byte IP. Unmap() keeps parity with the previous
+// net.IP.String() behavior: v4-mapped addresses (::ffff:a.b.c.d) render as
+// dotted-quad.
+func ipv6Str(b [16]byte) string {
+	return netip.AddrFrom16(b).Unmap().String()
+}
+
+// formatFlowLine builds the flow log message without fmt. Output is
+// byte-identical to the previous Infof formatting, which used different
+// separators per family:
+//
+//	v4: "... Proto %s Verdict %s Direction %s, Tier %s"
+//	v6: "... Proto: %s Verdict: %s Direction: %s Tier: %s"
+func formatFlowLine(v6 bool, srcIP string, srcPort uint32, destIP string, destPort uint32, protocol, verdict, direction, tier string) string {
+	b := make([]byte, 0, 160)
+	b = append(b, "Flow Info: Src IP: "...)
+	b = append(b, srcIP...)
+	b = append(b, " Src Port: "...)
+	b = strconv.AppendUint(b, uint64(srcPort), 10)
+	b = append(b, " Dest IP: "...)
+	b = append(b, destIP...)
+	b = append(b, " Dest Port: "...)
+	b = strconv.AppendUint(b, uint64(destPort), 10)
+	if v6 {
+		b = append(b, " Proto: "...)
+		b = append(b, protocol...)
+		b = append(b, " Verdict: "...)
+		b = append(b, verdict...)
+		b = append(b, " Direction: "...)
+		b = append(b, direction...)
+		b = append(b, " Tier: "...)
+	} else {
+		b = append(b, " Proto "...)
+		b = append(b, protocol...)
+		b = append(b, " Verdict "...)
+		b = append(b, verdict...)
+		b = append(b, " Direction "...)
+		b = append(b, direction...)
+		b = append(b, ", Tier "...)
+	}
+	b = append(b, tier...)
+	return string(b)
 }
 
 func setupCW(ctx context.Context) error {
@@ -171,123 +241,119 @@ func getTier(tier int) string {
 	return tierStr
 }
 
-func publishDataToCloudwatch(ctx context.Context, logQueue []types.InputLogEvent, message string) bool {
-	logQueue = append(logQueue, types.InputLogEvent{
-		Message:   aws.String(message),
-		Timestamp: aws.Int64(time.Now().UnixNano() / int64(time.Millisecond)),
-	})
-	if len(logQueue) > 0 {
-		log().Debug("Sending logs to CW")
-		input := &cloudwatchlogs.PutLogEventsInput{
-			LogEvents:     logQueue,
-			LogGroupName:  aws.String(logGroupName),
-			LogStreamName: aws.String(logStreamName),
-		}
-
-		if sequenceToken == "" {
-			err := createLogStream(ctx)
-			if err != nil {
-				log().Errorf("Failed to create log stream %v", err)
-				panic(err)
-			}
-		} else {
-			input.SequenceToken = aws.String(sequenceToken)
-		}
-
-		resp, err := cwl.PutLogEvents(ctx, input)
-		if err != nil {
-			log().Errorf("Push log events Failed %v", err)
-		} else if resp != nil && resp.NextSequenceToken != nil {
-			sequenceToken = *resp.NextSequenceToken
-		}
-
-		logQueue = []types.InputLogEvent{}
-		return false
+// publishDataToCloudwatch sends one policy event to CloudWatch Logs.
+// TODO: one synchronous PutLogEvents per event caps consumption at ~1/RTT and
+// can overflow the ring buffer at high event rates; batch the publish on a
+// separate goroutine.
+func publishDataToCloudwatch(ctx context.Context, message string) {
+	log().Debug("Sending logs to CW")
+	input := &cloudwatchlogs.PutLogEventsInput{
+		LogEvents: []types.InputLogEvent{{
+			Message:   aws.String(message),
+			Timestamp: aws.Int64(time.Now().UnixNano() / int64(time.Millisecond)),
+		}},
+		LogGroupName:  aws.String(logGroupName),
+		LogStreamName: aws.String(logStreamName),
 	}
-	return true
+
+	if sequenceToken == "" {
+		err := createLogStream(ctx)
+		if err != nil {
+			log().Errorf("Failed to create log stream %v", err)
+			panic(err)
+		}
+	} else {
+		input.SequenceToken = aws.String(sequenceToken)
+	}
+
+	resp, err := cwl.PutLogEvents(ctx, input)
+	if err != nil {
+		log().Errorf("Push log events Failed %v", err)
+	} else if resp != nil && resp.NextSequenceToken != nil {
+		sequenceToken = *resp.NextSequenceToken
+	}
 }
 
-func capturePolicyEvents(ctx context.Context, ringbufferdata <-chan []byte, enableCloudWatchLogs bool, enableIPv6 bool, logLevel string) {
+func capturePolicyEvents(ctx context.Context, rd *ringbuf.Reader, ringMap *cebpf.Map, enableCloudWatchLogs bool, enableIPv6 bool) {
 	nodeName := os.Getenv("MY_NODE_NAME")
-	// Read from ringbuffer channel, perf buffer support is not there and 5.10 kernel is needed.
-	go func(ringbufferdata <-chan []byte) {
-		done := false
-		for record := range ringbufferdata {
-			var logQueue []types.InputLogEvent
-			var message string
+	// dedicated non-sugared logger without caller capture for the hot path
+	flowLog := logger.GetFlowLogger()
+	// Gate ACCEPT logging on the core's level rather than the raw flag string.
+	debugEnabled := flowLog.Core().Enabled(zapcore.DebugLevel)
+	go func() {
+		// Hold ringMap for the reader's lifetime: cilium/ebpf closes the
+		// underlying FD once the Map is garbage collected, and the reader
+		// registers only the raw FD with epoll.
+		defer ringMap.Close()
+		defer rd.Close()
+		var rec ringbuf.Record
+		for {
+			if err := rd.ReadInto(&rec); err != nil {
+				if errors.Is(err, ringbuf.ErrClosed) {
+					return
+				}
+				log().Errorf("Failed to read from Ring buf %v", err)
+				// Avoid a hot error loop if the ring is in a bad state.
+				time.Sleep(50 * time.Millisecond)
+				continue
+			}
+
 			var isDenyVerdict bool
 			direction := "egress"
+
+			var srcIP, destIP string
+			var srcPort, destPort uint32
+			var protocolNum, verdictNum, packetSz uint32
+			var isEgress, tierNum uint8
+
 			if enableIPv6 {
-				var rb ringBufferDataV6_t
-				buf := bytes.NewBuffer(record)
-				if err := binary.Read(buf, binary.LittleEndian, &rb); err != nil {
-					log().Errorf("Failed to read from Ring buf %v", err)
+				if len(rec.RawSample) < int(unsafe.Sizeof(ringBufferDataV6_t{})) {
+					log().Errorf("Failed to read from Ring buf: short sample %d", len(rec.RawSample))
 					continue
 				}
-
-				protocol := utils.GetProtocol(int(rb.Protocol))
-				verdict := getVerdict(int(rb.Verdict))
-
-				if rb.IsEgress == 0 {
-					direction = "ingress"
-				}
-
-				tier := getTier(int(rb.Tier))
-				isDenyVerdict = rb.Verdict == VerdictDeny
-
-				if rb.Verdict == VerdictDeny {
-					dropCountTotal.WithLabelValues(direction).Add(float64(1))
-					dropBytesTotal.WithLabelValues(direction).Add(float64(rb.PacketSz))
-					log().Infof("Flow Info: Src IP: %s Src Port: %d Dest IP: %s Dest Port: %d Proto: %s Verdict: %s Direction: %s Tier: %s", utils.ConvByteToIPv6(rb.SourceIP).String(), rb.SourcePort,
-						utils.ConvByteToIPv6(rb.DestIP).String(), rb.DestPort, protocol, string(verdict), string(direction), tier)
-				} else {
-					log().Debugf("Flow Info: Src IP: %s Src Port: %d Dest IP: %s Dest Port: %d Proto: %s Verdict: %s Direction: %s Tier: %s", utils.ConvByteToIPv6(rb.SourceIP).String(), rb.SourcePort,
-						utils.ConvByteToIPv6(rb.DestIP).String(), rb.DestPort, protocol, string(verdict), string(direction), tier)
-				}
-
-				// message = "Node: " + nodeName + ";" + "SIP: " + utils.ConvByteToIPv6(rb.SourceIP).String() + ";" + "SPORT: " + strconv.Itoa(int(rb.SourcePort)) + ";" + "DIP: " + utils.ConvByteToIPv6(rb.DestIP).String() + ";" + "DPORT: " + strconv.Itoa(int(rb.DestPort)) + ";" + "PROTOCOL: " + protocol + ";" + "PolicyVerdict: " + verdict
-				message = "Node: " + nodeName + ";" + "SIP: " + utils.ConvByteToIPv6(rb.SourceIP).String() + ";" + "SPORT: " + strconv.Itoa(int(rb.SourcePort)) + ";" + "DIP: " + utils.ConvByteToIPv6(rb.DestIP).String() + ";" + "DPORT: " + strconv.Itoa(int(rb.DestPort)) + ";" + "PROTOCOL: " + protocol + ";" + "PolicyVerdict: " + verdict + ";" + "Tier: " + tier
+				rb := (*ringBufferDataV6_t)(unsafe.Pointer(&rec.RawSample[0]))
+				srcIP, destIP = ipv6Str(rb.SourceIP), ipv6Str(rb.DestIP)
+				srcPort, destPort = rb.SourcePort, rb.DestPort
+				protocolNum, verdictNum, packetSz = rb.Protocol, rb.Verdict, rb.PacketSz
+				isEgress, tierNum = rb.IsEgress, rb.Tier
 			} else {
-				var rb ringBufferDataV4_t
-				buf := bytes.NewBuffer(record)
-				if err := binary.Read(buf, binary.LittleEndian, &rb); err != nil {
-					log().Errorf("Failed to read from Ring buf %v", err)
+				if len(rec.RawSample) < int(unsafe.Sizeof(ringBufferDataV4_t{})) {
+					log().Errorf("Failed to read from Ring buf: short sample %d", len(rec.RawSample))
 					continue
 				}
-				protocol := utils.GetProtocol(int(rb.Protocol))
-				verdict := getVerdict(int(rb.Verdict))
+				rb := (*ringBufferDataV4_t)(unsafe.Pointer(&rec.RawSample[0]))
+				srcIP, destIP = ipv4Str(rb.SourceIP), ipv4Str(rb.DestIP)
+				srcPort, destPort = rb.SourcePort, rb.DestPort
+				protocolNum, verdictNum, packetSz = rb.Protocol, rb.Verdict, rb.PacketSz
+				isEgress, tierNum = rb.IsEgress, rb.Tier
+			}
 
-				if rb.IsEgress == 0 {
-					direction = "ingress"
-				}
+			protocol := utils.GetProtocol(int(protocolNum))
+			verdict := getVerdict(int(verdictNum))
+			if isEgress == 0 {
+				direction = "ingress"
+			}
+			tier := getTier(int(tierNum))
+			isDenyVerdict = verdictNum == VerdictDeny
 
-				tier := getTier(int(rb.Tier))
-				isDenyVerdict = rb.Verdict == VerdictDeny
-
-				if rb.Verdict == VerdictDeny {
-					dropCountTotal.WithLabelValues(direction).Add(float64(1))
-					dropBytesTotal.WithLabelValues(direction).Add(float64(rb.PacketSz))
-					log().Infof("Flow Info: Src IP: %s Src Port: %d Dest IP: %s Dest Port: %d Proto %s Verdict %s Direction %s, Tier %s", utils.ConvByteArrayToIP(rb.SourceIP), rb.SourcePort,
-						utils.ConvByteArrayToIP(rb.DestIP), rb.DestPort, protocol, string(verdict), string(direction), tier)
-				} else {
-					log().Debugf("Flow Info: Src IP: %s Src Port: %d Dest IP: %s Dest Port: %d Proto %s Verdict %s Direction %s, Tier %s", utils.ConvByteArrayToIP(rb.SourceIP), rb.SourcePort,
-						utils.ConvByteArrayToIP(rb.DestIP), rb.DestPort, protocol, string(verdict), string(direction), tier)
-				}
-				message = "Node: " + nodeName + ";" + "SIP: " + utils.ConvByteArrayToIP(rb.SourceIP) + ";" + "SPORT: " + strconv.Itoa(int(rb.SourcePort)) + ";" + "DIP: " + utils.ConvByteArrayToIP(rb.DestIP) + ";" + "DPORT: " + strconv.Itoa(int(rb.DestPort)) + ";" + "PROTOCOL: " + protocol + ";" + "PolicyVerdict: " + verdict + ";" + "Tier: " + tier
+			if isDenyVerdict {
+				dropCountTotal.WithLabelValues(direction).Add(float64(1))
+				dropBytesTotal.WithLabelValues(direction).Add(float64(packetSz))
+				flowLog.Info(formatFlowLine(enableIPv6, srcIP, srcPort, destIP, destPort, protocol, verdict, direction, tier))
+			} else if debugEnabled {
+				flowLog.Debug(formatFlowLine(enableIPv6, srcIP, srcPort, destIP, destPort, protocol, verdict, direction, tier))
 			}
 
 			if enableCloudWatchLogs {
 				// Apply same filtering as local logging:
 				// DENY always published, ACCEPT only at debug level
-				if isDenyVerdict || logLevel == "debug" {
-					done = publishDataToCloudwatch(ctx, logQueue, message)
-					if done {
-						break
-					}
+				if isDenyVerdict || debugEnabled {
+					message := "Node: " + nodeName + ";" + "SIP: " + srcIP + ";" + "SPORT: " + strconv.Itoa(int(srcPort)) + ";" + "DIP: " + destIP + ";" + "DPORT: " + strconv.Itoa(int(destPort)) + ";" + "PROTOCOL: " + protocol + ";" + "PolicyVerdict: " + verdict + ";" + "Tier: " + tier
+					publishDataToCloudwatch(ctx, message)
 				}
 			}
 		}
-	}(ringbufferdata)
+	}()
 }
 
 func ensureLogGroupExists(ctx context.Context, name string) error {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
 )
 
 var log Logger
@@ -58,4 +59,18 @@ func GetControllerRuntimeLogger() logr.Logger {
 		LogFileMaxBackups: DEFAULT_LOG_FILE_MAX_BACKUPS,
 	}
 	return zapr.NewLogger(inputLogConfig.newZapLoggerForControllerRuntime())
+}
+
+// GetFlowLogger returns a plain zap logger that shares the default logger's
+// core (same file writer, rotation and level) but with caller annotation
+// disabled. Intended for hot paths emitting preformatted lines at high rates
+// (e.g. policy flow events), where caller capture is comparatively expensive
+// and records the logging wrapper rather than the call site.
+func GetFlowLogger() *zap.Logger {
+	if sl, ok := Get().(*structuredLogger); ok {
+		return sl.zapLogger.Desugar().WithOptions(zap.WithCaller(false))
+	}
+	// Only structuredLogger implements Logger today; fall back to a nop
+	// logger for any other implementation.
+	return zap.NewNop()
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -502,26 +502,6 @@ func IsNonHostCIDR(ipAddr string) bool {
 	return false
 }
 
-func ConvByteArrayToIP(ipInInt uint32) string {
-	hexIPString := fmt.Sprintf("%x", ipInInt)
-
-	if len(hexIPString)%2 != 0 {
-		hexIPString = "0" + hexIPString
-	}
-
-	byteData, _ := hex.DecodeString(hexIPString)
-	reverseByteData := reverseByteArray(byteData)
-
-	return strings.Trim(strings.Join(strings.Fields(fmt.Sprint(reverseByteData)), "."), "[]")
-}
-
-func reverseByteArray(input []byte) []byte {
-	if len(input) == 0 {
-		return input
-	}
-	return append(reverseByteArray(input[1:]), input[0])
-}
-
 func ConvIntToIPv4(ipaddr uint32) net.IP {
 	ip := make(net.IP, 4)
 	binary.LittleEndian.PutUint32(ip, ipaddr)


### PR DESCRIPTION
*Issue*
Address https://github.com/aws/aws-network-policy-agent/issues/463 to some extent.

  ## Problem

  With `--enable-policy-event-logs=true`, the agent burns ~10 µs of CPU per policy event
  and saturates a full core at ~115k events/s. Beyond that, the kernel ring buffer fills
  and new events — including audit-critical DENY records — are **dropped silently**
  (`bpf_ringbuf_output`'s failure is ignored; measured 43% DENY loss at 200k events/s).
  Profiling showed the cost is in the userspace consumption path: per-event channel
  hand-offs and allocations in the aws-ebpf-sdk-go consumer, reflection-based decode,
  a Sprintf/hex round-trip IP formatter called 4× per event (~22% of CPU), and sugared
  zap logging with caller capture (~38%, including an always-wrong caller field).

  ## Solution

  Rework the userspace consumption path only — no eBPF/datapath changes, log text
  unchanged:

  - Consume the ring buffer with cilium/ebpf's pull-model `ringbuf.Reader` (reused
    buffer; no goroutine pipeline or unbuffered channel hand-offs). Measured alone:
    −18% CPU/event.
  - Decode records with a direct struct view instead of `binary.Read`; format IPs with
    `net/netip` (also fixes leading-zero octets rendering, e.g. `0.0.0.0` printed as "0").
  - Emit flow lines through a non-sugared zap logger sharing the same core, with caller
    capture disabled, and build the line with `strconv.Append` instead of `Infof`.
    Only visible change: the junk `"caller":"runtime/asm_amd64.s:1771"` field is gone.
  - Build the CloudWatch message only when CloudWatch logging is enabled.

  ## Results (live EKS, DENY-event storm, log-level=debug)

  | | stock v1.4.1 | this PR |
  |---|---|---|
  | CPU per event | 9.5–9.8 µs | **3.5–3.7 µs (−63%)** |
  | 200k events/s offered | 114.7k consumed, **43% lost**, 1.10 cores | **all consumed, 0% lost**, 0.72 cores |
  | max consume rate (1 core) | ~115k events/s | **~257k events/s** |

  Decode/format parity with the old path is pinned by unit tests for both address
  families, including the exact log line text.

----

 ## How event throughput and loss were measured

  **Load**: 2 pacer pods on one node send UDP to a pod IP at a controlled rate; the
  namespace NetworkPolicy allows egress only to TCP:80, so every packet is an egress
  DENY. Denied flows are never conntrack-cached, so each packet emits exactly one ring
  buffer event → offered events/s = send rate (self-reported by the pacers and verified
  per run).

  **Consumed**: delta of the agent's `network_policy_drop_count_total` prometheus
  counter (`:8162/metrics`) over a 60 s window — it increments only for events the
  userspace consumer actually read from the ring.

  **Lost**: offered − consumed. Loss occurs in the kernel: when the consumer lags, the
  512 KiB ring (~13k events) fills and `bpf_ringbuf_output()` fails its reservation.
  The TC programs ignore the return value, so this loss is silent and only visible via
  this subtraction - (TODO - need to open separate issue for this).

  **Agent CPU**: utime+stime delta from `/proc/<pid>/stat` over the same window;
  attribution via pprof (`--enable-profiling`).

  | build | µs CPU/event | @200k ev/s offered |
  |---|---|---|
  | stock v1.4.1 | 9.5–9.8 | 114.7k consumed, **43% lost**, 1.10 cores (saturated) |
  | this PR | **3.5** | 200.1k consumed, **0% lost**, 0.70 cores |



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
