### PR TITLE
fix(ebpf): close the attach-after-delete race that strands BPF pins

### DIFF
--- a/controllers/clusterpolicyendpoints_controller.go
+++ b/controllers/clusterpolicyendpoints_controller.go
@@ -257,10 +257,16 @@ func (r *ClusterPolicyEndpointsReconciler) configureClusterPolicyBPFProbes(podId
 			continue
 		}
 
-		err := r.ebpfClient.AttacheBPFProbes(pod.NamespacedName, podIdentifier, ebpf.INTERFACE_COUNT_UNKNOWN)
+		// podConfirmedLive=false: this work list comes from PolicyEndpoint caches,
+		// which can still name pods that no longer exist on the node.
+		attached, err := r.ebpfClient.AttacheBPFProbes(pod.NamespacedName, podIdentifier, ebpf.INTERFACE_COUNT_UNKNOWN, false)
 		if err != nil {
 			log().Errorf("Failed to attach eBPF probes for pod %s namespace %s : %v", pod.Name, pod.Namespace, err)
 			return err
+		}
+		if !attached {
+			log().Debugf("Skipped eBPF probe attach for deleted pod: %s in namespace %s", pod.Name, pod.Namespace)
+			continue
 		}
 		log().Infof("Successfully attached required eBPF probes for pod: %s in namespace %s", pod.Name, pod.Namespace)
 	}

--- a/controllers/clusterpolicyendpoints_controller.go
+++ b/controllers/clusterpolicyendpoints_controller.go
@@ -259,14 +259,15 @@ func (r *ClusterPolicyEndpointsReconciler) configureClusterPolicyBPFProbes(podId
 
 		// podConfirmedLive=false: this work list comes from PolicyEndpoint caches,
 		// which can still name pods that no longer exist on the node.
-		attached, err := r.ebpfClient.AttacheBPFProbes(pod.NamespacedName, podIdentifier, ebpf.INTERFACE_COUNT_UNKNOWN, false)
-		if err != nil {
+		if err := r.ebpfClient.AttacheBPFProbes(pod.NamespacedName, podIdentifier, ebpf.INTERFACE_COUNT_UNKNOWN, false); err != nil {
+			// A deleted pod is expected here, not a failure: work lists come from
+			// PolicyEndpoint caches that can still name pods that are already gone.
+			if errors.Is(err, ebpf.ErrAttachSkippedPodDeleted) {
+				log().Debugf("Skipped eBPF probe attach for deleted pod: %s in namespace %s", pod.Name, pod.Namespace)
+				continue
+			}
 			log().Errorf("Failed to attach eBPF probes for pod %s namespace %s : %v", pod.Name, pod.Namespace, err)
 			return err
-		}
-		if !attached {
-			log().Debugf("Skipped eBPF probe attach for deleted pod: %s in namespace %s", pod.Name, pod.Namespace)
-			continue
 		}
 		log().Infof("Successfully attached required eBPF probes for pod: %s in namespace %s", pod.Name, pod.Namespace)
 	}

--- a/controllers/policyendpoints_controller.go
+++ b/controllers/policyendpoints_controller.go
@@ -356,10 +356,16 @@ func (r *PolicyEndpointsReconciler) configureeBPFProbes(ctx context.Context, pod
 			continue
 		}
 
-		err := r.ebpfClient.AttacheBPFProbes(pod.NamespacedName, podIdentifier, ebpf.INTERFACE_COUNT_UNKNOWN)
+		// podConfirmedLive=false: this work list comes from PolicyEndpoint caches,
+		// which can still name pods that no longer exist on the node.
+		attached, err := r.ebpfClient.AttacheBPFProbes(pod.NamespacedName, podIdentifier, ebpf.INTERFACE_COUNT_UNKNOWN, false)
 		if err != nil {
 			log().Errorf("Failed to attach eBPF probes for pod %s namespace %s : %v", pod.Name, pod.Namespace, err)
 			return err
+		}
+		if !attached {
+			log().Debugf("Skipped eBPF probe attach for deleted pod: %s in namespace %s", pod.Name, pod.Namespace)
+			continue
 		}
 		log().Infof("Successfully attached required eBPF probes for pod: %s in namespace %s", pod.Name, pod.Namespace)
 	}

--- a/controllers/policyendpoints_controller.go
+++ b/controllers/policyendpoints_controller.go
@@ -358,14 +358,15 @@ func (r *PolicyEndpointsReconciler) configureeBPFProbes(ctx context.Context, pod
 
 		// podConfirmedLive=false: this work list comes from PolicyEndpoint caches,
 		// which can still name pods that no longer exist on the node.
-		attached, err := r.ebpfClient.AttacheBPFProbes(pod.NamespacedName, podIdentifier, ebpf.INTERFACE_COUNT_UNKNOWN, false)
-		if err != nil {
+		if err := r.ebpfClient.AttacheBPFProbes(pod.NamespacedName, podIdentifier, ebpf.INTERFACE_COUNT_UNKNOWN, false); err != nil {
+			// A deleted pod is expected here, not a failure: work lists come from
+			// PolicyEndpoint caches that can still name pods that are already gone.
+			if errors.Is(err, ebpf.ErrAttachSkippedPodDeleted) {
+				log().Debugf("Skipped eBPF probe attach for deleted pod: %s in namespace %s", pod.Name, pod.Namespace)
+				continue
+			}
 			log().Errorf("Failed to attach eBPF probes for pod %s namespace %s : %v", pod.Name, pod.Namespace, err)
 			return err
-		}
-		if !attached {
-			log().Debugf("Skipped eBPF probe attach for deleted pod: %s in namespace %s", pod.Name, pod.Namespace)
-			continue
 		}
 		log().Infof("Successfully attached required eBPF probes for pod: %s in namespace %s", pod.Name, pod.Namespace)
 	}

--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -124,6 +124,26 @@ func initAttachSuppressionSeries() {
 	attachSuppressedPodDeleted.WithLabelValues(suppressionStagePostLock)
 }
 
+// Number of mutexes shared across podIdentifiers. Not a limit on identifiers:
+// they are hashed onto these locks, so two identifiers may share one and simply
+// serialize against each other, which is always safe.
+const podIdentifierLockShards = 256
+
+// lockFor returns the mutex guarding podIdentifier's critical section.
+func (l *bpfClient) lockFor(podIdentifier string) *sync.Mutex {
+	return &l.podIdentifierLocks[shardIndex(podIdentifier)]
+}
+
+// shardIndex is FNV-1a inlined to avoid allocating a hash.Hash per call.
+func shardIndex(s string) uint32 {
+	h := uint32(2166136261)
+	for i := 0; i < len(s); i++ {
+		h ^= uint32(s[i])
+		h *= 16777619
+	}
+	return h % podIdentifierLockShards
+}
+
 // ErrAttachSkippedPodDeleted is returned when an attach is deliberately not
 // performed because the pod is already deleted. It is an outcome, not a failure:
 // reconcilers should skip such a pod, while a CNI ADD caller must treat it as an
@@ -370,10 +390,10 @@ type bpfClient struct {
 	ingressProgToPodsMap *sync.Map
 	// Stores the Egress eBPF Prog FD to pods mapping
 	egressProgToPodsMap *sync.Map
-	// podIdentifier -> operations lock. Entries are never removed: deleting one
-	// while held lets the next caller mint a second mutex for the same identifier
-	// and enter concurrently. By value, so the zero bpfClient is usable.
-	podIdentifierLock sync.Map
+	// Locks guarding per-podIdentifier critical sections, sharded over a fixed
+	// array: nothing is allocated or removed, so a lock can never be deleted while
+	// a goroutine holds or waits for it. See lockFor.
+	podIdentifierLocks [podIdentifierLockShards]sync.Mutex
 	// This is only updated and used for probe binary updates during initialization
 	interfaceNametoIngressPinPath map[string]string
 	// This is only updated and used for probe binary updates during initialization
@@ -781,8 +801,7 @@ func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier str
 
 	// Two go routines can try to attach the probes at the same time
 	// Locking will help updating all the datastructures correctly
-	value, _ := l.podIdentifierLock.LoadOrStore(podIdentifier, &sync.Mutex{})
-	podIdentifierLock := value.(*sync.Mutex)
+	podIdentifierLock := l.lockFor(podIdentifier)
 	podIdentifierLock.Lock()
 	log().Debugf("Got the podIdentifierLock for Pod: %s, Namespace: %s, PodIdentifier: %s", pod.Name, pod.Namespace, podIdentifier)
 	defer podIdentifierLock.Unlock()
@@ -970,8 +989,7 @@ func (l *bpfClient) HasBPFContext(podIdentifier string) bool {
 }
 
 func (l *bpfClient) DeleteBPFProbes(pod types.NamespacedName, podIdentifier string) error {
-	value, _ := l.podIdentifierLock.LoadOrStore(podIdentifier, &sync.Mutex{})
-	podIdentifierLock := value.(*sync.Mutex)
+	podIdentifierLock := l.lockFor(podIdentifier)
 	podIdentifierLock.Lock()
 	defer podIdentifierLock.Unlock()
 	log().Debugf("Got the podIdentifierLock for Pod: %s Namespace: %s PodIdentifier: %s", pod.Name, pod.Namespace, podIdentifier)
@@ -987,9 +1005,8 @@ func (l *bpfClient) DeleteBPFProbes(pod types.NamespacedName, podIdentifier stri
 			log().Errorf("BPF programs and Maps delete failed for podIdentifier: %s, error: %v", podIdentifier, err)
 			return err
 		}
-		// Deliberately no podIdentifierLock.Delete: removing an entry while holding it
-		// lets the next caller create a second mutex for this identifier and enter
-		// concurrently, breaking the re-check above and the plain-map writes below.
+		// No lock cleanup here: locks are a fixed shard array, never allocated per
+		// identifier, so there is nothing that could be removed while still in use.
 	}
 	return nil
 }

--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -102,7 +102,27 @@ var (
 		func() float64 { return float64(goebpfmetrics.ProgLoadEAGAINExhausted()) },
 	)
 
+	// AttacheBPFProbes suppresses an attach when the pod is known to have been
+	// deleted. Both suppression points log at Debug, which is off in production,
+	// so without this counter there is no way to tell "never needed" from
+	// "firing constantly". The stage label distinguishes the cheap pre-lock
+	// check from the post-lock re-check that closes the attach-after-delete
+	// race; a non-zero post_lock rate proves that race occurs in the field.
+	attachSuppressedPodDeleted = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "awsnodeagent_attach_suppressed_pod_deleted_total",
+			Help: "Attach attempts suppressed because the pod was already deleted, by the check that caught it",
+		},
+		[]string{"stage"},
+	)
+
 	prometheusRegistered = false
+)
+
+// Stages reported by the attachSuppressedPodDeleted counter.
+const (
+	suppressionStagePreLock  = "pre_lock"
+	suppressionStagePostLock = "post_lock"
 )
 
 type pod_state struct {
@@ -119,12 +139,13 @@ func prometheusRegister() {
 		metrics.Registry.MustRegister(sdkAPIErr)
 		metrics.Registry.MustRegister(sdkProgLoadEAGAINRetries)
 		metrics.Registry.MustRegister(sdkProgLoadEAGAINExhausted)
+		metrics.Registry.MustRegister(attachSuppressedPodDeleted)
 		prometheusRegistered = true
 	}
 }
 
 type BpfClient interface {
-	AttacheBPFProbes(pod types.NamespacedName, podIdentifier string, numInterfaces int) error
+	AttacheBPFProbes(pod types.NamespacedName, podIdentifier string, numInterfaces int, podConfirmedLive bool) (bool, error)
 	DeleteBPFProbes(pod types.NamespacedName, podIdentifier string) error
 	UpdateClusterPolicyEbpfMaps(podIdentifier string, ingressFirewallRules []fwrp.EbpfFirewallRules, egressFirewallRules []fwrp.EbpfFirewallRules) error
 	UpdateEbpfMaps(podIdentifier string, ingressFirewallRules []fwrp.EbpfFirewallRules, egressFirewallRules []fwrp.EbpfFirewallRules) error
@@ -155,7 +176,6 @@ func NewBpfClient(ctx context.Context, nodeIP string, enablePolicyEventLogs, ena
 		globalMaps:                      new(sync.Map),
 		ingressProgToPodsMap:            new(sync.Map),
 		egressProgToPodsMap:             new(sync.Map),
-		podIdentifierLock:               new(sync.Map),
 		podNameToInterfaceCount:         new(sync.Map),
 		networkPolicyMode:               networkPolicyMode,
 		isMultiNICEnabled:               isMultiNICEnabled,
@@ -338,8 +358,11 @@ type bpfClient struct {
 	ingressProgToPodsMap *sync.Map
 	// Stores the Egress eBPF Prog FD to pods mapping
 	egressProgToPodsMap *sync.Map
-	// Stores podIdentifier to operations lock mapping
-	podIdentifierLock *sync.Map
+	// Stores podIdentifier to operations lock mapping. Entries are never removed:
+	// deleting one while a goroutine holds it lets the next caller mint a second
+	// mutex for the same identifier and enter the critical section concurrently.
+	// Held by value so the zero bpfClient is usable and no caller can leave it nil.
+	podIdentifierLock sync.Map
 	// This is only updated and used for probe binary updates during initialization
 	interfaceNametoIngressPinPath map[string]string
 	// This is only updated and used for probe binary updates during initialization
@@ -711,15 +734,44 @@ func (l *bpfClient) getInterfaceCountForPod(pod types.NamespacedName, podIdentif
 	return 0, errors.New("Skipping probe attach: multiNIC enabled and interface count is unknown")
 }
 
-func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier string, numInterfaces int) error {
+// suppressAttachForDeletedPod reports whether podNamespacedName carries a
+// deletion tombstone, counting and logging the suppression against the check
+// that caught it.
+func (l *bpfClient) suppressAttachForDeletedPod(pod types.NamespacedName, podIdentifier, podNamespacedName, stage string) bool {
+	if _, deleted := l.deletedPods.Load(podNamespacedName); !deleted {
+		return false
+	}
+	attachSuppressedPodDeleted.WithLabelValues(stage).Inc()
+	log().Debugf("ignoring attaching ebpf probe to pod %s in namespace %s with pod identifier %s: deleted (detected at %s check)",
+		pod.Name, pod.Namespace, podIdentifier, stage)
+	return true
+}
+
+// AttacheBPFProbes attaches the ingress and egress TC probes for pod.
+//
+// podConfirmedLive tells the client the caller has authoritative evidence the
+// pod exists right now -- in practice, a CNI ADD arriving over the Enforce RPC.
+// Such a caller clears any deletion tombstone (under the same lock that writes
+// it) and is never skipped, because skipping a live pod would leave it with no
+// probes and therefore unenforced. Reconciler callers pass false: they derive
+// their work list from PolicyEndpoint caches that can name pods which no longer
+// exist, so for them a tombstone must veto the attach.
+//
+// The first return value reports whether probes are attached for the pod when
+// the call returns -- false means the attach was deliberately skipped. Callers
+// must not treat a skip as success: skipped is not an error, but it is also not
+// "programmed".
+func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier string, numInterfaces int, podConfirmedLive bool) (bool, error) {
 	var ingressProgFD int
 	var egressProgFD int
 
 	podNamespacedName := utils.GetPodNamespacedName(pod.Name, pod.Namespace)
 
-	if _, deleted := l.deletedPods.Load(podNamespacedName); deleted {
-		log().Debugf("ignoring attaching ebpf probe to pod %s in namespace %s with pod identifier %s as it is already deleted", pod.Name, pod.Namespace, podIdentifier)
-		return nil
+	// Cheap pre-lock check: a pod tombstoned before we even contend for the lock
+	// needs no further work. This is an optimization only -- correctness comes
+	// from the re-check below.
+	if !podConfirmedLive && l.suppressAttachForDeletedPod(pod, podIdentifier, podNamespacedName, suppressionStagePreLock) {
+		return false, nil
 	}
 
 	// Two go routines can try to attach the probes at the same time
@@ -730,17 +782,35 @@ func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier str
 	log().Debugf("Got the podIdentifierLock for Pod: %s, Namespace: %s, PodIdentifier: %s", pod.Name, pod.Namespace, podIdentifier)
 	defer podIdentifierLock.Unlock()
 
+	if podConfirmedLive {
+		// The pod demonstrably exists, so any tombstone is stale -- it belongs to a
+		// previous pod that reused this name, or to a DEL that raced this ADD. Drop
+		// it here, under the lock that DeleteBPFProbes uses to write it, so no
+		// concurrent delete can reinstate it between this point and the attach.
+		l.deletedPods.Delete(podNamespacedName)
+	} else if l.suppressAttachForDeletedPod(pod, podIdentifier, podNamespacedName, suppressionStagePostLock) {
+		// Re-check the tombstone now that we hold podIdentifierLock. DeleteBPFProbes
+		// records it while holding this same lock, so the pre-lock check above can be
+		// stale: a delete may have completed while we were blocked here. Attaching in
+		// that window re-inserts the pod into the shared progFD -> pods set, and
+		// nothing removes it again because no further CNI DEL arrives for a pod that
+		// is already torn down. The stale entry keeps isProgFdShared true for the last
+		// remaining pod of this podIdentifier, so its programs and maps are never
+		// unpinned and the pins leak permanently.
+		return false, nil
+	}
+
 	// Check if an eBPF probe is already attached on both ingress and egress direction(s) for this pod.
 	// If yes, then skip probe attach flow for this pod.
 	isIngressProbeAttached, isEgressProbeAttached := l.isEBPFProbeAttached(pod.Name, pod.Namespace)
 	if isIngressProbeAttached && isEgressProbeAttached {
-		return nil
+		return true, nil
 	}
 
 	// Determine the actual number of interfaces to attach probes to
 	actualInterfaceCount, err := l.getInterfaceCountForPod(pod, podIdentifier, numInterfaces)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	numInterfaces = actualInterfaceCount
@@ -751,7 +821,7 @@ func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier str
 		hostVethName, err := utils.GetHostVethName(pod.Name, pod.Namespace, index, []string{POD_VETH_PREFIX, BRANCH_ENI_VETH_PREFIX})
 		if err != nil {
 			log().Warnf("Failed to attach ebpf probes for pod %s in namespace %s. Pod might have been deleted", pod.Name, pod.Namespace)
-			return err
+			return false, err
 		}
 
 		log().Infof("AttacheBPFProbes for pod %s in namespace %s with hostVethName %s at interface %d", pod.Name, pod.Namespace, hostVethName, index)
@@ -764,7 +834,7 @@ func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier str
 			if err != nil {
 				log().Errorf("Failed to Attach Ingress TC probe for pod: %s in namespace %s at interface %d error: %v", pod.Name, pod.Namespace, index, err)
 				sdkAPIErr.WithLabelValues("attachIngressBPFProbe").Inc()
-				return err
+				return false, err
 			}
 			log().Infof("Successfully attached Ingress TC probe for pod: %s in namespace %s at interface %d", pod.Name, pod.Namespace, index)
 		}
@@ -777,7 +847,7 @@ func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier str
 			if err != nil {
 				log().Errorf("Failed to Attach Egress TC probe for pod: %s in namespace %s at interface %d error: %v", pod.Name, pod.Namespace, index, err)
 				sdkAPIErr.WithLabelValues("attachEgressBPFProbe").Inc()
-				return err
+				return false, err
 			}
 			log().Infof("Successfully attached Egress TC probe for pod: %s in namespace %s at interface %d", pod.Name, pod.Namespace, index)
 		}
@@ -793,7 +863,7 @@ func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier str
 		currentPodSet, _ := l.egressProgToPodsMap.LoadOrStore(egressProgFD, make(map[string]struct{}))
 		currentPodSet.(map[string]struct{})[podNamespacedName] = struct{}{}
 	}
-	return nil
+	return true, nil
 }
 
 func (l *bpfClient) attachIngressBPFProbe(hostVethName string, podIdentifier string) (int, error) {
@@ -918,7 +988,13 @@ func (l *bpfClient) DeleteBPFProbes(pod types.NamespacedName, podIdentifier stri
 			log().Errorf("BPF programs and Maps delete failed for podIdentifier: %s, error: %v", podIdentifier, err)
 			return err
 		}
-		l.podIdentifierLock.Delete(podIdentifier)
+		// Deliberately no podIdentifierLock.Delete here. Dropping the entry while
+		// this goroutine still holds the mutex lets the next caller create a second
+		// mutex for the same podIdentifier and enter the critical section
+		// concurrently -- which breaks the mutual exclusion that the deletedPods
+		// re-check above depends on, and makes concurrent writes to the plain maps
+		// inside ingress/egressProgToPodsMap reachable ("fatal error: concurrent
+		// map writes").
 	}
 	return nil
 }
@@ -1366,13 +1442,14 @@ func (l *bpfClient) isProgFdShared(targetPodName string, targetPodNamespace stri
 	if targetProgFD, ok := l.ingressPodToProgMap.Load(targetpodNamespacedName); ok {
 		if currentList, ok := l.ingressProgToPodsMap.Load(targetProgFD); ok {
 			podsList, ok := currentList.(map[string]struct{})
-			if ok {
-				if len(podsList) > 1 {
-					log().Debugf("Found shared ingress progFD for target: %s, progFD: %d", targetPodName, targetProgFD)
-					return true, nil
-				}
-				return false, nil // Not shared (only one pod)
+			if !ok {
+				return false, fmt.Errorf("unexpected type in ingressProgToPodsMap for progFD %v", targetProgFD)
 			}
+			if len(podsList) > 1 {
+				log().Debugf("Found shared ingress progFD for target: %s, progFD: %d", targetPodName, targetProgFD)
+				return true, nil
+			}
+			return false, nil // Not shared (only one pod)
 		}
 	}
 
@@ -1380,13 +1457,14 @@ func (l *bpfClient) isProgFdShared(targetPodName string, targetPodNamespace stri
 	if targetProgFD, ok := l.egressPodToProgMap.Load(targetpodNamespacedName); ok {
 		if currentList, ok := l.egressProgToPodsMap.Load(targetProgFD); ok {
 			podsList, ok := currentList.(map[string]struct{})
-			if ok {
-				if len(podsList) > 1 {
-					log().Debugf("Found shared egress progFD for target: %s, progFD: %d", targetPodName, targetProgFD)
-					return true, nil
-				}
-				return false, nil // Not shared (only one pod)
+			if !ok {
+				return false, fmt.Errorf("unexpected type in egressProgToPodsMap for progFD %v", targetProgFD)
 			}
+			if len(podsList) > 1 {
+				log().Debugf("Found shared egress progFD for target: %s, progFD: %d", targetPodName, targetProgFD)
+				return true, nil
+			}
+			return false, nil // Not shared (only one pod)
 		}
 	}
 

--- a/pkg/ebpf/bpf_client.go
+++ b/pkg/ebpf/bpf_client.go
@@ -102,12 +102,9 @@ var (
 		func() float64 { return float64(goebpfmetrics.ProgLoadEAGAINExhausted()) },
 	)
 
-	// AttacheBPFProbes suppresses an attach when the pod is known to have been
-	// deleted. Both suppression points log at Debug, which is off in production,
-	// so without this counter there is no way to tell "never needed" from
-	// "firing constantly". The stage label distinguishes the cheap pre-lock
-	// check from the post-lock re-check that closes the attach-after-delete
-	// race; a non-zero post_lock rate proves that race occurs in the field.
+	// Suppressed attaches, by the check that caught them. Both suppression points
+	// log at Debug (off in production), so this is the only production-visible
+	// evidence; a non-zero post_lock rate proves the race occurs in the field.
 	attachSuppressedPodDeleted = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "awsnodeagent_attach_suppressed_pod_deleted_total",
@@ -118,6 +115,20 @@ var (
 
 	prometheusRegistered = false
 )
+
+// A CounterVec exports nothing for a label until first used, so touch both:
+// otherwise the metric is absent from /metrics until the first suppression, and
+// "no suppressions" is indistinguishable from "this build lacks the metric".
+func initAttachSuppressionSeries() {
+	attachSuppressedPodDeleted.WithLabelValues(suppressionStagePreLock)
+	attachSuppressedPodDeleted.WithLabelValues(suppressionStagePostLock)
+}
+
+// ErrAttachSkippedPodDeleted is returned when an attach is deliberately not
+// performed because the pod is already deleted. It is an outcome, not a failure:
+// reconcilers should skip such a pod, while a CNI ADD caller must treat it as an
+// error rather than reporting a live pod as enforced.
+var ErrAttachSkippedPodDeleted = errors.New("attach skipped: pod already deleted")
 
 // Stages reported by the attachSuppressedPodDeleted counter.
 const (
@@ -140,12 +151,13 @@ func prometheusRegister() {
 		metrics.Registry.MustRegister(sdkProgLoadEAGAINRetries)
 		metrics.Registry.MustRegister(sdkProgLoadEAGAINExhausted)
 		metrics.Registry.MustRegister(attachSuppressedPodDeleted)
+		initAttachSuppressionSeries()
 		prometheusRegistered = true
 	}
 }
 
 type BpfClient interface {
-	AttacheBPFProbes(pod types.NamespacedName, podIdentifier string, numInterfaces int, podConfirmedLive bool) (bool, error)
+	AttacheBPFProbes(pod types.NamespacedName, podIdentifier string, numInterfaces int, podConfirmedLive bool) error
 	DeleteBPFProbes(pod types.NamespacedName, podIdentifier string) error
 	UpdateClusterPolicyEbpfMaps(podIdentifier string, ingressFirewallRules []fwrp.EbpfFirewallRules, egressFirewallRules []fwrp.EbpfFirewallRules) error
 	UpdateEbpfMaps(podIdentifier string, ingressFirewallRules []fwrp.EbpfFirewallRules, egressFirewallRules []fwrp.EbpfFirewallRules) error
@@ -358,10 +370,9 @@ type bpfClient struct {
 	ingressProgToPodsMap *sync.Map
 	// Stores the Egress eBPF Prog FD to pods mapping
 	egressProgToPodsMap *sync.Map
-	// Stores podIdentifier to operations lock mapping. Entries are never removed:
-	// deleting one while a goroutine holds it lets the next caller mint a second
-	// mutex for the same identifier and enter the critical section concurrently.
-	// Held by value so the zero bpfClient is usable and no caller can leave it nil.
+	// podIdentifier -> operations lock. Entries are never removed: deleting one
+	// while held lets the next caller mint a second mutex for the same identifier
+	// and enter concurrently. By value, so the zero bpfClient is usable.
 	podIdentifierLock sync.Map
 	// This is only updated and used for probe binary updates during initialization
 	interfaceNametoIngressPinPath map[string]string
@@ -749,19 +760,13 @@ func (l *bpfClient) suppressAttachForDeletedPod(pod types.NamespacedName, podIde
 
 // AttacheBPFProbes attaches the ingress and egress TC probes for pod.
 //
-// podConfirmedLive tells the client the caller has authoritative evidence the
-// pod exists right now -- in practice, a CNI ADD arriving over the Enforce RPC.
-// Such a caller clears any deletion tombstone (under the same lock that writes
-// it) and is never skipped, because skipping a live pod would leave it with no
-// probes and therefore unenforced. Reconciler callers pass false: they derive
-// their work list from PolicyEndpoint caches that can name pods which no longer
-// exist, so for them a tombstone must veto the attach.
+// podConfirmedLive means the caller has proof the pod exists (a CNI ADD): any
+// tombstone is stale, is cleared under the lock, and the attach is never skipped.
+// Reconcilers pass false -- their work lists can name pods that are already gone.
 //
-// The first return value reports whether probes are attached for the pod when
-// the call returns -- false means the attach was deliberately skipped. Callers
-// must not treat a skip as success: skipped is not an error, but it is also not
-// "programmed".
-func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier string, numInterfaces int, podConfirmedLive bool) (bool, error) {
+// Returns ErrAttachSkippedPodDeleted when the attach was deliberately skipped
+// because the pod is gone; callers decide whether that is acceptable.
+func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier string, numInterfaces int, podConfirmedLive bool) error {
 	var ingressProgFD int
 	var egressProgFD int
 
@@ -771,7 +776,7 @@ func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier str
 	// needs no further work. This is an optimization only -- correctness comes
 	// from the re-check below.
 	if !podConfirmedLive && l.suppressAttachForDeletedPod(pod, podIdentifier, podNamespacedName, suppressionStagePreLock) {
-		return false, nil
+		return ErrAttachSkippedPodDeleted
 	}
 
 	// Two go routines can try to attach the probes at the same time
@@ -783,34 +788,28 @@ func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier str
 	defer podIdentifierLock.Unlock()
 
 	if podConfirmedLive {
-		// The pod demonstrably exists, so any tombstone is stale -- it belongs to a
-		// previous pod that reused this name, or to a DEL that raced this ADD. Drop
-		// it here, under the lock that DeleteBPFProbes uses to write it, so no
-		// concurrent delete can reinstate it between this point and the attach.
+		// The pod exists, so any tombstone is stale (a reused name, or a DEL racing
+		// this ADD). Drop it under the same lock DeleteBPFProbes writes it with, so
+		// no concurrent delete can reinstate it before the attach.
 		l.deletedPods.Delete(podNamespacedName)
 	} else if l.suppressAttachForDeletedPod(pod, podIdentifier, podNamespacedName, suppressionStagePostLock) {
-		// Re-check the tombstone now that we hold podIdentifierLock. DeleteBPFProbes
-		// records it while holding this same lock, so the pre-lock check above can be
-		// stale: a delete may have completed while we were blocked here. Attaching in
-		// that window re-inserts the pod into the shared progFD -> pods set, and
-		// nothing removes it again because no further CNI DEL arrives for a pod that
-		// is already torn down. The stale entry keeps isProgFdShared true for the last
-		// remaining pod of this podIdentifier, so its programs and maps are never
-		// unpinned and the pins leak permanently.
-		return false, nil
+		// Re-check under the lock, since DeleteBPFProbes writes the tombstone holding
+		// it. Attaching in that window re-inserts a dead pod into the shared
+		// progFD -> pods set, keeping isProgFdShared true and leaking the pins.
+		return ErrAttachSkippedPodDeleted
 	}
 
 	// Check if an eBPF probe is already attached on both ingress and egress direction(s) for this pod.
 	// If yes, then skip probe attach flow for this pod.
 	isIngressProbeAttached, isEgressProbeAttached := l.isEBPFProbeAttached(pod.Name, pod.Namespace)
 	if isIngressProbeAttached && isEgressProbeAttached {
-		return true, nil
+		return nil
 	}
 
 	// Determine the actual number of interfaces to attach probes to
 	actualInterfaceCount, err := l.getInterfaceCountForPod(pod, podIdentifier, numInterfaces)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	numInterfaces = actualInterfaceCount
@@ -821,7 +820,7 @@ func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier str
 		hostVethName, err := utils.GetHostVethName(pod.Name, pod.Namespace, index, []string{POD_VETH_PREFIX, BRANCH_ENI_VETH_PREFIX})
 		if err != nil {
 			log().Warnf("Failed to attach ebpf probes for pod %s in namespace %s. Pod might have been deleted", pod.Name, pod.Namespace)
-			return false, err
+			return err
 		}
 
 		log().Infof("AttacheBPFProbes for pod %s in namespace %s with hostVethName %s at interface %d", pod.Name, pod.Namespace, hostVethName, index)
@@ -834,7 +833,7 @@ func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier str
 			if err != nil {
 				log().Errorf("Failed to Attach Ingress TC probe for pod: %s in namespace %s at interface %d error: %v", pod.Name, pod.Namespace, index, err)
 				sdkAPIErr.WithLabelValues("attachIngressBPFProbe").Inc()
-				return false, err
+				return err
 			}
 			log().Infof("Successfully attached Ingress TC probe for pod: %s in namespace %s at interface %d", pod.Name, pod.Namespace, index)
 		}
@@ -847,7 +846,7 @@ func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier str
 			if err != nil {
 				log().Errorf("Failed to Attach Egress TC probe for pod: %s in namespace %s at interface %d error: %v", pod.Name, pod.Namespace, index, err)
 				sdkAPIErr.WithLabelValues("attachEgressBPFProbe").Inc()
-				return false, err
+				return err
 			}
 			log().Infof("Successfully attached Egress TC probe for pod: %s in namespace %s at interface %d", pod.Name, pod.Namespace, index)
 		}
@@ -863,7 +862,7 @@ func (l *bpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier str
 		currentPodSet, _ := l.egressProgToPodsMap.LoadOrStore(egressProgFD, make(map[string]struct{}))
 		currentPodSet.(map[string]struct{})[podNamespacedName] = struct{}{}
 	}
-	return true, nil
+	return nil
 }
 
 func (l *bpfClient) attachIngressBPFProbe(hostVethName string, podIdentifier string) (int, error) {
@@ -988,13 +987,9 @@ func (l *bpfClient) DeleteBPFProbes(pod types.NamespacedName, podIdentifier stri
 			log().Errorf("BPF programs and Maps delete failed for podIdentifier: %s, error: %v", podIdentifier, err)
 			return err
 		}
-		// Deliberately no podIdentifierLock.Delete here. Dropping the entry while
-		// this goroutine still holds the mutex lets the next caller create a second
-		// mutex for the same podIdentifier and enter the critical section
-		// concurrently -- which breaks the mutual exclusion that the deletedPods
-		// re-check above depends on, and makes concurrent writes to the plain maps
-		// inside ingress/egressProgToPodsMap reachable ("fatal error: concurrent
-		// map writes").
+		// Deliberately no podIdentifierLock.Delete: removing an entry while holding it
+		// lets the next caller create a second mutex for this identifier and enter
+		// concurrently, breaking the re-check above and the plain-map writes below.
 	}
 	return nil
 }

--- a/pkg/ebpf/bpf_client_mock.go
+++ b/pkg/ebpf/bpf_client_mock.go
@@ -45,18 +45,21 @@ type MockBpfClient struct {
 	// podIdentifiers with no registered eBPF context. Empty by default so HasBPFContext
 	// reports true, preserving the original success-path behavior.
 	PodIdentifiersWithoutBPFContext map[string]bool
-	// AttachSkipped makes AttacheBPFProbes report that it deliberately skipped the
-	// attach (pod already deleted) instead of attaching.
+	// AttachSkipped makes AttacheBPFProbes return ErrAttachSkippedPodDeleted
+	// instead of attaching.
 	AttachSkipped bool
 	// LastAttachPodConfirmedLive records the podConfirmedLive argument of the most
 	// recent AttacheBPFProbes call.
 	LastAttachPodConfirmedLive bool
 }
 
-func (m *MockBpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier string, numInterfaces int, podConfirmedLive bool) (bool, error) {
+func (m *MockBpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier string, numInterfaces int, podConfirmedLive bool) error {
 	m.CallLog = append(m.CallLog, "AttacheBPFProbes")
 	m.LastAttachPodConfirmedLive = podConfirmedLive
-	return !m.AttachSkipped, nil
+	if m.AttachSkipped {
+		return ErrAttachSkippedPodDeleted
+	}
+	return nil
 }
 
 func (m *MockBpfClient) DeleteBPFProbes(pod types.NamespacedName, podIdentifier string) error {

--- a/pkg/ebpf/bpf_client_mock.go
+++ b/pkg/ebpf/bpf_client_mock.go
@@ -45,11 +45,18 @@ type MockBpfClient struct {
 	// podIdentifiers with no registered eBPF context. Empty by default so HasBPFContext
 	// reports true, preserving the original success-path behavior.
 	PodIdentifiersWithoutBPFContext map[string]bool
+	// AttachSkipped makes AttacheBPFProbes report that it deliberately skipped the
+	// attach (pod already deleted) instead of attaching.
+	AttachSkipped bool
+	// LastAttachPodConfirmedLive records the podConfirmedLive argument of the most
+	// recent AttacheBPFProbes call.
+	LastAttachPodConfirmedLive bool
 }
 
-func (m *MockBpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier string, numInterfaces int) error {
+func (m *MockBpfClient) AttacheBPFProbes(pod types.NamespacedName, podIdentifier string, numInterfaces int, podConfirmedLive bool) (bool, error) {
 	m.CallLog = append(m.CallLog, "AttacheBPFProbes")
-	return nil
+	m.LastAttachPodConfirmedLive = podConfirmedLive
+	return !m.AttachSkipped, nil
 }
 
 func (m *MockBpfClient) DeleteBPFProbes(pod types.NamespacedName, podIdentifier string) error {

--- a/pkg/ebpf/bpf_client_test.go
+++ b/pkg/ebpf/bpf_client_test.go
@@ -1100,6 +1100,32 @@ func TestIsProgFdShared(t *testing.T) {
 	}
 }
 
+// Locks are sharded over a fixed array, so the same identifier must always map to
+// the same mutex, every index must be in range, and identifiers must spread out
+// rather than piling onto one shard.
+func TestLockFor_ShardingIsStableAndInRange(t *testing.T) {
+	c := &bpfClient{}
+
+	// Same identifier -> same mutex, every time.
+	for _, id := range []string{"web-abc123@default", "api-xyz789@prod", ""} {
+		assert.Same(t, c.lockFor(id), c.lockFor(id), "identifier %q mapped to two different mutexes", id)
+	}
+
+	// Distinct identifiers spread across shards instead of collapsing onto one.
+	seen := map[uint32]int{}
+	for i := 0; i < 4096; i++ {
+		idx := shardIndex(fmt.Sprintf("rs-%d@ns%d", i, i%7))
+		assert.Less(t, idx, uint32(podIdentifierLockShards), "shard index out of range")
+		seen[idx]++
+	}
+	assert.Equal(t, podIdentifierLockShards, len(seen),
+		"4096 identifiers should reach every shard; got %d", len(seen))
+
+	// Two identifiers sharing a shard is expected and safe -- assert it can happen
+	// so the test documents the trade-off rather than pretending it cannot.
+	assert.Greater(t, seen[shardIndex("rs-0@ns0")], 1, "expected shard reuse across identifiers")
+}
+
 // suppressionCount reads one stage's counter value without pulling in testutil.
 func suppressionCount(t *testing.T, stage string) float64 {
 	t.Helper()
@@ -1287,8 +1313,7 @@ func TestAttacheBPFProbes_SkipsPodDeletedWhileWaitingForLock(t *testing.T) {
 
 	// Hold podIdentifierLock so the attach below parks on it, standing in for an
 	// in-flight DeleteBPFProbes which holds this same lock.
-	value, _ := testBpfClient.podIdentifierLock.LoadOrStore(podIdentifier, &sync.Mutex{})
-	heldLock := value.(*sync.Mutex)
+	heldLock := testBpfClient.lockFor(podIdentifier)
 	heldLock.Lock()
 
 	done := make(chan error, 1)

--- a/pkg/ebpf/bpf_client_test.go
+++ b/pkg/ebpf/bpf_client_test.go
@@ -479,7 +479,6 @@ func TestBpfClient_AttacheBPFProbes(t *testing.T) {
 			egressPodToProgMap:        new(sync.Map),
 			ingressProgToPodsMap:      new(sync.Map),
 			egressProgToPodsMap:       new(sync.Map),
-			podIdentifierLock:         new(sync.Map),
 			deletedPods:               new(sync.Map),
 		}
 
@@ -489,6 +488,7 @@ func TestBpfClient_AttacheBPFProbes(t *testing.T) {
 		}
 		testBpfClient.policyEndpointeBPFContext.Store(tt.podIdentifier, sampleBPFContext)
 
+		restoreGetHostVethName(t)
 		utils.GetHostVethName = func(podName, podNamespace string, interfaceIndex int, interfacePrefixes []string) (string, error) {
 			return "mockedveth0", nil
 		}
@@ -512,7 +512,6 @@ func TestBpfClient_AttacheBPFProbes(t *testing.T) {
 				egressPodToProgMap:        new(sync.Map),
 				ingressProgToPodsMap:      new(sync.Map),
 				egressProgToPodsMap:       new(sync.Map),
-				podIdentifierLock:         new(sync.Map),
 				isMultiNICEnabled:         tt.isMultiNICEnabled,
 				podNameToInterfaceCount:   new(sync.Map),
 				deletedPods:               new(sync.Map),
@@ -524,11 +523,12 @@ func TestBpfClient_AttacheBPFProbes(t *testing.T) {
 			}
 			testBpfClient.policyEndpointeBPFContext.Store(tt.podIdentifier, sampleBPFContext)
 
+			restoreGetHostVethName(t)
 			utils.GetHostVethName = func(podName, podNamespace string, interfaceIndex int, interfacePrefixes []string) (string, error) {
 				return fmt.Sprintf("mockedveth%d", interfaceIndex), nil
 			}
 
-			gotError := testBpfClient.AttacheBPFProbes(tt.testPod, tt.podIdentifier, tt.numInterfaces)
+			_, gotError := testBpfClient.AttacheBPFProbes(tt.testPod, tt.podIdentifier, tt.numInterfaces, false)
 			assert.Equal(t, tt.wantErr, gotError)
 		})
 	}
@@ -900,18 +900,18 @@ func TestBpfClient_AttacheBPFProbes_MultipleInterfacesFlow(t *testing.T) {
 		egressPodToProgMap:        new(sync.Map),
 		ingressProgToPodsMap:      new(sync.Map),
 		egressProgToPodsMap:       new(sync.Map),
-		podIdentifierLock:         new(sync.Map),
 		isMultiNICEnabled:         true,
 		ingressBinary:             "tc.v4ingress.bpf.o",
 		egressBinary:              "tc.v4egress.bpf.o",
 		deletedPods:               new(sync.Map),
 	}
 
+	restoreGetHostVethName(t)
 	utils.GetHostVethName = func(podName, podNamespace string, interfaceIndex int, interfacePrefixes []string) (string, error) {
 		return fmt.Sprintf("mockedveth%d", interfaceIndex), nil
 	}
 
-	err := testBpfClient.AttacheBPFProbes(testPod, podIdentifier, 2)
+	_, err := testBpfClient.AttacheBPFProbes(testPod, podIdentifier, 2, false)
 	assert.NoError(t, err)
 
 	podNamespacedName := utils.GetPodNamespacedName(testPod.Name, testPod.Namespace)
@@ -1098,6 +1098,70 @@ func TestIsProgFdShared(t *testing.T) {
 	}
 }
 
+// restoreGetHostVethName registers cleanup that puts the package-level
+// utils.GetHostVethName back after a test replaces it. Without this a stub leaks
+// into every later test in the package and results become order-dependent.
+func restoreGetHostVethName(t *testing.T) {
+	original := utils.GetHostVethName
+	t.Cleanup(func() { utils.GetHostVethName = original })
+}
+
+// newAttachTestClient builds a bpfClient wired for the AttacheBPFProbes tests,
+// with a BPFContext already registered for podIdentifier so the attach re-uses
+// ingress progFD 3 / egress progFD 5 instead of loading an ELF.
+func newAttachTestClient(t *testing.T, podIdentifier string, sdk *mock_bpfclient.MockBpfSDKClient, tc *mock_tc.MockBpfTc) *bpfClient {
+	t.Helper()
+	c := &bpfClient{
+		hostMask:                  "/32",
+		policyEndpointeBPFContext: new(sync.Map),
+		bpfSDKClient:              sdk,
+		bpfTCClient:               tc,
+		ingressPodToProgMap:       new(sync.Map),
+		egressPodToProgMap:        new(sync.Map),
+		ingressProgToPodsMap:      new(sync.Map),
+		egressProgToPodsMap:       new(sync.Map),
+		podNameToInterfaceCount:   new(sync.Map),
+		deletedPods:               new(sync.Map),
+		// Needed by deleteBPFProbes, so an attach/delete round trip does not nil
+		// dereference. Every sync.Map field AttacheBPFProbes or DeleteBPFProbes can
+		// reach must be initialized here.
+		ingressInMemoryMap:              new(sync.Map),
+		egressInMemoryMap:               new(sync.Map),
+		clusterPolicyIngressInMemoryMap: new(sync.Map),
+		clusterPolicyEgressInMemoryMap:  new(sync.Map),
+		globalMaps:                      new(sync.Map),
+	}
+	c.policyEndpointeBPFContext.Store(podIdentifier, BPFContext{
+		ingressPgmInfo: goelf.BpfData{Program: goebpfprogs.BpfProgram{ProgID: 2, ProgFD: 3}},
+		egressPgmInfo:  goelf.BpfData{Program: goebpfprogs.BpfProgram{ProgID: 4, ProgFD: 5}},
+	})
+	restoreGetHostVethName(t)
+	utils.GetHostVethName = func(_, _ string, _ int, _ []string) (string, error) {
+		return "mockedveth0", nil
+	}
+	return c
+}
+
+// assertNotInProgSets checks the pod is absent from the progFD -> pods sets.
+// These, not the podToProg maps, are what isProgFdShared counts, so they are the
+// structures whose corruption produces the pin leak.
+func assertNotInProgSets(t *testing.T, c *bpfClient, podNamespacedName string) {
+	t.Helper()
+	for _, m := range []struct {
+		name   string
+		set    *sync.Map
+		progFD int
+	}{
+		{"ingressProgToPodsMap", c.ingressProgToPodsMap, 3},
+		{"egressProgToPodsMap", c.egressProgToPodsMap, 5},
+	} {
+		if raw, ok := m.set.Load(m.progFD); ok {
+			_, present := raw.(map[string]struct{})[podNamespacedName]
+			assert.False(t, present, "deleted pod was re-inserted into %s", m.name)
+		}
+	}
+}
+
 func TestAttacheBPFProbes_SkipsDeletedPod(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1107,19 +1171,22 @@ func TestAttacheBPFProbes_SkipsDeletedPod(t *testing.T) {
 	mockTCClient.EXPECT().TCEgressAttach(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 	testBpfClient := &bpfClient{
-		podIdentifierLock: new(sync.Map),
-		deletedPods:       new(sync.Map),
-		bpfTCClient:       mockTCClient,
+		deletedPods: new(sync.Map),
+		bpfTCClient: mockTCClient,
 	}
 
 	pod := types.NamespacedName{Name: "nginx-abc123", Namespace: "default"}
 	testBpfClient.deletedPods.Store(utils.GetPodNamespacedName(pod.Name, pod.Namespace), time.Now())
 
-	err := testBpfClient.AttacheBPFProbes(pod, utils.GetPodIdentifier(pod.Name, pod.Namespace), 1)
+	attached, err := testBpfClient.AttacheBPFProbes(pod, utils.GetPodIdentifier(pod.Name, pod.Namespace), 1, false)
 	assert.NoError(t, err)
+	assert.False(t, attached, "a skipped attach must not report itself as attached")
 }
 
-func TestAttacheBPFProbes_ProceedsAfterClearDeletedPod(t *testing.T) {
+// A caller with authoritative evidence the pod exists (a CNI ADD) must never be
+// vetoed by a stale tombstone: skipping would leave a live pod with no probes,
+// unenforced, while the RPC still reported success.
+func TestAttacheBPFProbes_ProceedsWhenPodConfirmedLive(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -1134,35 +1201,176 @@ func TestAttacheBPFProbes_ProceedsAfterClearDeletedPod(t *testing.T) {
 	podIdentifier := utils.GetPodIdentifier(pod.Name, pod.Namespace)
 	podNamespacedName := utils.GetPodNamespacedName(pod.Name, pod.Namespace)
 
-	testBpfClient := &bpfClient{
-		hostMask:                  "/32",
-		policyEndpointeBPFContext: new(sync.Map),
-		bpfSDKClient:              mockBpfSDK,
-		bpfTCClient:               mockTCClient,
-		ingressPodToProgMap:       new(sync.Map),
-		egressPodToProgMap:        new(sync.Map),
-		ingressProgToPodsMap:      new(sync.Map),
-		egressProgToPodsMap:       new(sync.Map),
-		podIdentifierLock:         new(sync.Map),
-		deletedPods:               new(sync.Map),
-	}
-	testBpfClient.policyEndpointeBPFContext.Store(podIdentifier, BPFContext{
-		ingressPgmInfo: goelf.BpfData{Program: goebpfprogs.BpfProgram{ProgID: 2, ProgFD: 3}},
-		egressPgmInfo:  goelf.BpfData{Program: goebpfprogs.BpfProgram{ProgID: 4, ProgFD: 5}},
-	})
-	utils.GetHostVethName = func(_, _ string, _ int, _ []string) (string, error) {
-		return "mockedveth0", nil
-	}
+	testBpfClient := newAttachTestClient(t, podIdentifier, mockBpfSDK, mockTCClient)
 
-	// Delete then clear — simulates CNI DEL followed by CNI ADD
+	// A tombstone is present and is NOT cleared beforehand: the attach itself must
+	// drop it, under the lock, because the caller knows the pod is live.
 	testBpfClient.deletedPods.Store(podNamespacedName, time.Now())
-	testBpfClient.ClearDeletedPod(podNamespacedName)
 
-	err := testBpfClient.AttacheBPFProbes(pod, podIdentifier, 1)
+	attached, err := testBpfClient.AttacheBPFProbes(pod, podIdentifier, 1, true)
 	assert.NoError(t, err)
-
-	_, attached := testBpfClient.ingressPodToProgMap.Load(podNamespacedName)
 	assert.True(t, attached)
+
+	_, ingressAttached := testBpfClient.ingressPodToProgMap.Load(podNamespacedName)
+	assert.True(t, ingressAttached)
+	_, tombstoneStillSet := testBpfClient.deletedPods.Load(podNamespacedName)
+	assert.False(t, tombstoneStillSet, "a confirmed-live attach must clear the stale tombstone")
+}
+
+// A pod deleted while an attach is blocked on podIdentifierLock must not be
+// re-attached once the lock is released. The tombstone check before the lock can
+// be stale, so re-inserting here would leave the pod in ingressProgToPodsMap
+// forever — nothing removes it again — keeping isProgFdShared true for the last
+// pod of the podIdentifier and leaking its pinned programs and maps.
+func TestAttacheBPFProbes_SkipsPodDeletedWhileWaitingForLock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTCClient := mock_tc.NewMockBpfTc(ctrl)
+	mockTCClient.EXPECT().TCIngressAttach(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	mockTCClient.EXPECT().TCEgressAttach(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	mockBpfSDK := mock_bpfclient.NewMockBpfSDKClient(ctrl)
+	mockBpfSDK.EXPECT().LoadBpfFile(gomock.Any(), gomock.Any()).AnyTimes()
+
+	pod := types.NamespacedName{Name: "churn-abc123", Namespace: "leak-test"}
+	podIdentifier := utils.GetPodIdentifier(pod.Name, pod.Namespace)
+	podNamespacedName := utils.GetPodNamespacedName(pod.Name, pod.Namespace)
+
+	testBpfClient := newAttachTestClient(t, podIdentifier, mockBpfSDK, mockTCClient)
+
+	// Hold podIdentifierLock so the attach below parks on it, standing in for an
+	// in-flight DeleteBPFProbes which holds this same lock.
+	value, _ := testBpfClient.podIdentifierLock.LoadOrStore(podIdentifier, &sync.Mutex{})
+	heldLock := value.(*sync.Mutex)
+	heldLock.Lock()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := testBpfClient.AttacheBPFProbes(pod, podIdentifier, 1, false)
+		done <- err
+	}()
+
+	// Give the goroutine time to pass the pre-lock check and park on Lock(). With
+	// a bare sync.Mutex there is nothing to observe waiters on, so this is a sleep
+	// -- but it cannot produce a false pass: no tombstone exists yet, so the only
+	// way the attach could return is by completing, which the held lock prevents.
+	// The assertion below is what rules out a bail-out at the pre-lock check.
+	select {
+	case <-done:
+		heldLock.Unlock()
+		t.Fatal("AttacheBPFProbes returned while the lock was held; test cannot validate the post-lock check")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// DeleteBPFProbes would have recorded this while holding the lock.
+	testBpfClient.deletedPods.Store(podNamespacedName, time.Now())
+	heldLock.Unlock()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("AttacheBPFProbes did not return after podIdentifierLock was released")
+	}
+
+	// The pod must not have been re-registered against the shared program.
+	_, attached := testBpfClient.ingressPodToProgMap.Load(podNamespacedName)
+	assert.False(t, attached, "deleted pod was re-inserted into ingressPodToProgMap")
+	_, egressAttached := testBpfClient.egressPodToProgMap.Load(podNamespacedName)
+	assert.False(t, egressAttached, "deleted pod was re-inserted into egressPodToProgMap")
+	// The refcount, not the podToProg maps, is what leaks the pins.
+	assertNotInProgSets(t, testBpfClient, podNamespacedName)
+}
+
+// Drives concurrent attaches and deletes across one podIdentifier so the race
+// detector can see the progFD -> pods sets. Those inner values are plain Go
+// maps, and concurrent access to a plain map is a fatal runtime throw that takes
+// the whole agent down, so this must be exercised under -race rather than
+// reasoned about. Run with: go test -race -run TestAttachDeleteConcurrent ./pkg/ebpf/
+func TestAttachDeleteConcurrentOnOneIdentifier(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTCClient := mock_tc.NewMockBpfTc(ctrl)
+	mockTCClient.EXPECT().TCIngressAttach(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mockTCClient.EXPECT().TCEgressAttach(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mockTCClient.EXPECT().TCIngressDetach(gomock.Any()).AnyTimes()
+	mockTCClient.EXPECT().TCEgressDetach(gomock.Any()).AnyTimes()
+
+	// Every pod of a ReplicaSet shares one identifier, so pods churning under a
+	// single identifier is the steady state for any rolling Deployment.
+	const podIdentifier = "web-abc123@default"
+
+	// The first delete of each cycle drops policyEndpointeBPFContext, so later
+	// attaches take the load-from-ELF path. Return program data keyed by the pin
+	// paths the loader looks up, otherwise every attach after the first fails.
+	mockBpfSDK := mock_bpfclient.NewMockBpfSDKClient(ctrl)
+	mockBpfSDK.EXPECT().LoadBpfFile(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_, _ string) (map[string]goelf.BpfData, map[string]goebpfmaps.BpfMap, error) {
+			return map[string]goelf.BpfData{
+				utils.GetBPFPinPathFromPodIdentifier(podIdentifier, "ingress"): {
+					Program: goebpfprogs.BpfProgram{ProgID: 2, ProgFD: 3},
+					Maps: map[string]goebpfmaps.BpfMap{
+						utils.TC_INGRESS_MAP:           {MapFD: 100},
+						utils.TC_INGRESS_POD_STATE_MAP: {MapFD: 101},
+					},
+				},
+				utils.GetBPFPinPathFromPodIdentifier(podIdentifier, "egress"): {
+					Program: goebpfprogs.BpfProgram{ProgID: 4, ProgFD: 5},
+					Maps: map[string]goebpfmaps.BpfMap{
+						utils.TC_EGRESS_MAP:           {MapFD: 110},
+						utils.TC_EGRESS_POD_STATE_MAP: {MapFD: 111},
+					},
+				},
+			}, map[string]goebpfmaps.BpfMap{}, nil
+		}).AnyTimes()
+
+	testBpfClient := newAttachTestClient(t, podIdentifier, mockBpfSDK, mockTCClient)
+
+	const workers = 8
+	const iterations = 40
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				pod := types.NamespacedName{
+					Name:      fmt.Sprintf("web-abc123-w%dn%d", w, i),
+					Namespace: "default",
+				}
+				// podConfirmedLive=true mirrors the CNI ADD path, which must not be
+				// vetoed by another pod's tombstone.
+				if _, err := testBpfClient.AttacheBPFProbes(pod, podIdentifier, 1, true); err != nil {
+					t.Errorf("attach failed for %s: %v", pod.Name, err)
+					return
+				}
+				if err := testBpfClient.DeleteBPFProbes(pod, podIdentifier); err != nil {
+					t.Errorf("delete failed for %s: %v", pod.Name, err)
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// Once every pod has been deleted nothing may still be counted against the
+	// shared programs; a survivor here is the stale entry that keeps
+	// isProgFdShared true for the last pod and leaks its pins.
+	for _, m := range []struct {
+		name string
+		set  *sync.Map
+	}{
+		{"ingressProgToPodsMap", testBpfClient.ingressProgToPodsMap},
+		{"egressProgToPodsMap", testBpfClient.egressProgToPodsMap},
+	} {
+		m.set.Range(func(progFD, raw any) bool {
+			assert.Empty(t, raw.(map[string]struct{}),
+				"%s still counts pods against progFD %v after all pods were deleted", m.name, progFD)
+			return true
+		})
+	}
 }
 
 func TestDeleteBPFProbes_AddsPodToDeletedMap(t *testing.T) {
@@ -1171,7 +1379,6 @@ func TestDeleteBPFProbes_AddsPodToDeletedMap(t *testing.T) {
 		egressPodToProgMap:   new(sync.Map),
 		ingressProgToPodsMap: new(sync.Map),
 		egressProgToPodsMap:  new(sync.Map),
-		podIdentifierLock:    new(sync.Map),
 		deletedPods:          new(sync.Map),
 	}
 

--- a/pkg/ebpf/bpf_client_test.go
+++ b/pkg/ebpf/bpf_client_test.go
@@ -21,6 +21,8 @@ import (
 	fwrp "github.com/aws/aws-network-policy-agent/pkg/fwruleprocessor"
 	"github.com/aws/aws-network-policy-agent/pkg/utils"
 	"github.com/golang/mock/gomock"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -528,7 +530,7 @@ func TestBpfClient_AttacheBPFProbes(t *testing.T) {
 				return fmt.Sprintf("mockedveth%d", interfaceIndex), nil
 			}
 
-			_, gotError := testBpfClient.AttacheBPFProbes(tt.testPod, tt.podIdentifier, tt.numInterfaces, false)
+			gotError := testBpfClient.AttacheBPFProbes(tt.testPod, tt.podIdentifier, tt.numInterfaces, false)
 			assert.Equal(t, tt.wantErr, gotError)
 		})
 	}
@@ -911,7 +913,7 @@ func TestBpfClient_AttacheBPFProbes_MultipleInterfacesFlow(t *testing.T) {
 		return fmt.Sprintf("mockedveth%d", interfaceIndex), nil
 	}
 
-	_, err := testBpfClient.AttacheBPFProbes(testPod, podIdentifier, 2, false)
+	err := testBpfClient.AttacheBPFProbes(testPod, podIdentifier, 2, false)
 	assert.NoError(t, err)
 
 	podNamespacedName := utils.GetPodNamespacedName(testPod.Name, testPod.Namespace)
@@ -1098,6 +1100,52 @@ func TestIsProgFdShared(t *testing.T) {
 	}
 }
 
+// suppressionCount reads one stage's counter value without pulling in testutil.
+func suppressionCount(t *testing.T, stage string) float64 {
+	t.Helper()
+	c, err := attachSuppressedPodDeleted.GetMetricWithLabelValues(stage)
+	assert.NoError(t, err)
+	var m dto.Metric
+	assert.NoError(t, c.Write(&m))
+	return m.GetCounter().GetValue()
+}
+
+// A CounterVec exports nothing for a label until first used, so without
+// pre-initialisation the metric is absent from /metrics until the first
+// suppression -- observed on a live cluster, and useless for a dashboard.
+func TestAttachSuppressionCounter_ExportsBothStagesFromStartup(t *testing.T) {
+	// Reset first so the assertion does not depend on which tests ran before.
+	attachSuppressedPodDeleted.Reset()
+	initAttachSuppressionSeries()
+
+	ch := make(chan prometheus.Metric, 8)
+	attachSuppressedPodDeleted.Collect(ch)
+	close(ch)
+	assert.Equal(t, 2, len(ch),
+		"both pre_lock and post_lock series must exist before any suppression happens")
+}
+
+// And it must actually count, per stage.
+func TestAttachSuppressionCounter_IncrementsForTheStageThatFired(t *testing.T) {
+	prometheusRegister()
+
+	pod := types.NamespacedName{Name: "nginx-abc123", Namespace: "default"}
+	podIdentifier := utils.GetPodIdentifier(pod.Name, pod.Namespace)
+	podNamespacedName := utils.GetPodNamespacedName(pod.Name, pod.Namespace)
+
+	c := &bpfClient{deletedPods: new(sync.Map)}
+	before := suppressionCount(t, suppressionStagePostLock)
+
+	// No tombstone yet: nothing to suppress, nothing to count.
+	assert.False(t, c.suppressAttachForDeletedPod(pod, podIdentifier, podNamespacedName, suppressionStagePostLock))
+	assert.Equal(t, before, suppressionCount(t, suppressionStagePostLock))
+
+	c.deletedPods.Store(podNamespacedName, time.Now())
+	assert.True(t, c.suppressAttachForDeletedPod(pod, podIdentifier, podNamespacedName, suppressionStagePostLock))
+	assert.Equal(t, before+1, suppressionCount(t, suppressionStagePostLock),
+		"a post_lock suppression must increment the post_lock series")
+}
+
 // restoreGetHostVethName registers cleanup that puts the package-level
 // utils.GetHostVethName back after a test replaces it. Without this a stub leaks
 // into every later test in the package and results become order-dependent.
@@ -1178,9 +1226,8 @@ func TestAttacheBPFProbes_SkipsDeletedPod(t *testing.T) {
 	pod := types.NamespacedName{Name: "nginx-abc123", Namespace: "default"}
 	testBpfClient.deletedPods.Store(utils.GetPodNamespacedName(pod.Name, pod.Namespace), time.Now())
 
-	attached, err := testBpfClient.AttacheBPFProbes(pod, utils.GetPodIdentifier(pod.Name, pod.Namespace), 1, false)
-	assert.NoError(t, err)
-	assert.False(t, attached, "a skipped attach must not report itself as attached")
+	err := testBpfClient.AttacheBPFProbes(pod, utils.GetPodIdentifier(pod.Name, pod.Namespace), 1, false)
+	assert.ErrorIs(t, err, ErrAttachSkippedPodDeleted, "a skip must be reported as ErrAttachSkippedPodDeleted")
 }
 
 // A caller with authoritative evidence the pod exists (a CNI ADD) must never be
@@ -1207,9 +1254,8 @@ func TestAttacheBPFProbes_ProceedsWhenPodConfirmedLive(t *testing.T) {
 	// drop it, under the lock, because the caller knows the pod is live.
 	testBpfClient.deletedPods.Store(podNamespacedName, time.Now())
 
-	attached, err := testBpfClient.AttacheBPFProbes(pod, podIdentifier, 1, true)
-	assert.NoError(t, err)
-	assert.True(t, attached)
+	err := testBpfClient.AttacheBPFProbes(pod, podIdentifier, 1, true)
+	assert.NoError(t, err, "a confirmed-live attach must never be skipped")
 
 	_, ingressAttached := testBpfClient.ingressPodToProgMap.Load(podNamespacedName)
 	assert.True(t, ingressAttached)
@@ -1247,8 +1293,7 @@ func TestAttacheBPFProbes_SkipsPodDeletedWhileWaitingForLock(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := testBpfClient.AttacheBPFProbes(pod, podIdentifier, 1, false)
-		done <- err
+		done <- testBpfClient.AttacheBPFProbes(pod, podIdentifier, 1, false)
 	}()
 
 	// Give the goroutine time to pass the pre-lock check and park on Lock(). With
@@ -1269,7 +1314,7 @@ func TestAttacheBPFProbes_SkipsPodDeletedWhileWaitingForLock(t *testing.T) {
 
 	select {
 	case err := <-done:
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, ErrAttachSkippedPodDeleted)
 	case <-time.After(5 * time.Second):
 		t.Fatal("AttacheBPFProbes did not return after podIdentifierLock was released")
 	}
@@ -1342,7 +1387,7 @@ func TestAttachDeleteConcurrentOnOneIdentifier(t *testing.T) {
 				}
 				// podConfirmedLive=true mirrors the CNI ADD path, which must not be
 				// vetoed by another pod's tombstone.
-				if _, err := testBpfClient.AttacheBPFProbes(pod, podIdentifier, 1, true); err != nil {
+				if err := testBpfClient.AttacheBPFProbes(pod, podIdentifier, 1, true); err != nil {
 					t.Errorf("attach failed for %s: %v", pod.Name, err)
 					return
 				}

--- a/pkg/rpc/rpc_handler.go
+++ b/pkg/rpc/rpc_handler.go
@@ -15,6 +15,7 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 
@@ -83,10 +84,22 @@ func (s *server) EnforceNpToPod(ctx context.Context, in *rpc.EnforceNpRequest) (
 	podIdentifier := utils.GetPodIdentifier(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE)
 	isFirstPodInPodIdentifier := s.policyReconciler.GeteBPFClient().IsFirstPodInPodIdentifier(podIdentifier)
 	s.policyReconciler.GeteBPFClient().ClearDeletedPod(utils.GetPodNamespacedName(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE))
-	err = s.policyReconciler.GeteBPFClient().AttacheBPFProbes(types.NamespacedName{Name: in.K8S_POD_NAME, Namespace: in.K8S_POD_NAMESPACE},
-		podIdentifier, int(in.InterfaceCount))
+	// A CNI ADD is authoritative evidence that the pod exists, so pass
+	// podConfirmedLive=true: any deletion tombstone is stale and is dropped under
+	// podIdentifierLock rather than being allowed to veto this attach. Skipping
+	// here would leave a live pod with no probes while we still reported success.
+	attached, err := s.policyReconciler.GeteBPFClient().AttacheBPFProbes(types.NamespacedName{Name: in.K8S_POD_NAME, Namespace: in.K8S_POD_NAMESPACE},
+		podIdentifier, int(in.InterfaceCount), true)
 	if err != nil {
 		log().Errorf("Attaching eBPF probe failed for pod: %s namespace: %s, error: %v", in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, err)
+		return nil, err
+	}
+	if !attached {
+		// Unreachable while podConfirmedLive is true, but must never degrade into a
+		// silent success: the map updates below assume the pod has a BPF context, and
+		// the CNI would otherwise treat an unenforced pod as programmed.
+		err = fmt.Errorf("eBPF probes were not attached for pod %s in namespace %s", in.K8S_POD_NAME, in.K8S_POD_NAMESPACE)
+		log().Errorf("Refusing to report success: %v", err)
 		return nil, err
 	}
 	var podState, clusterPolicyState int

--- a/pkg/rpc/rpc_handler.go
+++ b/pkg/rpc/rpc_handler.go
@@ -15,7 +15,6 @@ package rpc
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"os"
 
@@ -84,22 +83,13 @@ func (s *server) EnforceNpToPod(ctx context.Context, in *rpc.EnforceNpRequest) (
 	podIdentifier := utils.GetPodIdentifier(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE)
 	isFirstPodInPodIdentifier := s.policyReconciler.GeteBPFClient().IsFirstPodInPodIdentifier(podIdentifier)
 	s.policyReconciler.GeteBPFClient().ClearDeletedPod(utils.GetPodNamespacedName(in.K8S_POD_NAME, in.K8S_POD_NAMESPACE))
-	// A CNI ADD is authoritative evidence that the pod exists, so pass
-	// podConfirmedLive=true: any deletion tombstone is stale and is dropped under
-	// podIdentifierLock rather than being allowed to veto this attach. Skipping
-	// here would leave a live pod with no probes while we still reported success.
-	attached, err := s.policyReconciler.GeteBPFClient().AttacheBPFProbes(types.NamespacedName{Name: in.K8S_POD_NAME, Namespace: in.K8S_POD_NAMESPACE},
+	// A CNI ADD proves the pod exists, so podConfirmedLive=true: a stale tombstone
+	// must not veto this attach. Any skip comes back as ErrAttachSkippedPodDeleted
+	// and fails the RPC, so a live pod is never reported as enforced.
+	err = s.policyReconciler.GeteBPFClient().AttacheBPFProbes(types.NamespacedName{Name: in.K8S_POD_NAME, Namespace: in.K8S_POD_NAMESPACE},
 		podIdentifier, int(in.InterfaceCount), true)
 	if err != nil {
 		log().Errorf("Attaching eBPF probe failed for pod: %s namespace: %s, error: %v", in.K8S_POD_NAME, in.K8S_POD_NAMESPACE, err)
-		return nil, err
-	}
-	if !attached {
-		// Unreachable while podConfirmedLive is true, but must never degrade into a
-		// silent success: the map updates below assume the pod has a BPF context, and
-		// the CNI would otherwise treat an unenforced pod as programmed.
-		err = fmt.Errorf("eBPF probes were not attached for pod %s in namespace %s", in.K8S_POD_NAME, in.K8S_POD_NAMESPACE)
-		log().Errorf("Refusing to report success: %v", err)
 		return nil, err
 	}
 	var podState, clusterPolicyState int

--- a/test/integration/leak/leak_test.go
+++ b/test/integration/leak/leak_test.go
@@ -14,6 +14,7 @@ import (
 	network "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -23,6 +24,10 @@ const (
 	podsPerJob    = 100
 	pollInterval  = 10 * time.Second
 	cronJobName   = "churn-generator"
+	agentLogPath  = "/var/log/aws-routed-eni/network-policy-agent.log"
+	// Logged once per completed egress probe attach, so a pod appearing twice has
+	// been attached twice.
+	egressAttachMarker = "Successfully attached Egress TC probe for pod: "
 )
 
 var _ = Describe("BPF Probe Leak Under Pod Churn", Ordered, func() {
@@ -31,6 +36,11 @@ var _ = Describe("BPF Probe Leak Under Pod Churn", Ordered, func() {
 		defaultDenyPolicy *network.NetworkPolicy
 		cronJob           *batchv1.CronJob
 		workerNodes       []v1.Node
+		// node name -> check pod name / pre-churn state, so the assertions below
+		// can compare against the node as it was before this run.
+		checkPods      map[string]string
+		baselineIdents map[string]map[string]bool
+		logOffsets     map[string]int
 	)
 
 	It("should not leak BPF progs/maps after high pod churn with network policy", func() {
@@ -40,10 +50,29 @@ var _ = Describe("BPF Probe Leak Under Pod Churn", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(workerNodes)).To(BeNumerically(">=", 1))
 		lo.ForEach(workerNodes, func(node v1.Node, _ int) {
-			node.Labels["test-node"] = "true"
-			err = fw.K8sClient.Update(ctx, &node)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(setNodeTestLabel(node.Name, true)).ToNot(HaveOccurred())
 		})
+
+		By("Deploying node-shell check pods and snapshotting pre-churn BPF state")
+		// The suite has to tolerate a node that is already dirty. Leaked pins never
+		// self-reclaim, so any earlier run's leftovers would otherwise fail this
+		// test forever, no matter how correct the agent is. Snapshot first and
+		// assert on the delta.
+		checkPods = map[string]string{}
+		baselineIdents = map[string]map[string]bool{}
+		logOffsets = map[string]int{}
+		for _, node := range workerNodes {
+			checkPodName := fmt.Sprintf("leak-check-%s", node.Name)
+			checkPod := buildNodeCheckPod(checkPodName, node.Name)
+			_, err := fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, checkPod, 2*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() {
+				fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, checkPod)
+			})
+			checkPods[node.Name] = checkPodName
+			baselineIdents[node.Name] = churnIdentifiersOnNode(checkPodName)
+			logOffsets[node.Name] = agentLogLineCount(checkPodName)
+		}
 
 		By("Creating a default deny network policy")
 		defaultDenyPolicy = buildDefaultDenyNetworkPolicy()
@@ -70,25 +99,14 @@ var _ = Describe("BPF Probe Leak Under Pod Churn", Ordered, func() {
 		// Wait for all churn pods to terminate
 		time.Sleep(2 * time.Minute)
 
-		By("Deploying node-shell check pods on each node to verify no leaked BPF state")
 		for _, node := range workerNodes {
-			checkPodName := fmt.Sprintf("leak-check-%s", node.Name)
-			checkPod := buildNodeCheckPod(checkPodName, node.Name)
+			checkPodName := checkPods[node.Name]
 
-			_, err := fw.PodManager.CreateAndWaitTillPodIsRunning(ctx, checkPod, 2*time.Minute)
-			Expect(err).ToNot(HaveOccurred())
-			DeferCleanup(func() {
-				fw.PodManager.DeleteAndWaitTillPodIsDeleted(ctx, checkPod)
-			})
+			By(fmt.Sprintf("Checking for newly leaked BPF pins on node %s", node.Name))
+			assertNoNewChurnLeaks(baselineIdents[node.Name], churnIdentifiersOnNode(checkPodName), node.Name)
 
-			By(fmt.Sprintf("Checking BPF maps on node %s", node.Name))
-			mapsOutput, err := fw.PodManager.ExecInPod(namespace, checkPodName,
-				[]string{"chroot", "/host", "/opt/cni/bin/aws-eks-na-cli", "ebpf", "loaded-ebpfdata"})
-			Expect(err).ToNot(HaveOccurred())
-
-			// No churn pod BPF artifacts should remain
-			// Only system pods (coredns, aws-node, etc.) should have pinned progs/maps
-			assertNoChurnPodLeaks(mapsOutput, node.Name)
+			By(fmt.Sprintf("Checking for ghost re-attaches on node %s", node.Name))
+			assertNoGhostReattaches(checkPodName, node.Name, logOffsets[node.Name])
 		}
 	})
 
@@ -103,8 +121,9 @@ var _ = Describe("BPF Probe Leak Under Pod Churn", Ordered, func() {
 			fw.NetworkPolicyManager.DeleteNetworkPolicy(ctx, defaultDenyPolicy)
 		}
 		lo.ForEach(workerNodes, func(node v1.Node, _ int) {
-			delete(node.Labels, "test-node")
-			fw.K8sClient.Update(ctx, &node)
+			if err := setNodeTestLabel(node.Name, false); err != nil {
+				AddReportEntry(fmt.Sprintf("failed to remove test-node label from %s: %v", node.Name, err))
+			}
 		})
 	})
 })
@@ -238,17 +257,125 @@ func getWorkerNodes() ([]v1.Node, error) {
 	}), nil
 }
 
-// assertNoChurnPodLeaks checks that no BPF artifacts from churn pods remain.
-// Churn pods have identifier containing "churn-generator" in their BPF pin paths.
-func assertNoChurnPodLeaks(output, nodeName string) {
+// setNodeTestLabel adds or removes the churn scheduling label on a node.
+//
+// It re-reads the node inside a conflict retry rather than updating a copy from
+// an earlier List. Node objects are rewritten constantly by their kubelet, so a
+// List-then-Update races even seconds later -- and in the cleanup path the copy
+// is tens of minutes stale, which silently left the label behind on every node.
+func setNodeTestLabel(nodeName string, present bool) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node := &v1.Node{}
+		if err := fw.K8sClient.Get(ctx, client.ObjectKey{Name: nodeName}, node); err != nil {
+			return err
+		}
+		_, has := node.Labels["test-node"]
+		if has == present {
+			return nil
+		}
+		if present {
+			if node.Labels == nil {
+				node.Labels = map[string]string{}
+			}
+			node.Labels["test-node"] = "true"
+		} else {
+			delete(node.Labels, "test-node")
+		}
+		return fw.K8sClient.Update(ctx, node)
+	})
+}
+
+// churnIdentifiersOnNode returns the set of podIdentifiers belonging to churn
+// pods that currently have pinned BPF programs or maps on the node.
+func churnIdentifiersOnNode(checkPodName string) map[string]bool {
+	output, err := fw.PodManager.ExecInPod(namespace, checkPodName,
+		[]string{"chroot", "/host", "/opt/cni/bin/aws-eks-na-cli", "ebpf", "loaded-ebpfdata"})
+	Expect(err).ToNot(HaveOccurred())
+
+	idents := map[string]bool{}
 	for _, line := range strings.Split(output, "\n") {
 		line = strings.TrimSpace(line)
-		if line == "" {
+		if line == "" || !strings.Contains(line, cronJobName) {
 			continue
 		}
-		Expect(line).ToNot(ContainSubstring(cronJobName),
-			fmt.Sprintf("Leaked BPF artifact found on node %s: %s", nodeName, line))
+		idents[churnIdentifierFromLine(line)] = true
 	}
+	return idents
+}
+
+// churnIdentifierFromLine pulls the "churn-generator-<generation>" token out of a
+// loaded-ebpfdata line so pins for the same identifier collapse to one entry
+// regardless of direction or whether it is a program or a map.
+func churnIdentifierFromLine(line string) string {
+	for _, field := range strings.FieldsFunc(line, func(r rune) bool {
+		return r == ' ' || r == '\t' || r == '/' || r == ':'
+	}) {
+		if strings.HasPrefix(field, cronJobName) {
+			return field
+		}
+	}
+	return line
+}
+
+// assertNoNewChurnLeaks fails only on identifiers that were not already pinned
+// before this run. Pre-existing leaks are reported, not failed on: they cannot
+// self-reclaim, so failing on them would make the suite permanently red on any
+// node that ever ran an affected build.
+func assertNoNewChurnLeaks(baseline, post map[string]bool, nodeName string) {
+	var leaked []string
+	for ident := range post {
+		if !baseline[ident] {
+			leaked = append(leaked, ident)
+		}
+	}
+	if len(baseline) > 0 {
+		AddReportEntry(fmt.Sprintf("node %s carried %d pre-existing leaked churn identifier(s) into this run; not counted against it",
+			nodeName, len(baseline)))
+	}
+	Expect(leaked).To(BeEmpty(),
+		fmt.Sprintf("node %s leaked %d new churn identifier(s) during this run: %v", nodeName, len(leaked), leaked))
+}
+
+// agentLogLineCount records how long the agent log already is, so the ghost
+// assertion can ignore everything an earlier run wrote.
+func agentLogLineCount(checkPodName string) int {
+	output, err := fw.PodManager.ExecInPod(namespace, checkPodName,
+		[]string{"chroot", "/host", "/bin/sh", "-c",
+			"wc -l < " + agentLogPath + " 2>/dev/null || echo 0"})
+	Expect(err).ToNot(HaveOccurred())
+
+	var lines int
+	// A missing or empty log is fine; it just means no offset to skip.
+	fmt.Sscanf(strings.TrimSpace(output), "%d", &lines)
+	return lines
+}
+
+// assertNoGhostReattaches checks the invariant that each churn pod completes at
+// most one attach. A pod attached twice is the ghost re-add: the second attach
+// re-inserts it into the shared progFD -> pods set after its delete already
+// removed it, which keeps isProgFdShared true for the last pod of the identifier
+// so its programs and maps are never unpinned.
+//
+// This is independent of pin scanning, so unlike assertNoNewChurnLeaks it is
+// unaffected by state left behind on the node.
+func assertNoGhostReattaches(checkPodName, nodeName string, logOffset int) {
+	// tail -n +N skips lines written before this run, which avoids having to
+	// parse the agent's JSON timestamps.
+	script := fmt.Sprintf(
+		"tail -n +%d %s 2>/dev/null | grep -F %q | grep -F %q "+
+			"| sed -e 's/.*for pod: //' -e 's/ in namespace.*//' | sort | uniq -d",
+		logOffset+1, agentLogPath, egressAttachMarker, cronJobName)
+
+	output, err := fw.PodManager.ExecInPod(namespace, checkPodName,
+		[]string{"chroot", "/host", "/bin/sh", "-c", script})
+	Expect(err).ToNot(HaveOccurred())
+
+	ghosts := lo.Filter(strings.Split(strings.TrimSpace(output), "\n"), func(s string, _ int) bool {
+		return strings.TrimSpace(s) != ""
+	})
+	Expect(ghosts).To(BeEmpty(),
+		fmt.Sprintf("node %s: %d churn pod(s) completed more than one attach (ghost re-add): %v",
+			nodeName, len(ghosts), ghosts))
 }
 
 func waitForChurnOrBail(jobStuckTimeout time.Duration) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

## The problem

Under pod churn, eBPF programs and maps stay pinned in bpffs forever. The pins
accumulate per node and never self-reclaim.

## Why it happens

`AttacheBPFProbes` reads the `deletedPods` tombstone **before** taking
`podIdentifierLock`, while `DeleteBPFProbes` writes that tombstone **inside** the
same lock. A read that is not ordered against the write is stale by construction:

```
AttacheBPFProbes                DeleteBPFProbes
(reconciler-driven)             (CNI DEL for the last pod)
--------------------------------------------------------------
deletedPods.Load(P)
  -> absent, continue
                                lock(podIdentifier)
                                isProgFdShared(P) -> false
                                remove P from progFD -> pods
                                deletedPods.Store(P)      <- tombstone
                                unpin programs + maps
                                (releases the lock)
lock(podIdentifier)
... attaches P ...
progFD -> pods [P] = {}         <- P is back, and P is dead
```

Nothing removes that entry again: no further CNI DEL arrives for a pod that is
already torn down. The stale entry keeps `isProgFdShared` true for the **last
surviving pod** of the identifier, so `deleteBPFProgramAndMaps` is never called
for it and its programs and maps stay pinned.

Three properties make this worse than a one-off leak:

- **Self-amplifying per identifier.** Once one ghost entry exists, every
  *subsequent* legitimate unpin for that `podIdentifier` is skipped too.
- **Never self-heals.** `recoverBPFState` *adopts* every pin under
  `/sys/fs/bpf/globals/aws` at startup with no liveness check, so restarting the
  agent re-adopts the orphans instead of reclaiming them.
- **Steady state, not an edge case.** `GetPodIdentifier` strips only the last
  `-` segment, so every pod of a ReplicaSet shares one identifier — "the last pod
  is deleted while a new pod attaches" happens on every rollout.

Single-use identifiers are hit hardest: for a Deployment the identifier is
reused, so a later attach may reclaim the orphan, but for Job/CronJob pods the
identifier is never seen again and the leak is permanent.

### A second defect the fix depends on

`DeleteBPFProbes` removed its `podIdentifierLock` entry **while still holding the
mutex** (the `Unlock` is deferred). The next caller then found no entry, created a
**second** mutex for the same identifier, and entered the critical section
concurrently. Any re-check of the tombstone is worthless while that is possible,
and it independently makes concurrent writes to the plain maps inside
`ingress/egressProgToPodsMap` reachable — `fatal error: concurrent map writes`, an
unrecoverable throw that takes policy enforcement down node-wide.

## Design

**Order the tombstone read against the write.** Re-check `deletedPods` after
`podIdentifierLock` is acquired, so it is read under the same lock that publishes
it. The pre-lock check stays as a fast path only.

**Stop allocating locks per identifier.** The locks were a `sync.Map` of
`*sync.Mutex`, and the entry was deleted when the identifier's last pod went away
— while the mutex was still held, which is what broke exclusion. Replaced with a
fixed shard array:

```go
const podIdentifierLockShards = 256
podIdentifierLocks [podIdentifierLockShards]sync.Mutex   // 2048 bytes, allocated once
```

Nothing is created or removed, so no lock can be deleted while in use. The count
is not a limit on identifiers — they are hashed onto the locks (FNV-1a) and may
share one, which only over-serializes and is always safe.

**Never skip an attach for a pod we know is alive.** A CNI ADD passes
`podConfirmedLive=true`: the tombstone is stale, is cleared under the lock, and
the attach proceeds. Without this the new check would fail *open* — skipping a
live pod while the RPC still replied `Success=true`. Reconcilers pass `false`;
their work lists can name pods that are already gone.

**Make a skip impossible to mistake for success.** A skip returns
`ErrAttachSkippedPodDeleted`, not a bare `nil`. The CNI ADD path needs no new
handling — its existing `err != nil` check fails the RPC. Reconcilers opt in with
`errors.Is` and move to the next pod.

**Make the race visible in production.** Both suppression points log at Debug, so
`awsnodeagent_attach_suppressed_pod_deleted_total{stage}` counts them instead.
Both label values are exported at 0 from startup, since a `CounterVec` emits
nothing for a label until first used.

### Cost

No API reads are added anywhere, and nothing is added to the CNI-blocking path —
on `EnforceNpToPod` the change is one extra `sync.Map.Delete` under a lock already
held. No new synchronization primitive is introduced: the fix reuses the
per-identifier mutex that already existed, so lock-acquisition cost is unchanged.

Memory is fixed rather than proportional to identifiers seen. `sizeof(sync.Mutex)`
is 8 bytes, so `[256]sync.Mutex` is exactly **2,048 bytes** whatever the workload
does — against the `sync.Map` it replaces, which cost 48 bytes plus roughly
100–150 per identifier, retained for the agent's lifetime. The crossover is about
15 identifiers, beyond which the array uses less and never grows again.

The trade is coarser locking: unrelated identifiers sharing a shard occasionally
serialize. Measured attach rate is ~1.2/sec across 256 shards, so a collision is
rare and costs the milliseconds of one eBPF load.

### API compatibility

`BpfClient.AttacheBPFProbes` gains one parameter:

```go
-  AttacheBPFProbes(pod types.NamespacedName, podIdentifier string, numInterfaces int) error
+  AttacheBPFProbes(pod types.NamespacedName, podIdentifier string, numInterfaces int, podConfirmedLive bool) error
```

The return type is unchanged, so `err := f(...)` keeps compiling once the argument
is supplied. Adding the parameter is still breaking for any out-of-tree
implementer of the interface; the three in-tree callers and the mock are updated
here.

## Monitoring

**Do not alert on `attach_suppressed_pod_deleted_total{stage="post_lock"} > 0`.**
A non-zero value means the guard is working. It is the expected steady state,
measured at 35 hits in 28 minutes on a healthy node running the fix; an alert on
`> 0` fires within minutes of rollout and never clears.

| signal | interpretation |
|---|---|
| pinned podIdentifiers with no corresponding live pod | a real leak — page on this |
| step change in the `post_lock` rate | the race window shifted; investigate |
| `post_lock` == 0 while attach volume is high | guard possibly not reached; verify the deployed build |

The `pre_lock` : `post_lock` ratio is a useful baseline — measured at roughly
113:1 (3,954 : 35), i.e. the cheap check catches most cases and the post-lock one
catches the ~0.9% it lets through. The counter is exported at any log level;
`--log-level=debug` is only needed to see the individual log lines.

## Results

Measured on a 20-node cluster (AL2023, k8s v1.36.2, VPC CNI v1.22.4-eksbuild.3)
driving 100 pods/min through a `default-deny` plus pod-selector NetworkPolicy.

Two agent images differing **only** in this guard, run back to back against the
same continuously-running churn:

| | control (26 min) | fixed (28 min) |
|---|---|---|
| attach completions | 2,458 | 2,800 |
| distinct pods | 2,455 | 2,800 |
| **ghost re-adds** | **3** | **0** |
| **suppressions at the post-lock check** | 0 | **35** |
| **newly leaked identifiers** | **3** | **0** |

Attribution was 3 for 3 — every ghost pod's identifier was still pinned after its
generation ended:

```
churn-generator-29805169-vbzfn -> churn-generator-29805169@leak-test   pinned
churn-generator-29805170-4b9hm -> churn-generator-29805170@leak-test   pinned
churn-generator-29805181-vdb4k -> churn-generator-29805181@leak-test   pinned
```

**Why this is attribution and not mere absence.** The post-lock check fired 35
times while the fixed arm did *more* work than the control (2,800 vs 2,458
attaches). The race still occurs at the same rate; it is now intercepted. A
zero-ghost result on its own would be indistinguishable from "the race did not
happen during this run". Separately, `churn-generator-29805194@leak-test` — pinned
and live when the control arm ended — was correctly unpinned, which is direct
evidence the unpin path works whenever no ghost has corrupted the refcount.

A confirmation run of the shipped code on the same cluster, audited across all
20 nodes:

| | |
|---|---|
| attach completions | 7,460 |
| distinct pods | 7,460 |
| **ghost re-adds** | **0** |
| suppressions at the post-lock check | 135 |
| churn **program** pins left behind | **0** |
| churn **map** pins left behind | **0** |

`attaches == distinct` exactly: not one pod attached twice out of 7,460, while
the post-lock check intercepted the race 135 times. Both program and map pins
were checked — maps are the bulk of the leak (the 58 leaked programs came with
174 leaked map pins), so programs alone being clean would not have shown the
unpin path completed. Every pin remaining on those nodes belongs to a different
live workload plus the two global maps.

Before and after on the node that had accumulated the leaks:

| | before | after |
|---|---|---|
| churn program pins | 58 | **0** |
| churn map pins | 174 | **0** |
| resident `sched_cls` programs | 58 | **0** |
| of those, attached to an interface | **0** | 0 |

All 58 were orphans — loaded, pinned, attached to nothing.

## Testing

**6 new unit tests, every one mutation-verified** — run against a deliberately
reintroduced defect to confirm it fails, because a regression test that passes
against the bug is worthless:

| test | mutation it was proven to catch |
|---|---|
| `TestAttacheBPFProbes_SkipsPodDeletedWhileWaitingForLock` | post-lock re-check disabled |
| `TestAttachDeleteConcurrentOnOneIdentifier` | lock entry deleted while held |
| `TestAttacheBPFProbes_ProceedsWhenPodConfirmedLive` | confirmed-live stops clearing the tombstone |
| `TestAttachSuppressionCounter_ExportsBothStagesFromStartup` | counter pre-initialisation removed |
| `TestAttachSuppressionCounter_IncrementsForTheStageThatFired` | counter `Inc()` removed |
| `TestLockFor_ShardingIsStableAndInRange` | hash collapsed onto a single shard |

`TestAttachDeleteConcurrentOnOneIdentifier` drives 8 workers × 40 attach/delete
cycles over a single `podIdentifier` under `-race` in ~0.2 s — the deterministic
detector for this bug class.

`pkg/ebpf` now has 23 tests. All 8 packages pass with `-race` under
`-mod=readonly`, alongside `gofmt`, `go build` and `go vet`.

**`test/integration/leak` was unable to validate this fix**, so three defects in
it are fixed here:

1. **The pin assertion was absolute, not a delta.** It failed if any pin path
   contained `churn-generator`. Since leaked pins never self-reclaim and the agent
   re-adopts them on restart, one leak from any earlier run made the suite
   permanently red on that node — a correct fix could not produce a green run.
   Observed: a node carrying **87** pre-existing leaked identifiers. The suite now
   snapshots before churn and blames a run only for identifiers it leaked,
   reporting inherited ones instead of failing on them.
2. **Node labelling raced the kubelet.** Both the setup loop and `AfterAll`
   updated `v1.Node` copies from an earlier `List`, so setup died with "the object
   has been modified" and `AfterAll` discarded the same error — leaving
   `test-node=true` on every node after every run (observed: 20 stale labels).
   Both paths now re-read inside `retry.RetryOnConflict`; verified 20 before, 0
   after.
3. **Nothing asserted the leak's mechanism.** Added a ghost re-attach check: no
   churn pod may complete more than one attach. It reads the agent log rather than
   bpffs, so unlike the pin assertion it is unaffected by whatever state the node
   arrived in, and it names the offending pods.

The suite passed both on a dirty node (87 inherited leaks, correctly tolerated)
and from a clean baseline after those leaks were cleared.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
