### PR TITLE
test: run cyclonus + integration suites on IPv4 and IPv6 in parallel

### DIFF
--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -15,5 +15,11 @@ runs:
     - name: Set up eksctl
       shell: bash
       run: |
-        curl --silent --location "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+        # Always install the latest eksctl: fetched fresh from the releases/latest
+        # redirect on every run. GitHub runners are ephemeral, so there is no
+        # cross-run cache to go stale. -fsSL fails fast if the download errors
+        # instead of piping an error page into tar.
+        curl -fsSL "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
         sudo mv /tmp/eksctl /usr/local/bin/
+        # Log the installed version so the run can be verified against latest.
+        eksctl version

--- a/.github/workflows/pr-cyclonus-tests.yaml
+++ b/.github/workflows/pr-cyclonus-tests.yaml
@@ -3,6 +3,10 @@ name: PR Cyclonus Tests
 on:
   issue_comment:
     types: [created]
+  # Manual trigger — run from any branch to exercise THAT branch's workflow
+  # definition (e.g. to validate this workflow on an upstream test branch
+  # before merging to main, without the /test cyclonus comment path).
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -10,11 +14,11 @@ permissions:
   pull-requests: write
   issues: write
 
-# Serialize runs per PR so overlapping `/test cyclonus` comments cannot collide
-# on the deterministic cluster name (create-vs-delete race). Queue rather than
-# cancel — cancelling mid-run would leak clusters.
+# Serialize per PR (comment path) so overlapping `/test cyclonus` comments can't
+# collide on the deterministic cluster name; dispatch runs key on run_id so each
+# is independent. Queue rather than cancel — cancelling mid-run leaks clusters.
 concurrency:
-  group: cyclonus-tests-${{ github.event.issue.number }}
+  group: cyclonus-tests-${{ github.event.issue.number || github.run_id }}
   cancel-in-progress: false
 
 env:
@@ -22,21 +26,39 @@ env:
   INSTANCE_TYPE: t3.large
 
 jobs:
-  check-trigger:
+  # Resolves the git ref to test + a unique cluster id, for BOTH triggers.
+  #  - workflow_dispatch: ref = the dispatched branch HEAD (github.sha),
+  #    cluster id = dispatch-<run_id>, no PR comment.
+  #  - issue_comment: validates commenter permission + the 40-char SHA against
+  #    the PR head (TOCTOU guard), then ref = that SHA, cluster id = pr-<num>.
+  setup:
     if: |
-      github.repository == 'aws/aws-network-policy-agent' &&
-      github.event.issue.pull_request != null &&
-      startsWith(github.event.comment.body, '/test cyclonus ')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.repository == 'aws/aws-network-policy-agent' &&
+       github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/test cyclonus '))
     runs-on: ubuntu-latest
     outputs:
-      pr-sha: ${{ steps.validate-sha.outputs.sha }}
+      ref: ${{ steps.resolve.outputs.ref }}
+      cluster-id: ${{ steps.resolve.outputs.cluster-id }}
+      is-comment: ${{ steps.resolve.outputs.is-comment }}
     steps:
-      - name: Validate SHA from comment
-        id: validate-sha
+      - name: Resolve ref and cluster id
+        id: resolve
         uses: actions/github-script@v7
         with:
           script: |
-            // Check triggering user has write+ permission on the repo
+            // Manual dispatch: test the branch it was dispatched on.
+            if (context.eventName === 'workflow_dispatch') {
+              core.setOutput('ref', context.sha);
+              core.setOutput('cluster-id', `dispatch-${context.runId}`);
+              core.setOutput('is-comment', 'false');
+              core.notice(`Cyclonus tests (IPv4 + IPv6) dispatched on ${context.ref} @ ${context.sha}`);
+              return;
+            }
+
+            // Comment path: require write+ permission.
             const { data: permData } = await github.rest.repos.getCollaboratorPermissionLevel({
               ...context.repo,
               username: context.actor
@@ -53,7 +75,6 @@ jobs:
 
             const comment = context.payload.comment.body.trim();
             const shaMatch = comment.match(/^\/test cyclonus ([a-f0-9]{40})$/);
-
             if (!shaMatch) {
               await github.rest.issues.createComment({
                 ...context.repo,
@@ -65,12 +86,10 @@ jobs:
             }
 
             const requestedSHA = shaMatch[1];
-
             const pr = (await github.rest.pulls.get({
               ...context.repo,
               pull_number: context.issue.number
             })).data;
-
             if (pr.head.sha !== requestedSHA) {
               await github.rest.issues.createComment({
                 ...context.repo,
@@ -81,7 +100,9 @@ jobs:
               return;
             }
 
-            core.setOutput('sha', requestedSHA);
+            core.setOutput('ref', requestedSHA);
+            core.setOutput('cluster-id', `pr-${context.issue.number}`);
+            core.setOutput('is-comment', 'true');
             await github.rest.issues.createComment({
               ...context.repo,
               issue_number: context.issue.number,
@@ -89,14 +110,14 @@ jobs:
             });
 
   build-image:
-    needs: check-trigger
+    needs: setup
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.build.outputs.image_uri }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.check-trigger.outputs.pr-sha }}
+          ref: ${{ needs.setup.outputs.ref }}
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -111,10 +132,10 @@ jobs:
           aws-region: ${{ env.REGION }}
 
   # One leg per IP family. Each leg creates its own cluster, runs the full
-  # suite set, and posts a family-labeled results comment. fail-fast: false so
-  # an IPv6 failure does not cancel the IPv4 leg (and vice versa).
+  # suite set, and reports family-labeled results. fail-fast: false so an IPv6
+  # failure does not cancel the IPv4 leg (and vice versa).
   cyclonus:
-    needs: [check-trigger, build-image]
+    needs: [setup, build-image]
     runs-on: ubuntu-latest
     timeout-minutes: 180
     strategy:
@@ -123,12 +144,12 @@ jobs:
         ip-family: [IPv4, IPv6]
     env:
       IP_FAMILY: ${{ matrix.ip-family }}
-      CLUSTER_NAME: cyclonus-pr-${{ github.event.issue.number }}-${{ matrix.ip-family }}
+      CLUSTER_NAME: cyclonus-${{ needs.setup.outputs.cluster-id }}-${{ matrix.ip-family }}
       KUBECONFIG: ${{ github.workspace }}/.kube/config
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.check-trigger.outputs.pr-sha }}
+          ref: ${{ needs.setup.outputs.ref }}
 
       - uses: ./.github/actions/install-dependencies
 
@@ -194,7 +215,7 @@ jobs:
           EOF
           eksctl update addon -f /tmp/addon-config.yaml --force
 
-          # Patch node agent image to PR build
+          # Patch node agent image to the built image
           kubectl set image daemonset/aws-node \
             -n kube-system \
             aws-eks-nodeagent=${{ needs.build-image.outputs.image }}
@@ -210,42 +231,49 @@ jobs:
           RUN_CLUSTER_NETWORK_POLICY_TESTS: "true"
         run: SKIP_ADDON_INSTALLATION=true ./scripts/run-cyclonus-tests.sh
 
-      - name: Post results
+      - name: Report results
         if: always()
         uses: actions/github-script@v7
         with:
           script: |
             const ipFamily = '${{ matrix.ip-family }}';
+            const isComment = '${{ needs.setup.outputs.is-comment }}' === 'true';
             const failed = '${{ steps.cyclonus.outcome }}' !== 'success';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const suites = ipFamily === 'IPv6'
               ? 'cyclonus, policy, clusternetworkpolicy, strict (ebpf auto-skips on IPv6)'
               : 'cyclonus, policy, ebpf, clusternetworkpolicy, strict';
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: ${{ github.event.issue.number }},
-              body: [
-                `## Cyclonus Test Results (${ipFamily}): ${failed ? '❌ Failed' : '✅ Passed'}`,
-                `- **Commit:** \`${{ needs.check-trigger.outputs.pr-sha }}\``,
-                `- **K8s Version:** ${{ steps.create.outputs.k8s-version }}`,
-                `- **Image:** \`${{ needs.build-image.outputs.image }}\``,
-                `- **Suites:** ${suites}`,
-                `- **[Full logs](${runUrl})**`
-              ].join('\n')
-            });
+            const body = [
+              `## Cyclonus Test Results (${ipFamily}): ${failed ? '❌ Failed' : '✅ Passed'}`,
+              `- **Ref:** \`${{ needs.setup.outputs.ref }}\``,
+              `- **K8s Version:** ${{ steps.create.outputs.k8s-version }}`,
+              `- **Image:** \`${{ needs.build-image.outputs.image }}\``,
+              `- **Suites:** ${suites}`,
+              `- **[Full logs](${runUrl})**`
+            ].join('\n');
+
+            // Always surface in the run summary; comment on the PR only for the comment path.
+            await core.summary.addRaw(body).write();
+            if (isComment) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            }
             if (failed) core.setFailed(`Cyclonus tests failed (${ipFamily})`);
 
   cleanup:
-    needs: [check-trigger, cyclonus]
-    if: always() && needs.check-trigger.result == 'success'
+    needs: [setup, cyclonus]
+    if: always() && needs.setup.result == 'success'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         ip-family: [IPv4, IPv6]
     env:
-      CLUSTER_NAME: cyclonus-pr-${{ github.event.issue.number }}-${{ matrix.ip-family }}
+      CLUSTER_NAME: cyclonus-${{ needs.setup.outputs.cluster-id }}-${{ matrix.ip-family }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr-cyclonus-tests.yaml
+++ b/.github/workflows/pr-cyclonus-tests.yaml
@@ -3,10 +3,6 @@ name: PR Cyclonus Tests
 on:
   issue_comment:
     types: [created]
-  # Manual trigger — run from any branch to exercise THAT branch's workflow
-  # definition (e.g. to validate this workflow on an upstream test branch
-  # before merging to main, without the /test cyclonus comment path).
-  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -14,11 +10,11 @@ permissions:
   pull-requests: write
   issues: write
 
-# Serialize per PR (comment path) so overlapping `/test cyclonus` comments can't
-# collide on the deterministic cluster name; dispatch runs key on run_id so each
-# is independent. Queue rather than cancel — cancelling mid-run leaks clusters.
+# Serialize runs per PR so overlapping `/test cyclonus` comments cannot collide
+# on the deterministic cluster name (create-vs-delete race). Queue rather than
+# cancel — cancelling mid-run would leak clusters.
 concurrency:
-  group: cyclonus-tests-${{ github.event.issue.number || github.run_id }}
+  group: cyclonus-tests-${{ github.event.issue.number }}
   cancel-in-progress: false
 
 env:
@@ -26,39 +22,21 @@ env:
   INSTANCE_TYPE: t3.large
 
 jobs:
-  # Resolves the git ref to test + a unique cluster id, for BOTH triggers.
-  #  - workflow_dispatch: ref = the dispatched branch HEAD (github.sha),
-  #    cluster id = dispatch-<run_id>, no PR comment.
-  #  - issue_comment: validates commenter permission + the 40-char SHA against
-  #    the PR head (TOCTOU guard), then ref = that SHA, cluster id = pr-<num>.
-  setup:
+  check-trigger:
     if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issue_comment' &&
-       github.repository == 'aws/aws-network-policy-agent' &&
-       github.event.issue.pull_request != null &&
-       startsWith(github.event.comment.body, '/test cyclonus '))
+      github.repository == 'aws/aws-network-policy-agent' &&
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/test cyclonus ')
     runs-on: ubuntu-latest
     outputs:
-      ref: ${{ steps.resolve.outputs.ref }}
-      cluster-id: ${{ steps.resolve.outputs.cluster-id }}
-      is-comment: ${{ steps.resolve.outputs.is-comment }}
+      pr-sha: ${{ steps.validate-sha.outputs.sha }}
     steps:
-      - name: Resolve ref and cluster id
-        id: resolve
+      - name: Validate SHA from comment
+        id: validate-sha
         uses: actions/github-script@v7
         with:
           script: |
-            // Manual dispatch: test the branch it was dispatched on.
-            if (context.eventName === 'workflow_dispatch') {
-              core.setOutput('ref', context.sha);
-              core.setOutput('cluster-id', `dispatch-${context.runId}`);
-              core.setOutput('is-comment', 'false');
-              core.notice(`Cyclonus tests (IPv4 + IPv6) dispatched on ${context.ref} @ ${context.sha}`);
-              return;
-            }
-
-            // Comment path: require write+ permission.
+            // Check triggering user has write+ permission on the repo
             const { data: permData } = await github.rest.repos.getCollaboratorPermissionLevel({
               ...context.repo,
               username: context.actor
@@ -75,6 +53,7 @@ jobs:
 
             const comment = context.payload.comment.body.trim();
             const shaMatch = comment.match(/^\/test cyclonus ([a-f0-9]{40})$/);
+
             if (!shaMatch) {
               await github.rest.issues.createComment({
                 ...context.repo,
@@ -86,10 +65,12 @@ jobs:
             }
 
             const requestedSHA = shaMatch[1];
+
             const pr = (await github.rest.pulls.get({
               ...context.repo,
               pull_number: context.issue.number
             })).data;
+
             if (pr.head.sha !== requestedSHA) {
               await github.rest.issues.createComment({
                 ...context.repo,
@@ -100,9 +81,7 @@ jobs:
               return;
             }
 
-            core.setOutput('ref', requestedSHA);
-            core.setOutput('cluster-id', `pr-${context.issue.number}`);
-            core.setOutput('is-comment', 'true');
+            core.setOutput('sha', requestedSHA);
             await github.rest.issues.createComment({
               ...context.repo,
               issue_number: context.issue.number,
@@ -110,14 +89,14 @@ jobs:
             });
 
   build-image:
-    needs: setup
+    needs: check-trigger
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.build.outputs.image_uri }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.setup.outputs.ref }}
+          ref: ${{ needs.check-trigger.outputs.pr-sha }}
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -132,10 +111,10 @@ jobs:
           aws-region: ${{ env.REGION }}
 
   # One leg per IP family. Each leg creates its own cluster, runs the full
-  # suite set, and reports family-labeled results. fail-fast: false so an IPv6
-  # failure does not cancel the IPv4 leg (and vice versa).
+  # suite set, and posts a family-labeled results comment. fail-fast: false so
+  # an IPv6 failure does not cancel the IPv4 leg (and vice versa).
   cyclonus:
-    needs: [setup, build-image]
+    needs: [check-trigger, build-image]
     runs-on: ubuntu-latest
     timeout-minutes: 180
     strategy:
@@ -144,12 +123,12 @@ jobs:
         ip-family: [IPv4, IPv6]
     env:
       IP_FAMILY: ${{ matrix.ip-family }}
-      CLUSTER_NAME: cyclonus-${{ needs.setup.outputs.cluster-id }}-${{ matrix.ip-family }}
+      CLUSTER_NAME: cyclonus-pr-${{ github.event.issue.number }}-${{ matrix.ip-family }}
       KUBECONFIG: ${{ github.workspace }}/.kube/config
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.setup.outputs.ref }}
+          ref: ${{ needs.check-trigger.outputs.pr-sha }}
 
       - uses: ./.github/actions/install-dependencies
 
@@ -215,7 +194,7 @@ jobs:
           EOF
           eksctl update addon -f /tmp/addon-config.yaml --force
 
-          # Patch node agent image to the built image
+          # Patch node agent image to PR build
           kubectl set image daemonset/aws-node \
             -n kube-system \
             aws-eks-nodeagent=${{ needs.build-image.outputs.image }}
@@ -231,49 +210,42 @@ jobs:
           RUN_CLUSTER_NETWORK_POLICY_TESTS: "true"
         run: SKIP_ADDON_INSTALLATION=true ./scripts/run-cyclonus-tests.sh
 
-      - name: Report results
+      - name: Post results
         if: always()
         uses: actions/github-script@v7
         with:
           script: |
             const ipFamily = '${{ matrix.ip-family }}';
-            const isComment = '${{ needs.setup.outputs.is-comment }}' === 'true';
             const failed = '${{ steps.cyclonus.outcome }}' !== 'success';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const suites = ipFamily === 'IPv6'
               ? 'cyclonus, policy, clusternetworkpolicy, strict (ebpf auto-skips on IPv6)'
               : 'cyclonus, policy, ebpf, clusternetworkpolicy, strict';
-            const body = [
-              `## Cyclonus Test Results (${ipFamily}): ${failed ? '❌ Failed' : '✅ Passed'}`,
-              `- **Ref:** \`${{ needs.setup.outputs.ref }}\``,
-              `- **K8s Version:** ${{ steps.create.outputs.k8s-version }}`,
-              `- **Image:** \`${{ needs.build-image.outputs.image }}\``,
-              `- **Suites:** ${suites}`,
-              `- **[Full logs](${runUrl})**`
-            ].join('\n');
-
-            // Always surface in the run summary; comment on the PR only for the comment path.
-            await core.summary.addRaw(body).write();
-            if (isComment) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body
-              });
-            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.issue.number }},
+              body: [
+                `## Cyclonus Test Results (${ipFamily}): ${failed ? '❌ Failed' : '✅ Passed'}`,
+                `- **Commit:** \`${{ needs.check-trigger.outputs.pr-sha }}\``,
+                `- **K8s Version:** ${{ steps.create.outputs.k8s-version }}`,
+                `- **Image:** \`${{ needs.build-image.outputs.image }}\``,
+                `- **Suites:** ${suites}`,
+                `- **[Full logs](${runUrl})**`
+              ].join('\n')
+            });
             if (failed) core.setFailed(`Cyclonus tests failed (${ipFamily})`);
 
   cleanup:
-    needs: [setup, cyclonus]
-    if: always() && needs.setup.result == 'success'
+    needs: [check-trigger, cyclonus]
+    if: always() && needs.check-trigger.result == 'success'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         ip-family: [IPv4, IPv6]
     env:
-      CLUSTER_NAME: cyclonus-${{ needs.setup.outputs.cluster-id }}-${{ matrix.ip-family }}
+      CLUSTER_NAME: cyclonus-pr-${{ github.event.issue.number }}-${{ matrix.ip-family }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr-cyclonus-tests.yaml
+++ b/.github/workflows/pr-cyclonus-tests.yaml
@@ -116,7 +116,9 @@ jobs:
   cyclonus:
     needs: [check-trigger, build-image]
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    # cyclonus alone runs ~3h; with the extra suites + cluster setup a leg can
+    # take ~4-4.5h. Cap below the 6h credential/GitHub job limit.
+    timeout-minutes: 330
     strategy:
       fail-fast: false
       matrix:
@@ -158,6 +160,12 @@ jobs:
             withOIDC: true
           kubernetesNetworkConfig:
             ipFamily: ${IP_FAMILY}
+          # Newer eksctl (CI installs latest) is moving to EKS Auto Mode by
+          # default, which drops managed nodegroups + the self-managed vpc-cni
+          # addon this workflow installs/patches and runs network-policy tests
+          # against. Pin the classic (non-Auto-Mode) cluster explicitly.
+          autoModeConfig:
+            enabled: false
           addons:
             - name: vpc-cni
             - name: coredns
@@ -258,4 +266,23 @@ jobs:
           role-duration-seconds: 3600
 
       - name: Delete EKS cluster
-        run: eksctl delete cluster --name $CLUSTER_NAME --region $REGION --disable-nodegroup-eviction || echo "cluster delete failed or cluster not found"
+        # Retry real delete failures (throttling/dependencies) instead of masking
+        # them. Only a genuine ResourceNotFoundException counts as "already gone" —
+        # do NOT treat auth/throttling describe errors as deleted (that would leak
+        # clusters silently, which is exactly what this guards against).
+        run: |
+          for attempt in 1 2 3; do
+            if eksctl delete cluster --name "$CLUSTER_NAME" --region "$REGION" --disable-nodegroup-eviction; then
+              echo "cluster deleted"; exit 0
+            fi
+            if ! out=$(aws eks describe-cluster --name "$CLUSTER_NAME" --region "$REGION" 2>&1); then
+              if echo "$out" | grep -q "ResourceNotFoundException"; then
+                echo "cluster $CLUSTER_NAME not found - treating as deleted"; exit 0
+              fi
+              echo "describe-cluster error (not a not-found, will retry): $out"
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "delete attempt $attempt failed; retrying in 30s..."; sleep 30
+            fi
+          done
+          echo "ERROR: cluster $CLUSTER_NAME still exists after 3 delete attempts"; exit 1

--- a/.github/workflows/pr-cyclonus-tests.yaml
+++ b/.github/workflows/pr-cyclonus-tests.yaml
@@ -10,9 +10,15 @@ permissions:
   pull-requests: write
   issues: write
 
+# Serialize runs per PR so overlapping `/test cyclonus` comments cannot collide
+# on the deterministic cluster name (create-vs-delete race). Queue rather than
+# cancel — cancelling mid-run would leak clusters.
+concurrency:
+  group: cyclonus-tests-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 env:
   REGION: us-west-2
-  IP_FAMILY: IPv4
   INSTANCE_TYPE: t3.large
 
 jobs:
@@ -79,44 +85,8 @@ jobs:
             await github.rest.issues.createComment({
               ...context.repo,
               issue_number: context.issue.number,
-              body: `✅ Cyclonus tests triggered by @${context.actor} for \`${requestedSHA}\`. [View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
+              body: `✅ Cyclonus tests (IPv4 + IPv6) triggered by @${context.actor} for \`${requestedSHA}\`. [View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
             });
-
-  create-cluster:
-    needs: check-trigger
-    runs-on: ubuntu-latest
-    outputs:
-      cluster-name: ${{ steps.setup.outputs.cluster-name }}
-      k8s-version: ${{ steps.setup.outputs.k8s-version }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.check-trigger.outputs.pr-sha }}
-
-      - uses: ./.github/actions/install-dependencies
-
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.OSS_ROLE_ARN }}
-          aws-region: ${{ env.REGION }}
-          role-duration-seconds: 21600
-
-      - name: Create EKS cluster
-        id: setup
-        run: |
-          K8S_VERSION=$(aws eks describe-addon-versions --addon-name vpc-cni --region $REGION \
-            | jq -r '[.addons[0].addonVersions[0].compatibilities[].clusterVersion] | sort_by(split(".")[1] | tonumber) | .[-2]')
-          CLUSTER_NAME="cyclonus-pr-${{ github.event.issue.number }}"
-          echo "k8s-version=$K8S_VERSION" >> $GITHUB_OUTPUT
-          echo "cluster-name=$CLUSTER_NAME" >> $GITHUB_OUTPUT
-
-          eksctl create cluster \
-            --name $CLUSTER_NAME \
-            --region $REGION \
-            --version $K8S_VERSION \
-            --instance-types $INSTANCE_TYPE \
-            --nodes 3 \
-            --with-oidc
 
   build-image:
     needs: check-trigger
@@ -140,13 +110,20 @@ jobs:
         with:
           aws-region: ${{ env.REGION }}
 
-  run-cyclonus:
-    needs: [check-trigger, create-cluster, build-image]
-    if: always() && needs.create-cluster.result == 'success' && needs.build-image.result == 'success'
+  # One leg per IP family. Each leg creates its own cluster, runs the full
+  # suite set, and posts a family-labeled results comment. fail-fast: false so
+  # an IPv6 failure does not cancel the IPv4 leg (and vice versa).
+  cyclonus:
+    needs: [check-trigger, build-image]
     runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        ip-family: [IPv4, IPv6]
     env:
-      CLUSTER_NAME: ${{ needs.create-cluster.outputs.cluster-name }}
-      K8S_VERSION: ${{ needs.create-cluster.outputs.k8s-version }}
+      IP_FAMILY: ${{ matrix.ip-family }}
+      CLUSTER_NAME: cyclonus-pr-${{ github.event.issue.number }}-${{ matrix.ip-family }}
       KUBECONFIG: ${{ github.workspace }}/.kube/config
     steps:
       - uses: actions/checkout@v4
@@ -160,6 +137,41 @@ jobs:
           role-to-assume: ${{ secrets.OSS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
           role-duration-seconds: 21600
+
+      - name: Create EKS cluster (${{ matrix.ip-family }})
+        id: create
+        run: |
+          K8S_VERSION=$(aws eks describe-addon-versions --addon-name vpc-cni --region $REGION \
+            | jq -r '[.addons[0].addonVersions[0].compatibilities[].clusterVersion] | sort_by(split(".")[1] | tonumber) | .[-2]')
+          echo "k8s-version=$K8S_VERSION" >> $GITHUB_OUTPUT
+
+          # eksctl config file (rather than the bare CLI) so we can set the
+          # IP family and enable OIDC, which IPv6 clusters require.
+          cat > /tmp/cluster-config.yaml <<EOF
+          apiVersion: eksctl.io/v1alpha5
+          kind: ClusterConfig
+          metadata:
+            name: ${CLUSTER_NAME}
+            region: ${REGION}
+            version: "${K8S_VERSION}"
+          iam:
+            withOIDC: true
+          kubernetesNetworkConfig:
+            ipFamily: ${IP_FAMILY}
+          addons:
+            - name: vpc-cni
+            - name: coredns
+            - name: kube-proxy
+          managedNodeGroups:
+            - name: ${CLUSTER_NAME}-ng
+              amiFamily: AmazonLinux2023
+              instanceType: ${INSTANCE_TYPE}
+              desiredCapacity: 3
+              minSize: 1
+              maxSize: 3
+          EOF
+
+          eksctl create cluster -f /tmp/cluster-config.yaml
 
       - name: Update kubeconfig
         run: |
@@ -189,9 +201,13 @@ jobs:
 
           kubectl rollout status daemonset/aws-node -n kube-system --timeout=300s
 
-      - name: Run cyclonus tests
+      - name: Run cyclonus + integration suites
         id: cyclonus
         continue-on-error: true
+        env:
+          ENABLE_STRICT_MODE: "true"
+          RUN_EBPF_TESTS: "true"
+          RUN_CLUSTER_NETWORK_POLICY_TESTS: "true"
         run: SKIP_ADDON_INSTALLATION=true ./scripts/run-cyclonus-tests.sh
 
       - name: Post results
@@ -199,28 +215,37 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const ipFamily = '${{ matrix.ip-family }}';
             const failed = '${{ steps.cyclonus.outcome }}' !== 'success';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const suites = ipFamily === 'IPv6'
+              ? 'cyclonus, policy, clusternetworkpolicy, strict (ebpf auto-skips on IPv6)'
+              : 'cyclonus, policy, ebpf, clusternetworkpolicy, strict';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: ${{ github.event.issue.number }},
               body: [
-                `## Cyclonus Test Results: ${failed ? '❌ Failed' : '✅ Passed'}`,
+                `## Cyclonus Test Results (${ipFamily}): ${failed ? '❌ Failed' : '✅ Passed'}`,
                 `- **Commit:** \`${{ needs.check-trigger.outputs.pr-sha }}\``,
-                `- **K8s Version:** ${{ needs.create-cluster.outputs.k8s-version }}`,
+                `- **K8s Version:** ${{ steps.create.outputs.k8s-version }}`,
                 `- **Image:** \`${{ needs.build-image.outputs.image }}\``,
+                `- **Suites:** ${suites}`,
                 `- **[Full logs](${runUrl})**`
               ].join('\n')
             });
-            if (failed) core.setFailed('Cyclonus tests failed');
+            if (failed) core.setFailed(`Cyclonus tests failed (${ipFamily})`);
 
   cleanup:
-    needs: [check-trigger, create-cluster, run-cyclonus]
-    if: always() && needs.create-cluster.outputs.cluster-name != ''
+    needs: [check-trigger, cyclonus]
+    if: always() && needs.check-trigger.result == 'success'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ip-family: [IPv4, IPv6]
     env:
-      CLUSTER_NAME: ${{ needs.create-cluster.outputs.cluster-name }}
+      CLUSTER_NAME: cyclonus-pr-${{ github.event.issue.number }}-${{ matrix.ip-family }}
     steps:
       - uses: actions/checkout@v4
 
@@ -233,4 +258,4 @@ jobs:
           role-duration-seconds: 3600
 
       - name: Delete EKS cluster
-        run: eksctl delete cluster --name $CLUSTER_NAME --region $REGION
+        run: eksctl delete cluster --name $CLUSTER_NAME --region $REGION --disable-nodegroup-eviction || echo "cluster delete failed or cluster not found"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/aws-network-policy-agent
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aws/amazon-vpc-cni-k8s v1.22.4

--- a/scripts/run-cyclonus-tests.sh
+++ b/scripts/run-cyclonus-tests.sh
@@ -6,6 +6,9 @@
 # KUBECONFIG: Set the variable to the cluster kubeconfig file path
 # REGION: defaults to us-west-2
 # IP_FAMILY: defaults to IPv4
+# ENABLE_STRICT_MODE: Optional, defaults to false. Runs the strict-mode suite (mutates aws-node to strict enforcement, so it runs last)
+# RUN_EBPF_TESTS: Optional, defaults to false. Runs the eBPF conntrack security suite (auto-skips on IPv6)
+# RUN_CLUSTER_NETWORK_POLICY_TESTS: Optional, defaults to false. Runs the ClusterNetworkPolicy suite (requires the CNP CRD + CNP-capable controller on the cluster)
 # ADDON_VERSION: Optional, defaults to the latest version
 # ENDPOINT: Optional
 # DEPLOY_NETWORK_POLICY_CONTROLLER_ON_DATAPLANE: false
@@ -30,14 +33,30 @@ source ${DIR}/lib/tests.sh
 : "${SKIP_ADDON_INSTALLATION:="false"}"
 : "${SKIP_MAKE_TEST_BINARIES:="false"}"
 : "${ENABLE_STRICT_MODE:="false"}"
+: "${RUN_EBPF_TESTS:="false"}"
+: "${RUN_CLUSTER_NETWORK_POLICY_TESTS:="false"}"
 : "${K8S_VERSION:=""}"
 : "${TEST_IMAGE_REGISTRY:="registry.k8s.io"}"
 : "${PROD_IMAGE_REGISTRY:=""}"
 : "${DEPLOY_NETWORK_POLICY_CONTROLLER_ON_DATAPLANE:="false"}"
-: "${NP_CONTROLLER_ENDPOINT_CHUNK_SIZE=""}}"
+: "${NP_CONTROLLER_ENDPOINT_CHUNK_SIZE:=""}"
 : "${KUBE_CONFIG_PATH:=$KUBECONFIG}"
 
 TEST_FAILED="false"
+
+# Runs a prebuilt ginkgo suite binary against the cluster. Records any failure
+# in TEST_FAILED (instead of aborting) so the remaining suites still run.
+run_ginkgo_suite() {
+    local suite_binary="$1"
+    local timeout="${2:-15m}"
+    echo "Running ${suite_binary} (timeout ${timeout})"
+    CGO_ENABLED=0 ginkgo -v -timeout "$timeout" --no-color --fail-on-pending \
+        "$GINKGO_TEST_BUILD_DIR/$suite_binary" -- \
+        --cluster-kubeconfig="$KUBE_CONFIG_PATH" \
+        --cluster-name="$CLUSTER_NAME" \
+        --test-image-registry="$TEST_IMAGE_REGISTRY" \
+        --ip-family="$IP_FAMILY" || TEST_FAILED="true"
+}
 
 if [[ ! -z $ENDPOINT ]]; then
     ENDPOINT_FLAG="--endpoint-url $ENDPOINT"
@@ -97,7 +116,16 @@ else
     echo "Skipping making ginkgo test binaries"
 fi
 
-CGO_ENABLED=0 ginkgo -v -timeout 15m --no-color --fail-on-pending $GINKGO_TEST_BUILD_DIR/policy.test -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --test-image-registry=$TEST_IMAGE_REGISTRY --ip-family=$IP_FAMILY || TEST_FAILED="true"
+run_ginkgo_suite policy.test 15m
+
+if [[ $RUN_EBPF_TESTS == "true" ]]; then
+    # eBPF conntrack security suite auto-skips on IPv6 (AF_PACKET is IPv4-only)
+    run_ginkgo_suite ebpf.test 15m
+fi
+
+if [[ $RUN_CLUSTER_NETWORK_POLICY_TESTS == "true" ]]; then
+    run_ginkgo_suite clusternetworkpolicy.test 30m
+fi
 
 if [[ $ENABLE_STRICT_MODE == "true" ]]; then
 
@@ -107,7 +135,7 @@ if [[ $ENABLE_STRICT_MODE == "true" ]]; then
     echo "Check aws-node daemonset status"
     kubectl rollout status ds/aws-node -n kube-system --timeout=300s
 
-    CGO_ENABLED=0 ginkgo -v -timeout 15m --no-color --fail-on-pending $GINKGO_TEST_BUILD_DIR/strict.test -- --cluster-kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --test-image-registry=$TEST_IMAGE_REGISTRY --ip-family=$IP_FAMILY || TEST_FAILED="true"
+    run_ginkgo_suite strict.test 15m
 
 fi
 


### PR DESCRIPTION
## What

Make the `/test cyclonus` PR gate exercise **both IPv4 and IPv6** clusters in parallel, and broaden per-leg suite coverage.

Today the gate creates a single IPv4-only cluster and runs cyclonus + the policy suite. This adds a parallel IPv6 leg and runs the ebpf, clusternetworkpolicy, and strict suites too.

## Changes

**`.github/workflows/pr-cyclonus-tests.yaml`**
- Matrix `ip-family: [IPv4, IPv6]` with `fail-fast: false` — the two legs run in parallel and independently.
- One cluster per family via an eksctl **config file** (`kubernetesNetworkConfig.ipFamily` + `iam.withOIDC`, required for IPv6) with deterministic names `cyclonus-pr-<PR#>-<family>`.
- Single shared image build; each leg posts its own labeled comment: **`Cyclonus Test Results (IPv4/IPv6): ✅/❌`**.
- Per-PR `concurrency` group (queue, don't cancel) so overlapping comments can't collide on the cluster name; `timeout-minutes: 180` on the test job.

**`scripts/run-cyclonus-tests.sh`**
- Opt-in `RUN_EBPF_TESTS` and `RUN_CLUSTER_NETWORK_POLICY_TESTS` flags (default `false`, so `make run-cyclonus-test` / `update-image-and-test` are unaffected), plus existing `ENABLE_STRICT_MODE`.
- All suites run through a shared `run_ginkgo_suite` helper (dedups four near-identical ginkgo invocations). Strict runs **last** (it mutates `aws-node` to strict enforcement).

## Per-leg coverage

| Leg | Suites |
|---|---|
| **IPv4** | cyclonus + policy + ebpf + clusternetworkpolicy + strict |
| **IPv6** | cyclonus + policy + clusternetworkpolicy + strict (ebpf self-skips — AF_PACKET is IPv4-only) |

## Testing

- `bash -n` on the script and YAML parse on the workflow: clean.
- Suite dir → binary-name mapping verified (`ebpf.test`, `clusternetworkpolicy.test` match `make build-test-binaries`).
- Note: `issue_comment` workflows run the **default-branch** definition, so `/test cyclonus` can only exercise this new logic **after merge**. First post-merge run should confirm: IPv6 pods get IPv6 addresses, `aws-node` retains `ENABLE_IPv6=true` after the addon update, and the ClusterNetworkPolicy suite finds its CRD on the managed cluster.
