### PR TITLE
fixed E2E metric calculations

### DIFF
--- a/controllers/clusterpolicyendpoints_controller.go
+++ b/controllers/clusterpolicyendpoints_controller.go
@@ -82,6 +82,10 @@ type ClusterPolicyEndpointsReconciler struct {
 	// stale ClusterPolicyEndpoint annotations and avoid emitting artificially high
 	// E2E latency on restart
 	trackerStartTime time.Time
+	// lastObservedTriggerTimes maps CPE name (cluster-scoped, so name alone is
+	// unique) to the last last-change-trigger-time annotation value consumed,
+	// so each trigger time is observed at most once
+	lastObservedTriggerTimes sync.Map
 
 	// Maps pod Identifier to list of ClusterPolicyEndpoint resources
 	podIdentifierToClusterPolicyEndpointMap      sync.Map
@@ -124,6 +128,8 @@ func (r *ClusterPolicyEndpointsReconciler) reconcile(ctx context.Context, req ct
 
 func (r *ClusterPolicyEndpointsReconciler) cleanUpClusterPolicyEndpoint(ctx context.Context, req ctrl.Request) error {
 	log().Infof("Clean Up ClusterPolicyEndpoint resources for name: %s", req.Name)
+
+	r.lastObservedTriggerTimes.Delete(req.Name)
 
 	parentCNP := utils.GetParentNPNameFromPEName(req.Name)
 	resourceName := req.Name
@@ -173,6 +179,7 @@ func (r *ClusterPolicyEndpointsReconciler) reconcileClusterPolicyEndpoint(ctx co
 		return err
 	}
 
+	programmingSucceeded := true
 	for podIdentifier := range targetPodIdentifiers {
 		ingressRules, egressRules, err := r.deriveClusterPolicyIngressAndEgressFirewallRules(ctx, podIdentifier, ClusterPolicyEndpoint.Name, false)
 		if err != nil {
@@ -183,18 +190,20 @@ func (r *ClusterPolicyEndpointsReconciler) reconcileClusterPolicyEndpoint(ctx co
 		err = r.configureClusterPolicyBPFProbes(podIdentifier, targetPods, ingressRules, egressRules)
 		if err != nil {
 			log().Errorf("Error configuring Cluster Policy eBPF Probes %v", err)
+			programmingSucceeded = false
 		}
 	}
 
-	r.observeClusterPolicyProgrammingLatency(ClusterPolicyEndpoint)
+	r.observeClusterPolicyProgrammingLatency(ClusterPolicyEndpoint, programmingSucceeded)
 
 	return nil
 }
 
-// observeClusterPolicyProgrammingLatency reads the last-change-trigger-time annotation
-// from the ClusterPolicyEndpoint and emits the E2E latency histogram if the timestamp
-// is newer than this agent's start time.
-func (r *ClusterPolicyEndpointsReconciler) observeClusterPolicyProgrammingLatency(cpe *policyk8sawsv1.ClusterPolicyEndpoint) {
+// observeClusterPolicyProgrammingLatency emits the E2E latency histogram from
+// the last-change-trigger-time annotation. Each annotation value is consumed
+// at most once per CPE, even when the observation is suppressed (programming
+// failure, clock skew), so stale rewrites/resyncs/relists never re-observe it.
+func (r *ClusterPolicyEndpointsReconciler) observeClusterPolicyProgrammingLatency(cpe *policyk8sawsv1.ClusterPolicyEndpoint, programmingSucceeded bool) {
 	if cpe.Annotations == nil {
 		return
 	}
@@ -210,7 +219,22 @@ func (r *ClusterPolicyEndpointsReconciler) observeClusterPolicyProgrammingLatenc
 	if !triggerTime.After(r.trackerStartTime) {
 		return
 	}
+	if prev, ok := r.lastObservedTriggerTimes.Load(cpe.Name); ok && prev.(string) == triggerTimeStr {
+		return
+	}
+	// Consume before the suppression checks below: a suppressed observation
+	// must never be re-emitted (inflated) by a later resync of the same annotation.
+	r.lastObservedTriggerTimes.Store(cpe.Name, triggerTimeStr)
+	if !programmingSucceeded {
+		log().Debugf("Skipping E2E cluster policy programming latency for CPE %s: programming failed", cpe.Name)
+		return
+	}
 	latency := time.Since(triggerTime).Seconds()
+	if latency < 0 {
+		// Clock skew between NPC (control plane) and this node
+		log().Debugf("Skipping negative E2E cluster policy programming latency %.3fs for CPE %s", latency, cpe.Name)
+		return
+	}
 	clusterPolicyProgrammingLatency.Observe(latency)
 	log().Debugf("E2E cluster policy programming latency: %.3fs for CPE %s", latency, cpe.Name)
 }

--- a/controllers/policyendpoints_controller.go
+++ b/controllers/policyendpoints_controller.go
@@ -126,6 +126,10 @@ type PolicyEndpointsReconciler struct {
 	// stale PolicyEndpoint annotations and avoid emitting artificially high
 	// E2E latency on restart
 	trackerStartTime time.Time
+	// lastObservedTriggerTimes maps a PE's types.NamespacedName to the last
+	// last-change-trigger-time annotation value consumed, so each trigger
+	// time is observed at most once
+	lastObservedTriggerTimes sync.Map
 	// Maps pod Identifier to list of PolicyEndpoint resources
 	podIdentifierToPolicyEndpointMap sync.Map
 	// Mutex for operations on PodIdentifierToPolicyEndpointMap
@@ -170,6 +174,8 @@ func (r *PolicyEndpointsReconciler) cleanUpPolicyEndpoint(ctx context.Context, r
 	log().Infof("Clean Up PolicyEndpoint resources for name: %s", req.NamespacedName.Name)
 	policyEndpointIdentifier := utils.GetPolicyEndpointIdentifier(req.NamespacedName.Name,
 		req.NamespacedName.Namespace)
+
+	r.lastObservedTriggerTimes.Delete(req.NamespacedName)
 
 	start := time.Now()
 
@@ -259,6 +265,7 @@ func (r *PolicyEndpointsReconciler) reconcilePolicyEndpoint(ctx context.Context,
 		return err
 	}
 
+	programmingSucceeded := true
 	for podIdentifier := range podIdentifiers {
 		// Derive Ingress IPs from the PolicyEndpoint
 		ingressRules, egressRules, isIngressIsolated, isEgressIsolated, err := r.deriveIngressAndEgressFirewallRules(ctx, podIdentifier,
@@ -284,23 +291,23 @@ func (r *PolicyEndpointsReconciler) reconcilePolicyEndpoint(ctx context.Context,
 		err = r.configureeBPFProbes(ctx, podIdentifier, targetPods, ingressRules, egressRules)
 		if err != nil {
 			log().Errorf("Error configuring eBPF Probes %v", err)
+			programmingSucceeded = false
 		}
 		duration := msSince(start)
 		policySetupLatency.WithLabelValues(policyEndpoint.Name, policyEndpoint.Namespace).Observe(duration)
 	}
 
-	// Observe E2E policy programming latency (NPC change → NPA eBPF programmed).
-	// Only emit if the annotation timestamp is after this agent's start time to
-	// avoid stale latency on restart/new node (same pattern as kube-proxy).
-	r.observePolicyProgrammingLatency(policyEndpoint)
+	// Observe E2E policy programming latency (NPC change → NPA eBPF programmed)
+	r.observePolicyProgrammingLatency(policyEndpoint, programmingSucceeded)
 
 	return nil
 }
 
-// observePolicyProgrammingLatency reads the last-change-trigger-time annotation
-// from the PolicyEndpoint and emits the E2E latency histogram if the timestamp
-// is newer than this agent's start time.
-func (r *PolicyEndpointsReconciler) observePolicyProgrammingLatency(pe *policyk8sawsv1.PolicyEndpoint) {
+// observePolicyProgrammingLatency emits the E2E latency histogram from the
+// last-change-trigger-time annotation. Each annotation value is consumed at
+// most once per PE, even when the observation is suppressed (programming
+// failure, clock skew), so stale rewrites/resyncs/relists never re-observe it.
+func (r *PolicyEndpointsReconciler) observePolicyProgrammingLatency(pe *policyk8sawsv1.PolicyEndpoint, programmingSucceeded bool) {
 	if pe.Annotations == nil {
 		return
 	}
@@ -316,7 +323,23 @@ func (r *PolicyEndpointsReconciler) observePolicyProgrammingLatency(pe *policyk8
 	if !triggerTime.After(r.trackerStartTime) {
 		return
 	}
+	peKey := types.NamespacedName{Namespace: pe.Namespace, Name: pe.Name}
+	if prev, ok := r.lastObservedTriggerTimes.Load(peKey); ok && prev.(string) == triggerTimeStr {
+		return
+	}
+	// Consume before the suppression checks below: a suppressed observation
+	// must never be re-emitted (inflated) by a later resync of the same annotation.
+	r.lastObservedTriggerTimes.Store(peKey, triggerTimeStr)
+	if !programmingSucceeded {
+		log().Debugf("Skipping E2E policy programming latency for PE %s/%s: programming failed", pe.Namespace, pe.Name)
+		return
+	}
 	latency := time.Since(triggerTime).Seconds()
+	if latency < 0 {
+		// Clock skew between NPC (control plane) and this node
+		log().Debugf("Skipping negative E2E policy programming latency %.3fs for PE %s/%s", latency, pe.Namespace, pe.Name)
+		return
+	}
 	policyProgrammingLatency.Observe(latency)
 	log().Debugf("E2E policy programming latency: %.3fs for PE %s/%s", latency, pe.Namespace, pe.Name)
 }

--- a/controllers/programming_latency_test.go
+++ b/controllers/programming_latency_test.go
@@ -1,0 +1,201 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	policyendpoint "github.com/aws/aws-network-policy-agent/api/v1alpha1"
+	mock_client "github.com/aws/aws-network-policy-agent/mocks/controller-runtime/client"
+	"github.com/golang/mock/gomock"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+)
+
+// histSampleCount reads the cumulative sample count of a package-level
+// histogram. Tests assert on before/after deltas so they stay independent of
+// execution order and -count=N reruns; do not add t.Parallel() to tests that
+// share these histograms.
+func histSampleCount(t *testing.T, h prometheus.Histogram) uint64 {
+	t.Helper()
+	m := &dto.Metric{}
+	assert.NoError(t, h.Write(m))
+	return m.GetHistogram().GetSampleCount()
+}
+
+func newPEWithTriggerTime(name, namespace, triggerTime string) *policyendpoint.PolicyEndpoint {
+	pe := &policyendpoint.PolicyEndpoint{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+	if triggerTime != "" {
+		pe.Annotations = map[string]string{LastChangeTriggerTimeAnnotation: triggerTime}
+	}
+	return pe
+}
+
+func TestObservePolicyProgrammingLatency(t *testing.T) {
+	now := time.Now()
+	fresh := now.Add(-2 * time.Second).UTC().Format(time.RFC3339Nano)
+	fresher := now.Add(-1 * time.Second).UTC().Format(time.RFC3339Nano)
+	beforeStart := now.Add(-2 * time.Hour).UTC().Format(time.RFC3339Nano)
+	future := now.Add(1 * time.Hour).UTC().Format(time.RFC3339Nano)
+
+	type observeCall struct {
+		pe                   *policyendpoint.PolicyEndpoint
+		programmingSucceeded bool
+	}
+	obs := func(pe *policyendpoint.PolicyEndpoint) observeCall {
+		return observeCall{pe: pe, programmingSucceeded: true}
+	}
+
+	tests := []struct {
+		name     string
+		calls    []observeCall
+		observed uint64 // expected number of new observations
+	}{
+		{
+			name:     "no annotations",
+			calls:    []observeCall{obs(newPEWithTriggerTime("pe-1", "ns", ""))},
+			observed: 0,
+		},
+		{
+			name:     "unparseable annotation",
+			calls:    []observeCall{obs(newPEWithTriggerTime("pe-1", "ns", "not-a-timestamp"))},
+			observed: 0,
+		},
+		{
+			name:     "annotation predates agent start (restart guard)",
+			calls:    []observeCall{obs(newPEWithTriggerTime("pe-1", "ns", beforeStart))},
+			observed: 0,
+		},
+		{
+			name:     "fresh annotation observed once",
+			calls:    []observeCall{obs(newPEWithTriggerTime("pe-1", "ns", fresh))},
+			observed: 1,
+		},
+		{
+			name: "repeat reconcile with unchanged annotation is skipped (issue #644)",
+			calls: []observeCall{
+				obs(newPEWithTriggerTime("pe-1", "ns", fresh)),
+				obs(newPEWithTriggerTime("pe-1", "ns", fresh)),
+				obs(newPEWithTriggerTime("pe-1", "ns", fresh)),
+			},
+			observed: 1,
+		},
+		{
+			name: "changed annotation observed again",
+			calls: []observeCall{
+				obs(newPEWithTriggerTime("pe-1", "ns", fresh)),
+				obs(newPEWithTriggerTime("pe-1", "ns", fresh)),
+				obs(newPEWithTriggerTime("pe-1", "ns", fresher)),
+			},
+			observed: 2,
+		},
+		{
+			name: "same annotation on different PEs observed per PE",
+			calls: []observeCall{
+				obs(newPEWithTriggerTime("pe-1", "ns", fresh)),
+				obs(newPEWithTriggerTime("pe-2", "ns", fresh)),
+			},
+			observed: 2,
+		},
+		{
+			name: "negative latency (clock skew) skipped but consumed",
+			calls: []observeCall{
+				obs(newPEWithTriggerTime("pe-1", "ns", future)),
+				obs(newPEWithTriggerTime("pe-1", "ns", future)),
+			},
+			observed: 0,
+		},
+		{
+			name: "programming failure suppresses observation AND consumes trigger time",
+			// a later resync of the same annotation must not emit an inflated value
+			calls: []observeCall{
+				{pe: newPEWithTriggerTime("pe-1", "ns", fresh), programmingSucceeded: false},
+				{pe: newPEWithTriggerTime("pe-1", "ns", fresh), programmingSucceeded: true},
+			},
+			observed: 0,
+		},
+		{
+			name: "new annotation after programming failure is observed",
+			calls: []observeCall{
+				{pe: newPEWithTriggerTime("pe-1", "ns", fresh), programmingSucceeded: false},
+				{pe: newPEWithTriggerTime("pe-1", "ns", fresher), programmingSucceeded: true},
+			},
+			observed: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &PolicyEndpointsReconciler{
+				trackerStartTime: now.Add(-1 * time.Hour),
+			}
+			before := histSampleCount(t, policyProgrammingLatency)
+			for _, c := range tt.calls {
+				r.observePolicyProgrammingLatency(c.pe, c.programmingSucceeded)
+			}
+			assert.Equal(t, tt.observed, histSampleCount(t, policyProgrammingLatency)-before)
+		})
+	}
+}
+
+func TestObservePolicyProgrammingLatency_CleanupResetsTracking(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockClient := mock_client.NewMockClient(mockCtrl)
+	mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&policyendpoint.PolicyEndpointList{}), gomock.Any()).Return(nil).AnyTimes()
+
+	now := time.Now()
+	fresh := now.Add(-2 * time.Second).UTC().Format(time.RFC3339Nano)
+	r := &PolicyEndpointsReconciler{k8sClient: mockClient, trackerStartTime: now.Add(-1 * time.Hour)}
+	pe := newPEWithTriggerTime("pe-1", "ns", fresh)
+
+	before := histSampleCount(t, policyProgrammingLatency)
+	r.observePolicyProgrammingLatency(pe, true)
+	r.observePolicyProgrammingLatency(pe, true) // duplicate, skipped
+	assert.Equal(t, uint64(1), histSampleCount(t, policyProgrammingLatency)-before)
+
+	// the real cleanup path must delete the tracking entry
+	err := r.cleanUpPolicyEndpoint(context.TODO(), controllerruntime.Request{
+		NamespacedName: types.NamespacedName{Name: "pe-1", Namespace: "ns"},
+	})
+	assert.NoError(t, err)
+
+	// a recreated PE with a fresh annotation is observed again
+	r.observePolicyProgrammingLatency(pe, true)
+	assert.Equal(t, uint64(2), histSampleCount(t, policyProgrammingLatency)-before)
+}
+
+func TestObserveClusterPolicyProgrammingLatency(t *testing.T) {
+	now := time.Now()
+	fresh := now.Add(-2 * time.Second).UTC().Format(time.RFC3339Nano)
+	fresher := now.Add(-1 * time.Second).UTC().Format(time.RFC3339Nano)
+	freshest := now.Add(-500 * time.Millisecond).UTC().Format(time.RFC3339Nano)
+
+	r := &ClusterPolicyEndpointsReconciler{trackerStartTime: now.Add(-1 * time.Hour)}
+	cpe := &policyendpoint.ClusterPolicyEndpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "cpe-1",
+			Annotations: map[string]string{LastChangeTriggerTimeAnnotation: fresh},
+		},
+	}
+
+	before := histSampleCount(t, clusterPolicyProgrammingLatency)
+	r.observeClusterPolicyProgrammingLatency(cpe, true)
+	r.observeClusterPolicyProgrammingLatency(cpe, true) // duplicate, skipped
+	assert.Equal(t, uint64(1), histSampleCount(t, clusterPolicyProgrammingLatency)-before)
+
+	cpe.Annotations[LastChangeTriggerTimeAnnotation] = fresher
+	r.observeClusterPolicyProgrammingLatency(cpe, false) // programming failed: consumed, not observed
+	r.observeClusterPolicyProgrammingLatency(cpe, true)  // same annotation: stays consumed
+	assert.Equal(t, uint64(1), histSampleCount(t, clusterPolicyProgrammingLatency)-before)
+
+	cpe.Annotations[LastChangeTriggerTimeAnnotation] = freshest
+	r.observeClusterPolicyProgrammingLatency(cpe, true) // changed annotation, observed
+	assert.Equal(t, uint64(2), histSampleCount(t, clusterPolicyProgrammingLatency)-before)
+}


### PR DESCRIPTION
*Issue #, if available:*
Fixes #644 

*Description of changes:*

Introduces a consume-once pattern:
  each reconciler keeps a `sync.Map` of the last consumed annotation value per
  PE (`types.NamespacedName`) / CPE (name), and emits an observation only when
  the annotation value changes. The trigger time is consumed *before* the
  suppression checks (programming failure, negative latency), so a suppressed
  observation can never be re-emitted inflated by a later resync. Tracking
  entries are removed when the PE/CPE is deleted. Memory cost is ~190 bytes per
  tracked PE, bounded by live PE count.

### Testing

  - Unit tests (`controllers/programming_latency_test.go`, run with `-race`):
    dedup, restart guard, consume-on-failure, clock-skew skip, cleanup reset,
    CPE parity.
  - Verified on a live EKS cluster (K8s 1.35, 2 nodes): metadata-only PE/CPE
    writes now produce zero observations (previously one ~12h observation per
    write per agent, landing in +Inf); genuine NetworkPolicy /
    ClusterNetworkPolicy changes are still observed exactly once per agent
    (~7 ms); agent restart and PE/CPE deletion emit nothing.


Map memory shouldn't increase much as data stored is PE key and timestamp value

  | PE count | map memory |
  |---|---|
  | 100 | ~19 KB |
  | 1,000 | ~190 KB |
  | 10,000 | ~1.9 MB |
  | 100,000 (extreme) | ~19 MB |

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
