### PR TITLE
feat: allow configuring Kubernetes API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Please refer to [EKS User Guide](https://docs.aws.amazon.com/eks/latest/userguid
 ### Network Policy Agent Configuration flags
 ---
 
+#### `apiserver`
+
+Type: String
+
+Default: empty
+
+Overrides the Kubernetes API server URL from the in-cluster configuration or kubeconfig. The existing authentication and TLS configuration are preserved. This can be used to provide an API server endpoint that does not depend on kube-proxy programming the Kubernetes Service ClusterIP.
+
 #### `enable-network-policy`
 
 Type: Boolean

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Type: String
 
 Default: empty
 
-Overrides the Kubernetes API server URL from the in-cluster configuration or kubeconfig. The existing authentication and TLS configuration are preserved. This can be used to provide an API server endpoint that does not depend on kube-proxy programming the Kubernetes Service ClusterIP.
+Overrides the Kubernetes API server URL from the in-cluster configuration or kubeconfig. The value must be an HTTPS URL without a path, query, fragment, or user information. It takes precedence over the API server derived from `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT`.
+
+The existing credentials and certificate authority are preserved, so the configured hostname must be covered by the Kubernetes API server's serving certificate. The endpoint must also be routable and resolvable without cluster networking; for example, an EKS cluster API endpoint can avoid waiting for kube-proxy to program the Kubernetes Service ClusterIP. The deployment layer is responsible for supplying this flag, and the value must be updated if the cluster API endpoint changes.
 
 #### `enable-network-policy`
 

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+	"net/url"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -62,11 +64,34 @@ func BuildRestConfig(rtCfg RuntimeConfig) (*rest.Config, error) {
 		return nil, err
 	}
 	if rtCfg.APIServer != "" {
+		if err := validateAPIServer(rtCfg.APIServer); err != nil {
+			return nil, err
+		}
 		restCFG.Host = rtCfg.APIServer
+		// The kubeconfig host and TLS server name describe the same endpoint. Clear
+		// an explicit server name so TLS verifies the configured API server host.
+		restCFG.TLSClientConfig.ServerName = ""
 	}
 	restCFG.QPS = defaultQPS
 	restCFG.Burst = defaultBurst
 	return restCFG, nil
+}
+
+func validateAPIServer(apiServer string) error {
+	parsedURL, err := url.ParseRequestURI(apiServer)
+	if err != nil {
+		return fmt.Errorf("invalid Kubernetes API server URL %q: %w", apiServer, err)
+	}
+	if parsedURL.Scheme != "https" {
+		return fmt.Errorf("invalid Kubernetes API server URL %q: scheme must be https", apiServer)
+	}
+	if parsedURL.Host == "" {
+		return fmt.Errorf("invalid Kubernetes API server URL %q: host is required", apiServer)
+	}
+	if parsedURL.User != nil || parsedURL.Path != "" || parsedURL.RawQuery != "" || parsedURL.Fragment != "" {
+		return fmt.Errorf("invalid Kubernetes API server URL %q: user info, path, query, and fragment are not supported", apiServer)
+	}
+	return nil
 }
 
 // BuildRuntimeOptions builds the options for the controller runtime based on config

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -14,10 +14,12 @@ import (
 )
 
 const (
+	flagAPIServer           = "apiserver"
 	flagKubeconfig          = "kubeconfig"
 	flagMetricsBindAddr     = "metrics-bind-addr"
 	flagHealthProbeBindAddr = "health-probe-bind-addr"
 
+	defaultAPIServer              = ""
 	defaultKubeconfig             = ""
 	defaultWatchNamespace         = corev1.NamespaceAll
 	defaultMetricsAddr            = ":8162"
@@ -36,6 +38,8 @@ type RuntimeConfig struct {
 }
 
 func (c *RuntimeConfig) BindFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&c.APIServer, flagAPIServer, defaultAPIServer,
+		"URL of the Kubernetes API server. Overrides the API server from the in-cluster config or kubeconfig.")
 	fs.StringVar(&c.KubeConfig, flagKubeconfig, defaultKubeconfig,
 		"Path to the kubeconfig file containing authorization and API server information.")
 	fs.StringVar(&c.MetricsBindAddress, flagMetricsBindAddr, defaultMetricsAddr,
@@ -56,6 +60,9 @@ func BuildRestConfig(rtCfg RuntimeConfig) (*rest.Config, error) {
 	}
 	if err != nil {
 		return nil, err
+	}
+	if rtCfg.APIServer != "" {
+		restCFG.Host = rtCfg.APIServer
 	}
 	restCFG.QPS = defaultQPS
 	restCFG.Burst = defaultBurst

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -52,6 +52,7 @@ func TestBuildRestConfig(t *testing.T) {
 		Clusters: map[string]*clientcmdapi.Cluster{
 			"test": {
 				Server:                   kubeconfigAPIServer,
+				TLSServerName:            "kubernetes-service.example.com",
 				CertificateAuthorityData: []byte(certificateData),
 			},
 		},
@@ -97,8 +98,51 @@ func TestBuildRestConfig(t *testing.T) {
 			assert.Equal(t, tt.expectedAPIServer, restConfig.Host)
 			assert.Equal(t, bearerToken, restConfig.BearerToken)
 			assert.Equal(t, []byte(certificateData), restConfig.CAData)
+			if tt.apiServer == "" {
+				assert.Equal(t, "kubernetes-service.example.com", restConfig.TLSClientConfig.ServerName)
+			} else {
+				assert.Empty(t, restConfig.TLSClientConfig.ServerName)
+			}
 			assert.Equal(t, float32(defaultQPS), restConfig.QPS)
 			assert.Equal(t, defaultBurst, restConfig.Burst)
+		})
+	}
+}
+
+func TestBuildRestConfigRejectsInvalidAPIServer(t *testing.T) {
+	kubeconfigPath := filepath.Join(t.TempDir(), "kubeconfig")
+	kubeconfig := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"test": {Server: "https://kubernetes-service.example.com"},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"test": {Cluster: "test"},
+		},
+		CurrentContext: "test",
+	}
+	require.NoError(t, clientcmd.WriteToFile(kubeconfig, kubeconfigPath))
+
+	tests := []struct {
+		name      string
+		apiServer string
+	}{
+		{name: "rejects HTTP", apiServer: "http://api.example.com"},
+		{name: "rejects unsupported scheme", apiServer: "tcp://api.example.com:443"},
+		{name: "rejects missing scheme", apiServer: "api.example.com"},
+		{name: "rejects path", apiServer: "https://api.example.com/proxy"},
+		{name: "rejects query", apiServer: "https://api.example.com?proxy=true"},
+		{name: "rejects user info", apiServer: "https://user@api.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := BuildRestConfig(RuntimeConfig{
+				APIServer:  tt.apiServer,
+				KubeConfig: kubeconfigPath,
+			})
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid Kubernetes API server URL")
 		})
 	}
 }

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestRuntimeConfigBindFlags(t *testing.T) {
+	tests := []struct {
+		name              string
+		args              []string
+		expectedAPIServer string
+	}{
+		{
+			name: "API server is empty by default",
+		},
+		{
+			name:              "API server can be configured",
+			args:              []string{"--apiserver", "https://api.example.com"},
+			expectedAPIServer: "https://api.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg RuntimeConfig
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			cfg.BindFlags(flags)
+
+			require.NoError(t, flags.Parse(tt.args))
+			assert.Equal(t, tt.expectedAPIServer, cfg.APIServer)
+		})
+	}
+}
+
+func TestBuildRestConfig(t *testing.T) {
+	const (
+		kubeconfigAPIServer = "https://kubernetes-service.example.com"
+		directAPIServer     = "https://direct-api.example.com"
+		bearerToken         = "service-account-token"
+		certificateData     = "cluster-ca"
+	)
+
+	kubeconfigPath := filepath.Join(t.TempDir(), "kubeconfig")
+	kubeconfig := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"test": {
+				Server:                   kubeconfigAPIServer,
+				CertificateAuthorityData: []byte(certificateData),
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"test": {
+				Token: bearerToken,
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"test": {
+				Cluster:  "test",
+				AuthInfo: "test",
+			},
+		},
+		CurrentContext: "test",
+	}
+	require.NoError(t, clientcmd.WriteToFile(kubeconfig, kubeconfigPath))
+
+	tests := []struct {
+		name              string
+		apiServer         string
+		expectedAPIServer string
+	}{
+		{
+			name:              "uses API server from kubeconfig by default",
+			expectedAPIServer: kubeconfigAPIServer,
+		},
+		{
+			name:              "overrides API server while preserving authentication",
+			apiServer:         directAPIServer,
+			expectedAPIServer: directAPIServer,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restConfig, err := BuildRestConfig(RuntimeConfig{
+				APIServer:  tt.apiServer,
+				KubeConfig: kubeconfigPath,
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedAPIServer, restConfig.Host)
+			assert.Equal(t, bearerToken, restConfig.BearerToken)
+			assert.Equal(t, []byte(certificateData), restConfig.CAData)
+			assert.Equal(t, float32(defaultQPS), restConfig.QPS)
+			assert.Equal(t, defaultBurst, restConfig.Burst)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add an optional `--apiserver` flag so the network policy agent can use a Kubernetes API endpoint that does not depend on kube-proxy programming the Kubernetes Service ClusterIP. The default behavior is unchanged.

Fixes #659.

## Changes

- Bind the existing `RuntimeConfig.APIServer` field to `--apiserver`.
- Build the REST config through the existing in-cluster or kubeconfig path, then override only its host so authentication and TLS settings are preserved.
- Document the flag and add focused tests for default behavior, flag parsing, host override, and credential/CA preservation.

## Test Plan

- [x] Focused unit tests exercise the runtime configuration entry point:

```console
$ go test ./pkg/config -count=1 -v
=== RUN   TestRuntimeConfigBindFlags
--- PASS: TestRuntimeConfigBindFlags (0.00s)
=== RUN   TestBuildRestConfig
--- PASS: TestBuildRestConfig (0.00s)
PASS
ok  github.com/aws/aws-network-policy-agent/pkg/config  0.628s
```

- [x] Focused static analysis:

```console
$ go vet ./pkg/config
```

- [x] Repository formatting check:

```console
$ make check-format
```

- [ ] Upstream Linux CI will run the complete build and test suite after a maintainer approves the first-time-contributor workflow run. The full package suite cannot run natively on the development host because unchanged eBPF/netlink dependencies are Linux-only.

Testbox is not applicable to this standalone upstream binary change: no deployment package currently exposes the new argument. The unit tests exercise the changed `BuildRestConfig` path directly; deployment-level validation belongs with the follow-up VPC CNI/add-on wiring.

## Deploy Plan

No direct deployment in this PR. A follow-up change in the VPC CNI/add-on deployment layer must supply the EKS API endpoint through `--apiserver` where this startup dependency needs to be avoided.
