### PR TITLE
Sync release-1.4 with main for v1.4.2 (excluding #610)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,22 @@ This feature requires you to provide relevant Cloudwatch permissions to `aws-nod
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "VisualEditor0",
+            "Sid": "CloudWatchLogsWrites",
             "Effect": "Allow",
             "Action": [
-                "logs:DescribeLogGroups",
                 "logs:CreateLogGroup",
                 "logs:CreateLogStream",
                 "logs:PutLogEvents"
             ],
-            "Resource": "*"
+            "Resource": [
+                "arn:aws:logs:<region-code>:<aws-account-id>:log-group:/aws/eks/<cluster-name>/cluster:*"
+            ]
+        },
+        {
+            "Sid": "CloudWatchLogsReads",
+            "Effect": "Allow",
+            "Action": "logs:DescribeLogGroups",
+            "Resource": "arn:aws:logs:<region-code>:<aws-account-id>:log-group::log-stream*"
         }
     ]
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/aws/amazon-vpc-cni-k8s v1.22.4
-	github.com/aws/aws-ebpf-sdk-go v1.0.15
+	github.com/aws/aws-ebpf-sdk-go v1.0.16
 	github.com/aws/aws-sdk-go-v2 v1.43.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.31

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/aws/amazon-vpc-cni-k8s v1.22.4 h1:040AzVL94vW4i9f8d5vz4tI83sKaxUM2KjB
 github.com/aws/amazon-vpc-cni-k8s v1.22.4/go.mod h1:H9f69VZbroA/1ns5LtTnoMA4vAdPghcgU0tIH5FX4+s=
 github.com/aws/amazon-vpc-resource-controller-k8s v1.7.18 h1:V/h33TgtVkR/1hkYVWU8RFD8i8h5G+xZ6eX9Hr0zKpk=
 github.com/aws/amazon-vpc-resource-controller-k8s v1.7.18/go.mod h1:iZa92r5f6vu42hQhyzrQa9UnxieNWcYmQ9DEKYMuXWo=
-github.com/aws/aws-ebpf-sdk-go v1.0.15 h1:iKAiGIfldszZEsAkND2T09Qz2gVfuGlMovPPhI9oRY4=
-github.com/aws/aws-ebpf-sdk-go v1.0.15/go.mod h1:2v/brJqgaXZxyg2XzOPOQX8v0CL2gOlIzgP/mMPB00o=
+github.com/aws/aws-ebpf-sdk-go v1.0.16 h1:g2cT+YTYKW/IITlM/Rq9r5ELsyul49FaF2aieGgZeI8=
+github.com/aws/aws-ebpf-sdk-go v1.0.16/go.mod h1:2v/brJqgaXZxyg2XzOPOQX8v0CL2gOlIzgP/mMPB00o=
 github.com/aws/aws-sdk-go-v2 v1.43.0 h1:fharf/WhbRAVZ1du0QL7roNFxZ6T/sWr+4Ni617bwSI=
 github.com/aws/aws-sdk-go-v2 v1.43.0/go.mod h1:5pKeft2eJj+gElQ38Jqg4ibCqh+/AK33/0X3hip7IjM=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=

--- a/pkg/fwruleprocessor/fw_rule_processor.go
+++ b/pkg/fwruleprocessor/fw_rule_processor.go
@@ -98,6 +98,19 @@ func (f *FirewallRuleProcessor) ComputeMapEntriesFromEndpointRules(firewallRules
 			firewallRule.IPCidr += v1alpha1.NetworkAddress(f.hostMask)
 		}
 
+		// Canonicalize the CIDR (mask off host bits) before it is used as the
+		// cidrsMap key. A rule expressed with host bits set - e.g. 10.161.0.0/8,
+		// which a /8 mask reduces to the network 10.0.0.0/8 - would otherwise be
+		// keyed by its raw string and treated as distinct from 10.0.0.0/8. Their
+		// L4 (port) sets would never be merged, and because both encode to the
+		// identical LPM trie key, the final map write silently overwrites one
+		// with the other in Go's randomized map-iteration order, producing
+		// non-deterministic port enforcement across reconciliations. Masking here
+		// makes such rules share a key so their ports are merged deterministically.
+		if _, ipNet, err := net.ParseCIDR(string(firewallRule.IPCidr)); err == nil {
+			firewallRule.IPCidr = v1alpha1.NetworkAddress(ipNet.String())
+		}
+
 		if f.shouldSkipRule(string(firewallRule.IPCidr)) {
 			continue
 		}
@@ -156,8 +169,11 @@ func (f *FirewallRuleProcessor) ComputeMapEntriesFromEndpointRules(firewallRules
 }
 
 // sorting Firewall Rules in Ascending Order of Prefix length
+// SliceStable is used so that rules sharing the same prefix length retain a
+// deterministic relative order; this keeps the L4-info inheritance in
+// checkAndDeriveL4InfoFromAnyMatchingCIDRs stable across runs.
 func sortFirewallRulesByPrefixLength(rules []EbpfFirewallRules, prefixLenStr string) {
-	sort.Slice(rules, func(i, j int) bool {
+	sort.SliceStable(rules, func(i, j int) bool {
 
 		prefixSplit := strings.Split(prefixLenStr, "/")
 		prefixLen, _ := strconv.Atoi(prefixSplit[1])

--- a/pkg/fwruleprocessor/fw_rule_processor.go
+++ b/pkg/fwruleprocessor/fw_rule_processor.go
@@ -284,6 +284,19 @@ func (f *FirewallRuleProcessor) ComputeClusterPolicyMapEntriesFromEndpointRules(
 	cidrL4Rules := make(map[string][]utils.L4Rule)
 	processedCIDRs := make([]string, 0)
 
+	// Traffic from the local node should always be allowed. Add NodeIP by default to map entries.
+	// This ensures kubelet liveness/readiness probes are never blocked by cluster network policies.
+	_, mapKey, _ := net.ParseCIDR(f.nodeIP + f.hostMask)
+	key := utils.ComputeTrieKey(*mapKey, f.enableIPv6)
+	nodeIPL4Rule := []utils.L4Rule{
+		{
+			Action:   "Accept",
+			Priority: 0, // Highest priority — node-IP allow must not be overridden
+		},
+	}
+	value := utils.ComputeTrieValueForCPE(nodeIPL4Rule)
+	firewallMap[string(key)] = value
+
 	// Step 1: Sort by CIDR length
 	f.sortByCIDRLength(firewallRules)
 

--- a/pkg/fwruleprocessor/fw_rule_processor.go
+++ b/pkg/fwruleprocessor/fw_rule_processor.go
@@ -141,16 +141,20 @@ func (f *FirewallRuleProcessor) ComputeMapEntriesFromEndpointRules(firewallRules
 
 	// Go through except CIDRs and append DENY all rule to the L4 info
 	for exceptCidr := range exceptCidrs {
-		if _, ok := cidrsMap[exceptCidr]; !ok {
+		canonicalExcept := exceptCidr
+		if _, ipNet, err := net.ParseCIDR(exceptCidr); err == nil {
+			canonicalExcept = ipNet.String()
+		}
+		if _, ok := cidrsMap[canonicalExcept]; !ok {
 			exceptFirewall := EbpfFirewallRules{
-				IPCidr: v1alpha1.NetworkAddress(exceptCidr),
+				IPCidr: v1alpha1.NetworkAddress(canonicalExcept),
 				Except: []v1alpha1.NetworkAddress{},
 				L4Info: []v1alpha1.Port{},
 			}
 			addDenyAllL4Entry(&exceptFirewall)
-			cidrsMap[exceptCidr] = exceptFirewall
+			cidrsMap[canonicalExcept] = exceptFirewall
 		}
-		log().Debugf("Parsed Except CIDR: %s", exceptCidr)
+		log().Debugf("Parsed Except CIDR: %s (canonical: %s)", exceptCidr, canonicalExcept)
 	}
 
 	for key, value := range cidrsMap {
@@ -337,7 +341,10 @@ func (f *FirewallRuleProcessor) ComputeClusterPolicyMapEntriesFromEndpointRules(
 
 func (f *FirewallRuleProcessor) normalizeCIDR(cidr string) string {
 	if !strings.Contains(cidr, "/") {
-		return cidr + f.hostMask
+		cidr = cidr + f.hostMask
+	}
+	if _, ipNet, err := net.ParseCIDR(cidr); err == nil {
+		return ipNet.String()
 	}
 	return cidr
 }
@@ -359,7 +366,7 @@ func (f *FirewallRuleProcessor) shouldSkipRule(cidr string) bool {
 }
 
 func (f *FirewallRuleProcessor) sortByCIDRLength(rules []EbpfFirewallRules) {
-	sort.Slice(rules, func(i, j int) bool {
+	sort.SliceStable(rules, func(i, j int) bool {
 		cidrI := f.normalizeCIDR(string(rules[i].IPCidr))
 		cidrJ := f.normalizeCIDR(string(rules[j].IPCidr))
 

--- a/pkg/fwruleprocessor/fw_rule_processor_test.go
+++ b/pkg/fwruleprocessor/fw_rule_processor_test.go
@@ -600,6 +600,108 @@ func containsInt(haystack []int, needle int) bool {
 	return false
 }
 
+// TestClusterPolicy_NonCanonicalCIDRCollision verifies the CNP path
+// (ComputeClusterPolicyMapEntriesFromEndpointRules) canonicalizes CIDRs before
+// using them as map keys, preventing the same LPM-collision bug that affected
+// the pod-scoped path.
+func TestClusterPolicy_NonCanonicalCIDRCollision(t *testing.T) {
+	protocolTCP := corev1.ProtocolTCP
+	var port443 int32 = 443
+	var port3128 int32 = 3128
+
+	nodeIP := "192.168.0.1"
+
+	rules := []EbpfFirewallRules{
+		{
+			IPCidr:   "10.0.0.0/8",
+			L4Info:   []v1alpha1.Port{{Protocol: &protocolTCP, Port: &port443}},
+			Action:   v1alpha1.ClusterNetworkPolicyRuleActionAccept,
+			Priority: 100,
+		},
+		{
+			IPCidr:   "10.161.0.0/8", // host bits set; masks to 10.0.0.0/8
+			L4Info:   []v1alpha1.Port{{Protocol: &protocolTCP, Port: &port3128}},
+			Action:   v1alpha1.ClusterNetworkPolicyRuleActionAccept,
+			Priority: 100,
+		},
+	}
+
+	_, canonicalNet, _ := net.ParseCIDR("10.0.0.0/8")
+	canonicalKey := string(utils.ComputeTrieKey(*canonicalNet, false))
+
+	for i := 0; i < 500; i++ {
+		got, err := NewFirewallRuleProcessor(nodeIP, "/32", false).ComputeClusterPolicyMapEntriesFromEndpointRules(rules)
+		if err != nil {
+			t.Fatalf("iteration %d: unexpected error: %v", i, err)
+		}
+
+		value, ok := got[canonicalKey]
+		if !ok {
+			t.Fatalf("iteration %d: expected a map entry for canonical key 10.0.0.0/8", i)
+		}
+
+		ports := decodeCPETrieValuePorts(value)
+		if !containsInt(ports, int(port443)) || !containsInt(ports, int(port3128)) {
+			t.Fatalf("iteration %d: CNP 10.0.0.0/8 entry lost a port; got ports=%v (want both 443 and 3128). "+
+				"Non-canonical CIDR 10.161.0.0/8 collided with 10.0.0.0/8.", i, ports)
+		}
+	}
+}
+
+// TestFWRuleProcessor_ExceptCIDRCanonicalization verifies that an except CIDR
+// with host bits set is canonicalized so it doesn't silently overwrite the allow
+// rule for the same network prefix.
+func TestFWRuleProcessor_ExceptCIDRCanonicalization(t *testing.T) {
+	protocolTCP := corev1.ProtocolTCP
+	var port443 int32 = 443
+
+	nodeIP := "192.168.0.1"
+
+	rules := []EbpfFirewallRules{
+		{
+			IPCidr: "10.0.0.0/8",
+			L4Info: []v1alpha1.Port{{Protocol: &protocolTCP, Port: &port443}},
+			Except: []v1alpha1.NetworkAddress{"10.161.0.0/8"}, // host bits set; masks to 10.0.0.0/8
+		},
+	}
+
+	_, canonicalNet, _ := net.ParseCIDR("10.0.0.0/8")
+	canonicalKey := string(utils.ComputeTrieKey(*canonicalNet, false))
+
+	for i := 0; i < 500; i++ {
+		got, err := NewFirewallRuleProcessor(nodeIP, "/32", false).ComputeMapEntriesFromEndpointRules(rules)
+		if err != nil {
+			t.Fatalf("iteration %d: unexpected error: %v", i, err)
+		}
+
+		value, ok := got[canonicalKey]
+		if !ok {
+			t.Fatalf("iteration %d: expected a map entry for canonical key 10.0.0.0/8", i)
+		}
+
+		ports := decodeTrieValuePorts(value)
+		if !containsInt(ports, int(port443)) {
+			t.Fatalf("iteration %d: 10.0.0.0/8 entry lost port 443; got ports=%v. "+
+				"Except CIDR 10.161.0.0/8 (canonicalizes to 10.0.0.0/8) overwrote the allow with a DENY.", i, ports)
+		}
+	}
+}
+
+// decodeCPETrieValuePorts decodes a TRIE value produced by utils.ComputeTrieValueForCPE.
+// Each entry is 16 bytes: protocol (4) + priority (4) + startPort (4) + endPort (4).
+func decodeCPETrieValuePorts(value []byte) []int {
+	var ports []int
+	for off := 0; off+16 <= len(value); off += 16 {
+		protocol := binary.LittleEndian.Uint32(value[off : off+4])
+		if protocol == 0 {
+			continue
+		}
+		startPort := binary.LittleEndian.Uint32(value[off+8 : off+12])
+		ports = append(ports, int(startPort))
+	}
+	return ports
+}
+
 // TestFWRuleProcessor_NonCanonicalCIDRCollision reproduces the intermittent
 // enforcement bug where two ipBlock rules whose CIDRs reduce to the same
 // network after masking (e.g. 10.0.0.0/8 and 10.161.0.0/8, since /8 makes the

--- a/pkg/fwruleprocessor/fw_rule_processor_test.go
+++ b/pkg/fwruleprocessor/fw_rule_processor_test.go
@@ -1,6 +1,7 @@
 package fwruleprocessor
 
 import (
+	"encoding/binary"
 	"net"
 	"sort"
 	"testing"
@@ -570,5 +571,84 @@ func TestFirewallRuleProcessor_ShouldSkipRule(t *testing.T) {
 			f := NewFirewallRuleProcessor(tt.nodeIP, tt.hostMask, tt.enableIPv6)
 			assert.Equal(t, tt.expected, f.shouldSkipRule(tt.cidr))
 		})
+	}
+}
+
+// decodeTrieValuePorts decodes a TRIE value produced by utils.ComputeTrieValue
+// into the list of start ports it encodes. Each entry is 12 bytes:
+// protocol (4) + startPort (4) + endPort (4), little-endian. Unused trailing
+// entries have protocol == 0 and are skipped.
+func decodeTrieValuePorts(value []byte) []int {
+	var ports []int
+	for off := 0; off+12 <= len(value); off += 12 {
+		protocol := binary.LittleEndian.Uint32(value[off : off+4])
+		if protocol == 0 {
+			continue
+		}
+		startPort := binary.LittleEndian.Uint32(value[off+4 : off+8])
+		ports = append(ports, int(startPort))
+	}
+	return ports
+}
+
+func containsInt(haystack []int, needle int) bool {
+	for _, v := range haystack {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// TestFWRuleProcessor_NonCanonicalCIDRCollision reproduces the intermittent
+// enforcement bug where two ipBlock rules whose CIDRs reduce to the same
+// network after masking (e.g. 10.0.0.0/8 and 10.161.0.0/8, since /8 makes the
+// .161 octet meaningless) are keyed separately in cidrsMap by their raw string.
+// Their L4 (port) sets are never merged, and the final encode loop collapses
+// both to the identical LPM trie key and overwrites one with the other in a
+// non-deterministic (Go map iteration) order.
+//
+// A correct implementation must canonicalize the CIDR before keying, so the
+// resulting 10.0.0.0/8 entry carries the union of both port sets deterministically.
+func TestFWRuleProcessor_NonCanonicalCIDRCollision(t *testing.T) {
+	protocolTCP := corev1.ProtocolTCP
+	var port443 int32 = 443   // STS / VPC endpoint traffic
+	var port3128 int32 = 3128 // proxy traffic
+
+	nodeIP := "192.168.0.1"
+
+	rules := []EbpfFirewallRules{
+		{
+			IPCidr: "10.0.0.0/8",
+			L4Info: []v1alpha1.Port{{Protocol: &protocolTCP, Port: &port443}},
+		},
+		{
+			IPCidr: "10.161.0.0/8", // host bits set; masks to 10.0.0.0/8
+			L4Info: []v1alpha1.Port{{Protocol: &protocolTCP, Port: &port3128}},
+		},
+	}
+
+	_, canonicalNet, _ := net.ParseCIDR("10.0.0.0/8")
+	canonicalKey := string(utils.ComputeTrieKey(*canonicalNet, false))
+
+	// Go map iteration order is randomized, so the overwrite is probabilistic.
+	// Run many iterations to deterministically catch the bug and to prove the
+	// fix is stable across orderings.
+	for i := 0; i < 500; i++ {
+		got, err := NewFirewallRuleProcessor(nodeIP, "/32", false).ComputeMapEntriesFromEndpointRules(rules)
+		if err != nil {
+			t.Fatalf("iteration %d: unexpected error: %v", i, err)
+		}
+
+		value, ok := got[canonicalKey]
+		if !ok {
+			t.Fatalf("iteration %d: expected a map entry for canonical key 10.0.0.0/8", i)
+		}
+
+		ports := decodeTrieValuePorts(value)
+		if !containsInt(ports, int(port443)) || !containsInt(ports, int(port3128)) {
+			t.Fatalf("iteration %d: 10.0.0.0/8 entry lost a port; got ports=%v (want both 443 and 3128). "+
+				"Non-canonical CIDR 10.161.0.0/8 collided with 10.0.0.0/8 and overwrote its L4 info.", i, ports)
+		}
 	}
 }

--- a/pkg/fwruleprocessor/fw_rule_processor_test.go
+++ b/pkg/fwruleprocessor/fw_rule_processor_test.go
@@ -754,3 +754,102 @@ func TestFWRuleProcessor_NonCanonicalCIDRCollision(t *testing.T) {
 		}
 	}
 }
+
+func TestFWRuleProcessor_ComputeClusterPolicyMapEntriesFromEndpointRules_NodeIPAlwaysPresent(t *testing.T) {
+	nodeIP := "10.1.1.1"
+	_, nodeIPCIDR, _ := net.ParseCIDR(nodeIP + "/32")
+	nodeIPKey := string(utils.ComputeTrieKey(*nodeIPCIDR, false))
+
+	tests := []struct {
+		name          string
+		firewallRules []EbpfFirewallRules
+	}{
+		{
+			name:          "Empty rules - node IP still present",
+			firewallRules: []EbpfFirewallRules{},
+		},
+		{
+			name: "Egress-only CNP rule - node IP still present in ingress map",
+			firewallRules: []EbpfFirewallRules{
+				{
+					IPCidr:   "0.0.0.0/0",
+					Action:   "Accept",
+					Priority: 50,
+				},
+			},
+		},
+		{
+			name: "Ingress rule with specific CIDR - node IP also present",
+			firewallRules: []EbpfFirewallRules{
+				{
+					IPCidr:   "10.0.0.0/16",
+					Action:   "Accept",
+					Priority: 50,
+					L4Info: []v1alpha1.Port{
+						{
+							Protocol: func() *corev1.Protocol { p := corev1.ProtocolTCP; return &p }(),
+							Port:     Int32Ptr(80),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Rule with node IP CIDR - should be skipped but node IP entry still present",
+			firewallRules: []EbpfFirewallRules{
+				{
+					IPCidr:   "10.1.1.1/32",
+					Action:   "Accept",
+					Priority: 50,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewFirewallRuleProcessor(nodeIP, "/32", false).ComputeClusterPolicyMapEntriesFromEndpointRules(tt.firewallRules)
+			assert.NoError(t, err)
+
+			// The node IP key must always be present in the resulting map
+			_, nodeIPExists := got[nodeIPKey]
+			assert.True(t, nodeIPExists, "Node IP entry must always be present in cluster policy firewall map")
+		})
+	}
+}
+
+func TestFWRuleProcessor_ComputeClusterPolicyMapEntriesFromEndpointRules_IPv6_NodeIPAlwaysPresent(t *testing.T) {
+	nodeIP := "2001:db8:abcd:0012::1"
+	_, nodeIPCIDR, _ := net.ParseCIDR(nodeIP + "/128")
+	nodeIPKey := string(utils.ComputeTrieKey(*nodeIPCIDR, true))
+
+	tests := []struct {
+		name          string
+		firewallRules []EbpfFirewallRules
+	}{
+		{
+			name:          "Empty rules - IPv6 node IP still present",
+			firewallRules: []EbpfFirewallRules{},
+		},
+		{
+			name: "Egress-only CNP rule - IPv6 node IP still present",
+			firewallRules: []EbpfFirewallRules{
+				{
+					IPCidr:   "::/0",
+					Action:   "Accept",
+					Priority: 50,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewFirewallRuleProcessor(nodeIP, "/128", true).ComputeClusterPolicyMapEntriesFromEndpointRules(tt.firewallRules)
+			assert.NoError(t, err)
+
+			_, nodeIPExists := got[nodeIPKey]
+			assert.True(t, nodeIPExists, "IPv6 Node IP entry must always be present in cluster policy firewall map")
+		})
+	}
+}

--- a/test/framework/resources/k8s/pod/resource.go
+++ b/test/framework/resources/k8s/pod/resource.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -29,6 +30,7 @@ type Manager interface {
 	PodLogs(namespace string, name string) (string, error)
 	ExecInPod(namespace string, podName string, command []string) (string, error)
 	ValidateConnection(namespace string, podName string, url string, ipFamily string) (string, error)
+	TCPProbe(namespace string, podName string, host string, port int) (string, error)
 }
 
 type defaultManager struct {
@@ -212,6 +214,23 @@ func (d *defaultManager) ExecInPod(namespace string, podName string, command []s
 	}
 
 	return strings.TrimSpace(result), nil
+}
+
+// TCPProbe execs `nc -z` in the pod and returns "OPEN" or "CLOSE" for a connection to
+// host:port. A denied connection is silently dropped (no RST), so nc blocks its full
+// timeout before reporting CLOSE. host and port are passed as positional shell
+// arguments so they are never interpreted as shell syntax.
+func (d *defaultManager) TCPProbe(namespace string, podName string, host string, port int) (string, error) {
+	cmd := []string{
+		"/bin/sh", "-c",
+		`nc -z -w2 "$1" "$2" 2>/dev/null && echo "OPEN" || echo "CLOSE"`,
+		"sh", host, strconv.Itoa(port),
+	}
+	out, err := d.ExecInPod(namespace, podName, cmd)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
 }
 
 func (d *defaultManager) ValidateConnection(namespace string, podName string, url string, ipFamily string) (string, error) {

--- a/test/framework/utils/poll.go
+++ b/test/framework/utils/poll.go
@@ -4,4 +4,10 @@ import "time"
 
 const (
 	PollIntervalShort = 2 * time.Second
+
+	// Probe timing for polling live connectivity while a network policy converges.
+	EnforcementTimeout = 90 * time.Second // wait for policy to be programmed into the datapath
+	ProbeTimeout       = 30 * time.Second // probe once enforcement is expected to be active
+	StabilityWindow    = 10 * time.Second // window over which a converged verdict must hold
+	ProbeInterval      = 3 * time.Second
 )

--- a/test/integration/policy/ebpf_rules_test.go
+++ b/test/integration/policy/ebpf_rules_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Ebpf prog protocol and port evaluation test", func() {
 
 	It("should allow traffic to both ports when policy uses ANY protocol and ANY port", func() {
 		rule := manifest.NewEgressRuleBuilder().
-			AddPeer(nil, nil, serverIP+"/32").
+			AddPeer(nil, nil, serverIP+hostMask(fw.Options.IpFamily)).
 			AddPort(-1, "").
 			Build()
 
@@ -101,7 +101,7 @@ var _ = Describe("Ebpf prog protocol and port evaluation test", func() {
 
 	It("should allow on portA and deny on portB when policy allows only portA and ANY protocol", func() {
 		rule := manifest.NewEgressRuleBuilder().
-			AddPeer(nil, nil, serverIP+"/32").
+			AddPeer(nil, nil, serverIP+hostMask(fw.Options.IpFamily)).
 			AddPort(portA, "").
 			Build()
 

--- a/test/integration/policy/except_block_test.go
+++ b/test/integration/policy/except_block_test.go
@@ -3,23 +3,17 @@ package policy
 import (
 	"fmt"
 	"net"
-	"strings"
 	"time"
 
 	"sigs.k8s.io/yaml"
 
 	"github.com/aws/aws-network-policy-agent/test/framework/manifest"
+	"github.com/aws/aws-network-policy-agent/test/framework/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
 	network "k8s.io/api/networking/v1"
-)
-
-const (
-	enforcementTimeout = 90 * time.Second // wait for policy to be programmed into the datapath
-	probeTimeout       = 30 * time.Second // allow probes once enforcement is active
-	probeInterval      = 3 * time.Second
 )
 
 func printNetworkPolicyYAML(np *network.NetworkPolicy) {
@@ -171,31 +165,31 @@ var _ = Describe("IPBlock Except Test Cases", func() {
 
 			// Deny converging first proves enforcement is active.
 			By(fmt.Sprintf("denying egress to the server on excepted port %d", blockPort), func() {
-				Eventually(func() string {
-					return tcpProbe(clientNamespace, clientName, serverIP, blockPort)
-				}, enforcementTimeout, probeInterval).Should(Equal("CLOSE"),
+				Eventually(func() (string, error) {
+					return fw.PodManager.TCPProbe(clientNamespace, clientName, serverIP, blockPort)
+				}, utils.EnforcementTimeout, utils.ProbeInterval).Should(Equal("CLOSE"),
 					"expected deny to server on excepted port %d", blockPort)
 			})
 
 			By(fmt.Sprintf("allowing egress to the server on allowed port %d", allowPort), func() {
-				Eventually(func() string {
-					return tcpProbe(clientNamespace, clientName, serverIP, allowPort)
-				}, probeTimeout, probeInterval).Should(Equal("OPEN"),
+				Eventually(func() (string, error) {
+					return fw.PodManager.TCPProbe(clientNamespace, clientName, serverIP, allowPort)
+				}, utils.ProbeTimeout, utils.ProbeInterval).Should(Equal("OPEN"),
 					"expected allow to server on port %d", allowPort)
 			})
 
 			By("allowing egress to endpoints outside the excepted prefix", func() {
-				Eventually(func() string {
-					return tcpProbe(clientNamespace, clientName, cfg.extProbeIP, 53)
-				}, probeTimeout, probeInterval).Should(Equal("OPEN"),
+				Eventually(func() (string, error) {
+					return fw.PodManager.TCPProbe(clientNamespace, clientName, cfg.extProbeIP, 53)
+				}, utils.ProbeTimeout, utils.ProbeInterval).Should(Equal("OPEN"),
 					"expected allow to external endpoint outside the excepted prefix")
 			})
 
 			// Consistently (not Eventually) ensures the deny didn't flap.
 			By(fmt.Sprintf("confirming deny on excepted port %d still holds", blockPort), func() {
-				Consistently(func() string {
-					return tcpProbe(clientNamespace, clientName, serverIP, blockPort)
-				}, 10*time.Second, probeInterval).Should(Equal("CLOSE"),
+				Consistently(func() (string, error) {
+					return fw.PodManager.TCPProbe(clientNamespace, clientName, serverIP, blockPort)
+				}, utils.StabilityWindow, utils.ProbeInterval).Should(Equal("CLOSE"),
 					"deny on excepted port %d did not persist through the allow probes", blockPort)
 			})
 		})
@@ -215,22 +209,3 @@ var _ = Describe("IPBlock Except Test Cases", func() {
 		fw.NamespaceManager.DeleteAndWaitTillNamespaceDeleted(ctx, clientNamespace)
 	})
 })
-
-// probeError distinguishes an exec failure from an OPEN/CLOSE verdict, so it shows
-// explicitly in assertion output instead of as an empty string.
-const probeError = "PROBE_ERROR"
-
-// tcpProbe execs `nc -z` in the client pod. Returns "OPEN" or "CLOSE".
-// stderr is suppressed so ExecInPod returns only the deterministic stdout.
-func tcpProbe(namespace, podName, host string, port int) string {
-	cmd := []string{
-		"/bin/sh", "-c",
-		fmt.Sprintf(`nc -z -w2 %s %d 2>/dev/null && echo "OPEN" || echo "CLOSE"`, host, port),
-	}
-	out, err := fw.PodManager.ExecInPod(namespace, podName, cmd)
-	if err != nil {
-		GinkgoWriter.Printf("tcpProbe %s:%d exec error: %v\n", host, port, err)
-		return probeError
-	}
-	return strings.TrimSpace(out)
-}

--- a/test/integration/policy/except_block_test.go
+++ b/test/integration/policy/except_block_test.go
@@ -65,6 +65,16 @@ func getPrefix(ipStr string, maskLen int) (string, error) {
 	return fmt.Sprintf("%s/%d", network.String(), maskLen), nil
 }
 
+// hostMask returns the single-host CIDR suffix for the cluster's IP family —
+// "/32" for IPv4, "/128" for IPv6. A "/32" suffix is rejected by the API server
+// on IPv6 addresses.
+func hostMask(ipFamily string) string {
+	if ipFamily == "IPv6" {
+		return "/128"
+	}
+	return "/32"
+}
+
 var _ = Describe("IPBlock Except Test Cases", func() {
 	var (
 		serverPod       *v1.Pod

--- a/test/integration/policy/policy_suite_test.go
+++ b/test/integration/policy/policy_suite_test.go
@@ -15,7 +15,7 @@ var (
 	namespace = "policy"
 )
 
-func TestStrictModeNetworkPolicy(t *testing.T) {
+func TestNetworkPolicy(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Network Policy Test Suite")
 }

--- a/test/integration/strict/strict_mode_test.go
+++ b/test/integration/strict/strict_mode_test.go
@@ -1,11 +1,10 @@
 package strict
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-network-policy-agent/test/framework/manifest"
+	"github.com/aws/aws-network-policy-agent/test/framework/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -13,36 +12,32 @@ import (
 	network "k8s.io/api/networking/v1"
 )
 
+const serverPort = 8080
+
 var _ = Describe("Strict Mode Test Cases", func() {
 	Context("when pod is launched", func() {
 		var clientPod *v1.Pod
 		var podName = "clientpod"
 
 		BeforeEach(func() {
-			By("Creating a pod to which tries to reach to external network", func() {
-				agnhostContainer := manifest.NewAgnHostContainerBuilder().
-					ImageRepository(fw.Options.TestImageRegistry).
-					Args([]string{"while true; do wget https://www.google.com --spider -T 1; if [ $? == 0 ]; then echo \"Success\"; else echo \"Fail\"; fi; sleep 1s; done"}).
-					Build()
-
-				clientPod = manifest.NewDefaultPodBuilder().
-					Container(agnhostContainer).
-					Namespace(namespace).
-					Name(podName).
-					Build()
-
-				_, err := fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, clientPod, 2*time.Minute)
-				Expect(err).ToNot(HaveOccurred())
+			By("Creating an idle client pod", func() {
+				clientPod = deployIdlePod(podName, namespace)
 			})
 		})
 
 		It("by default should not have connectivity to external network", func() {
-			By("Verify pod does not have external connectivity", func() {
-				time.Sleep(1 * time.Minute)
-				logs, err := fw.PodManager.PodLogs(namespace, podName)
-				Expect(err).ToNot(HaveOccurred())
-				err = processLogs(logs, true, false, false)
-				Expect(err).ToNot(HaveOccurred())
+			host, port := externalProbeTarget(fw.Options.IpFamily)
+			By("verifying egress to the external endpoint is denied", func() {
+				Eventually(func() (string, error) {
+					return fw.PodManager.TCPProbe(namespace, podName, host, port)
+				}, utils.EnforcementTimeout, utils.ProbeInterval).Should(Equal("CLOSE"),
+					"strict mode should deny egress from a pod with no network policy")
+			})
+			By("verifying the deny persists", func() {
+				Consistently(func() (string, error) {
+					return fw.PodManager.TCPProbe(namespace, podName, host, port)
+				}, utils.StabilityWindow, utils.ProbeInterval).Should(Equal("CLOSE"),
+					"deny should not flap while no policy allows the traffic")
 			})
 		})
 
@@ -56,8 +51,6 @@ var _ = Describe("Strict Mode Test Cases", func() {
 			serverPod           *v1.Pod
 			clientDeployment    *appsv1.Deployment
 			serverPodIP         string
-			newPod              string
-			firstPod            string
 			serverName          = "serverpod"
 			clientName          = "clientdeploy"
 			serverNetworkPolicy *network.NetworkPolicy
@@ -65,13 +58,11 @@ var _ = Describe("Strict Mode Test Cases", func() {
 		)
 
 		BeforeEach(func() {
-
 			By("Deploying a server pod with allow all ingress network policy", func() {
-
 				ingressPeer := manifest.NewIngressRuleBuilder().
 					AddPeer(nil, nil, "0.0.0.0/0").
 					AddPeer(nil, nil, "::/0").
-					AddPort(8080, v1.ProtocolTCP).
+					AddPort(serverPort, v1.ProtocolTCP).
 					Build()
 
 				serverNetworkPolicy = manifest.NewNetworkPolicyBuilder().
@@ -87,7 +78,7 @@ var _ = Describe("Strict Mode Test Cases", func() {
 				serverContainer := manifest.NewAgnHostContainerBuilder().
 					ImageRepository(fw.Options.TestImageRegistry).
 					Args([]string{"/agnhost netexec"}).
-					AddContainerPort(v1.ContainerPort{ContainerPort: 8080}).
+					AddContainerPort(v1.ContainerPort{ContainerPort: serverPort}).
 					Build()
 
 				serverPod = manifest.NewDefaultPodBuilder().
@@ -102,11 +93,10 @@ var _ = Describe("Strict Mode Test Cases", func() {
 				serverPodIP = pod.Status.PodIP
 			})
 
-			By("Deploying a client deployment and an egress policy to allow communication with server", func() {
-
+			By("Deploying an idle client deployment and an egress policy to allow communication with server", func() {
 				egressPeer := manifest.NewEgressRuleBuilder().
 					AddPeer(nil, map[string]string{"app": serverName}, "").
-					AddPort(8080, v1.ProtocolTCP).
+					AddPort(serverPort, v1.ProtocolTCP).
 					Build()
 
 				clientNetworkPolicy = manifest.NewNetworkPolicyBuilder().
@@ -116,72 +106,51 @@ var _ = Describe("Strict Mode Test Cases", func() {
 					AddEgressRule(egressPeer).
 					Build()
 
-				if fw.Options.IpFamily == "IPv6" {
-					serverPodIP = fmt.Sprintf("[%s]", serverPodIP)
-				}
-
 				err := fw.NetworkPolicyManager.CreateNetworkPolicy(ctx, clientNetworkPolicy)
 				Expect(err).ToNot(HaveOccurred())
 
-				clientContainer := manifest.NewAgnHostContainerBuilder().
-					ImageRepository(fw.Options.TestImageRegistry).
-					Command([]string{"/bin/sh", "-c"}).
-					Args([]string{fmt.Sprintf("while true; do wget %s:8080 --spider -T 2; if [ $? == 0 ]; then echo \"Success\"; else echo \"Fail\"; fi; done", serverPodIP)}).
-					Build()
-
-				clientDeployment = manifest.NewDefaultDeploymentBuilder().
-					Name(clientName).
-					Replicas(1).
-					Namespace(namespace).
-					AddLabel("app", clientName).
-					Container(clientContainer).
-					Build()
-
-				_, err = fw.DeploymentManager.CreateAndWaitUntilDeploymentReady(ctx, clientDeployment)
-				Expect(err).ToNot(HaveOccurred())
+				clientDeployment = deployIdleDeployment(clientName, namespace, 1)
 			})
 		})
 
-		It("Traffic from first replica of client deployment must be denied initially before succeeding but second replica should be instantaneous", func() {
-			By("Verify traffic probes are denied and then accepted from first replica of client pod", func() {
-				time.Sleep(30 * time.Second)
-				podList, err := fw.PodManager.GetPodsWithLabel(ctx, namespace, "app", clientName)
-				Expect(err).ToNot(HaveOccurred())
+		It("allows egress once the policy is enforced, and a second replica sharing the policy is also allowed", func() {
+			var firstPod, secondPod string
 
-				firstPod = podList[0].Name
-				podLog, err := fw.PodManager.PodLogs(namespace, firstPod)
-				Expect(err).ToNot(HaveOccurred())
-
-				err = processLogs(podLog, false, false, true)
-				Expect(err).ToNot(HaveOccurred())
+			By("resolving the first client replica", func() {
+				firstPod = podNameForReplica(namespace, clientName, "")
 			})
 
-			By("Scaling the client deployment to 2", func() {
+			// First pod cold-starts in strict default-deny; allowed once the egress rule is programmed.
+			By("verifying the first replica eventually reaches the server", func() {
+				Eventually(func() (string, error) {
+					return fw.PodManager.TCPProbe(namespace, firstPod, serverPodIP, serverPort)
+				}, utils.EnforcementTimeout, utils.ProbeInterval).Should(Equal("OPEN"),
+					"first replica should reach the server once the egress policy is programmed")
+			})
+
+			By("scaling the client deployment to 2", func() {
 				err := fw.DeploymentManager.ScaleDeploymentAndWaitTillReady(ctx, namespace, clientName, 2)
 				Expect(err).ToNot(HaveOccurred())
-
-				time.Sleep(10 * time.Second)
-
-				podList, err := fw.PodManager.GetPodsWithLabel(ctx, namespace, "app", clientName)
-				Expect(err).ToNot(HaveOccurred())
-
-				for _, pod := range podList {
-					if pod.Name != firstPod {
-						newPod = pod.Name
-						break
-					}
-				}
-				Expect(newPod).ToNot(BeEmpty())
+				secondPod = podNameForReplica(namespace, clientName, firstPod)
 			})
 
-			By("Verify all traffic probes are accepted from second replica of client pod", func() {
-				time.Sleep(30 * time.Second)
+			// The second replica shares the pod identifier's already-programmed maps, so it should
+			// be allowed without a cold-start deny. Consistently from the first poll asserts that
+			// instantaneous property: a replica that wrongly cold-started would probe CLOSE early.
+			// (We do not assert the first replica's initial deny window; catching it depends on
+			// racing the probe against datapath programming, which is the flake this rewrite removes.)
+			By("verifying the second replica reaches the server without a cold-start deny", func() {
+				Consistently(func() (string, error) {
+					return fw.PodManager.TCPProbe(namespace, secondPod, serverPodIP, serverPort)
+				}, utils.StabilityWindow, utils.ProbeInterval).Should(Equal("OPEN"),
+					"second replica should reach the server immediately via the shared policy maps")
+			})
 
-				podLog, err := fw.PodManager.PodLogs(namespace, newPod)
-				Expect(err).ToNot(HaveOccurred())
-
-				err = processLogs(podLog, false, true, false)
-				Expect(err).ToNot(HaveOccurred())
+			By("verifying connectivity is stable for the first replica", func() {
+				Consistently(func() (string, error) {
+					return fw.PodManager.TCPProbe(namespace, firstPod, serverPodIP, serverPort)
+				}, utils.StabilityWindow, utils.ProbeInterval).Should(Equal("OPEN"),
+					"allow should not flap once the policy is enforced")
 			})
 		})
 
@@ -194,30 +163,68 @@ var _ = Describe("Strict Mode Test Cases", func() {
 	})
 })
 
-func processLogs(podlogs string, allDeny bool, allAllow bool, mix bool) error {
+// externalProbeTarget returns an off-cluster host and port for the cluster's IP family.
+func externalProbeTarget(ipFamily string) (string, int) {
+	if ipFamily == "IPv6" {
+		return "2001:4860:4860::8888", 53
+	}
+	return "8.8.8.8", 53
+}
 
-	passFlag := false
-	failFlag := false
-	for _, log := range strings.Split(strings.TrimSuffix(podlogs, "\n"), "\n") {
-		if log == "Fail" {
-			if passFlag {
-				return fmt.Errorf("Connection failed after initial success")
-			}
-			failFlag = true
-		} else if log == "Success" {
-			passFlag = true
+// deployIdlePod creates a running busybox pod that sleeps, so probes can be exec'd on demand.
+func deployIdlePod(name, ns string) *v1.Pod {
+	ctnr := manifest.NewBusyBoxContainerBuilder().
+		ImageRepository(fw.Options.TestImageRegistry).
+		Command([]string{"/bin/sh", "-c"}).
+		Args([]string{"sleep 1000000"}).
+		Build()
+
+	pod, err := fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, manifest.NewDefaultPodBuilder().
+		Name(name).
+		Namespace(ns).
+		Container(ctnr).
+		Build(), 2*time.Minute)
+	Expect(err).ToNot(HaveOccurred())
+	return pod
+}
+
+// deployIdleDeployment creates a busybox deployment whose pods sleep, so probes can be exec'd on demand.
+func deployIdleDeployment(name, ns string, replicas int) *appsv1.Deployment {
+	ctnr := manifest.NewBusyBoxContainerBuilder().
+		ImageRepository(fw.Options.TestImageRegistry).
+		Command([]string{"/bin/sh", "-c"}).
+		Args([]string{"sleep 1000000"}).
+		Build()
+
+	deployment := manifest.NewDefaultDeploymentBuilder().
+		Name(name).
+		Replicas(replicas).
+		Namespace(ns).
+		AddLabel("app", name).
+		Container(ctnr).
+		Build()
+
+	dp, err := fw.DeploymentManager.CreateAndWaitUntilDeploymentReady(ctx, deployment)
+	Expect(err).ToNot(HaveOccurred())
+	return dp
+}
+
+// podNameForReplica polls for a pod with app=name, skipping excludeName, since scaling
+// does not block until the new pod registers.
+func podNameForReplica(ns, name, excludeName string) string {
+	var podName string
+	Eventually(func() bool {
+		pods, err := fw.PodManager.GetPodsWithLabel(ctx, ns, "app", name)
+		if err != nil {
+			return false
 		}
-	}
-
-	if !passFlag && !failFlag {
-		return fmt.Errorf("Error generating traffic probes")
-	} else if allDeny && passFlag {
-		return fmt.Errorf("Failed as all traffic probes did not get DENY")
-	} else if allAllow && failFlag {
-		return fmt.Errorf("Failed as all traffic probes did not get ACCEPT")
-	} else if mix && !(passFlag && failFlag) {
-		return fmt.Errorf("Failed as traffic probes did not get DENY first and then ACCEPT")
-	}
-
-	return nil
+		for _, pod := range pods {
+			if pod.Name != excludeName {
+				podName = pod.Name
+				return true
+			}
+		}
+		return false
+	}, utils.ProbeTimeout, utils.ProbeInterval).Should(BeTrue(), "expected a client replica with app=%s", name)
+	return podName
 }

--- a/test/integration/strict/strict_mode_test.go
+++ b/test/integration/strict/strict_mode_test.go
@@ -134,11 +134,11 @@ var _ = Describe("Strict Mode Test Cases", func() {
 				secondPod = podNameForReplica(namespace, clientName, firstPod)
 			})
 
-			// The second replica shares the pod identifier's already-programmed maps, so it should
-			// be allowed without a cold-start deny. Consistently from the first poll asserts that
-			// instantaneous property: a replica that wrongly cold-started would probe CLOSE early.
-			// (We do not assert the first replica's initial deny window; catching it depends on
-			// racing the probe against datapath programming, which is the flake this rewrite removes.)
+			// Second replica shares the pod identifier's already-programmed maps, so it must be
+			// allowed from its first packet with no cold-start deny. podNameForReplica returns it
+			// only once Running, so Consistently probes from the start: a replica that wrongly
+			// cold-started would show an early CLOSE. (Eventually here would mask that by waiting
+			// out the deny, breaking the "instantaneous" contract.)
 			By("verifying the second replica reaches the server without a cold-start deny", func() {
 				Consistently(func() (string, error) {
 					return fw.PodManager.TCPProbe(namespace, secondPod, serverPodIP, serverPort)
@@ -209,8 +209,9 @@ func deployIdleDeployment(name, ns string, replicas int) *appsv1.Deployment {
 	return dp
 }
 
-// podNameForReplica polls for a pod with app=name, skipping excludeName, since scaling
-// does not block until the new pod registers.
+// podNameForReplica polls for a Running pod with app=name, skipping excludeName. It gates
+// on Running so callers get an exec-ready pod: a pod is listed by label before its
+// container starts, and exec-ing that early fails with "container not found".
 func podNameForReplica(ns, name, excludeName string) string {
 	var podName string
 	Eventually(func() bool {
@@ -219,12 +220,12 @@ func podNameForReplica(ns, name, excludeName string) string {
 			return false
 		}
 		for _, pod := range pods {
-			if pod.Name != excludeName {
+			if pod.Name != excludeName && pod.Status.Phase == v1.PodRunning {
 				podName = pod.Name
 				return true
 			}
 		}
 		return false
-	}, utils.ProbeTimeout, utils.ProbeInterval).Should(BeTrue(), "expected a client replica with app=%s", name)
+	}, utils.ProbeTimeout, utils.ProbeInterval).Should(BeTrue(), "expected a running client replica with app=%s", name)
 	return podName
 }


### PR DESCRIPTION
Cherry-picks the post-v1.4.1 changes from `main` onto `release-1.4` for the v1.4.2 patch release.

**Included:**
- #550 Minimize CloudWatch Logs IAM policy
- #608 Canonicalize CIDRs to prevent LPM key collisions (+ CNP path / except-block extension)
- #630 ebpf sdk bump
- #632 test: fix flaky strict-mode spec
- #633 test: gate podNameForReplica on Running to fix strict-mode exec race
- #634 test: use family-aware host CIDR in ebpf_rules egress policy
- #636 fix: add node-IP allow to ClusterNetworkPolicy ingress path

**Excluded:**
- #610 conntrack port-reuse GC race fix (intentionally held back for this release)

**Verification:** `go build ./...` passes (go 1.26.5); `go vet` and unit tests pass for `pkg/fwruleprocessor`.
