### PR TITLE
Adding metrics into eagain failures and SDK bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.6
 
 require (
 	github.com/aws/amazon-vpc-cni-k8s v1.22.4
-	github.com/aws/aws-ebpf-sdk-go v1.0.16
+	github.com/aws/aws-ebpf-sdk-go v1.0.17
 	github.com/aws/aws-sdk-go-v2 v1.43.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.31
@@ -20,6 +20,7 @@ require (
 	github.com/onsi/gomega v1.39.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/samber/lo v1.52.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -77,7 +78,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/aws/amazon-vpc-cni-k8s v1.22.4 h1:040AzVL94vW4i9f8d5vz4tI83sKaxUM2KjB
 github.com/aws/amazon-vpc-cni-k8s v1.22.4/go.mod h1:H9f69VZbroA/1ns5LtTnoMA4vAdPghcgU0tIH5FX4+s=
 github.com/aws/amazon-vpc-resource-controller-k8s v1.7.18 h1:V/h33TgtVkR/1hkYVWU8RFD8i8h5G+xZ6eX9Hr0zKpk=
 github.com/aws/amazon-vpc-resource-controller-k8s v1.7.18/go.mod h1:iZa92r5f6vu42hQhyzrQa9UnxieNWcYmQ9DEKYMuXWo=
-github.com/aws/aws-ebpf-sdk-go v1.0.16 h1:g2cT+YTYKW/IITlM/Rq9r5ELsyul49FaF2aieGgZeI8=
-github.com/aws/aws-ebpf-sdk-go v1.0.16/go.mod h1:2v/brJqgaXZxyg2XzOPOQX8v0CL2gOlIzgP/mMPB00o=
+github.com/aws/aws-ebpf-sdk-go v1.0.17 h1:ghFTci/7PxhJzDZjozcUJxm6//SEAroUEJXENgOQy/E=
+github.com/aws/aws-ebpf-sdk-go v1.0.17/go.mod h1:2v/brJqgaXZxyg2XzOPOQX8v0CL2gOlIzgP/mMPB00o=
 github.com/aws/aws-sdk-go-v2 v1.43.0 h1:fharf/WhbRAVZ1du0QL7roNFxZ6T/sWr+4Ni617bwSI=
 github.com/aws/aws-sdk-go-v2 v1.43.0/go.mod h1:5pKeft2eJj+gElQ38Jqg4ibCqh+/AK33/0X3hip7IjM=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=

--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/ipamd/datastore"
 	goelf "github.com/aws/aws-ebpf-sdk-go/pkg/elfparser"
 	goebpfmaps "github.com/aws/aws-ebpf-sdk-go/pkg/maps"
+	goebpfmetrics "github.com/aws/aws-ebpf-sdk-go/pkg/metrics"
 	"github.com/aws/aws-ebpf-sdk-go/pkg/tc"
 	"github.com/aws/aws-network-policy-agent/pkg/ebpf/conntrack"
 	"github.com/aws/aws-network-policy-agent/pkg/ebpf/events"
@@ -80,6 +81,27 @@ var (
 		},
 		[]string{"fn"},
 	)
+
+	// The SDK retries BPF_PROG_LOAD on EAGAIN (verifier interrupted by a pending
+	// signal) transparently, so successful retries are
+	// invisible to sdkAPIErr. These CounterFuncs read the SDK's process-wide
+	// atomic counters so the race stays observable on the agent's /metrics.
+	sdkProgLoadEAGAINRetries = prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Name: "awsnodeagent_aws_ebpfsdk_prog_load_eagain_retries_total",
+			Help: "Cumulative BPF_PROG_LOAD attempts retried by the SDK after the verifier returned EAGAIN",
+		},
+		func() float64 { return float64(goebpfmetrics.ProgLoadEAGAINRetries()) },
+	)
+
+	sdkProgLoadEAGAINExhausted = prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Name: "awsnodeagent_aws_ebpfsdk_prog_load_eagain_exhausted_total",
+			Help: "Cumulative BPF_PROG_LOAD calls that exhausted all SDK retries on EAGAIN and were left unattached (enforcement gaps)",
+		},
+		func() float64 { return float64(goebpfmetrics.ProgLoadEAGAINExhausted()) },
+	)
+
 	prometheusRegistered = false
 )
 
@@ -95,6 +117,8 @@ func prometheusRegister() {
 	if !prometheusRegistered {
 		metrics.Registry.MustRegister(sdkAPILatency)
 		metrics.Registry.MustRegister(sdkAPIErr)
+		metrics.Registry.MustRegister(sdkProgLoadEAGAINRetries)
+		metrics.Registry.MustRegister(sdkProgLoadEAGAINExhausted)
 		prometheusRegistered = true
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A 

*Description of changes:*
SDK v1.0.17 introduced metrics that can be used to expose the kernel failures that happen during program load. This change initializes that metric so that can be used to report in NPA metrics



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
